### PR TITLE
Netobserv scenarios and evals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,105 +18,154 @@ venv/bin/activate:
 	venv/bin/pip install --quiet git+https://github.com/lightspeed-core/lightspeed-evaluation.git
 	@printf '\033[0;32mDone.\033[0m venv ready at ./venv\n'
 
-##@ OpenShift MCP Server
+##@ MCP servers (OpenShift vs kubernetes-mcp-server)
 
-MCP_NS        ?= openshift-mcp
-OLS_NS        ?= openshift-lightspeed
-MCP_ISTIO_NS  ?= istio-system
-OPENSHIFT_MCP_INTERNAL_IMAGE="registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:83f288c04aad9c742cf2cee51f45e1be1982e1fcc388d2112cf5483e381fff62"
-#
-#  Enable toolsets for the OpenShift MCP server: core and config
-#  Add additional toolsets to the list by setting TOOLSETS_ADDITIONAL separated by commas
-#
-TOOLSETS_ADDITIONAL ?= ossm
+OLS_NS ?= openshift-lightspeed
+MCP_ISTIO_NS ?= istio-system
 
-.PHONY: setup-openshift-mcp
-setup-openshift-mcp: ## Deploy the OpenShift MCP server (namespace, RBAC, config, deployment, route)
+# Namespaces — one MCP flavor per namespace
+OPENSHIFT_MCP_NS ?= openshift-mcp
+KUBERNETES_MCP_NS ?= kubernetes-mcp-server
+MCP_NS ?= $(OPENSHIFT_MCP_NS)
+
+# OpenShift MCP (fixed Red Hat image, Kiali/ossm evals — not overridable)
+OPENSHIFT_MCP_INTERNAL_IMAGE = registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:83f288c04aad9c742cf2cee51f45e1be1982e1fcc388d2112cf5483e381fff62
+OPENSHIFT_MCP_TOOLSETS ?= ossm
+
+# kubernetes-mcp-server (upstream image, NetObserv evals)
+KUBERNETES_MCP_IMAGE ?= quay.io/containers/kubernetes_mcp_server:latest
+KUBERNETES_MCP_TOOLSETS ?= netobserv
+
+.PHONY: setup-openshift-mcp setup-kubernetes-mcp
+setup-openshift-mcp: ## Deploy Red Hat openshift-mcp-server (namespace openshift-mcp)
+	$(MAKE) _mcp-setup \
+	  MCP_NS=$(OPENSHIFT_MCP_NS) \
+	  MCP_DEPLOYMENT=openshift-mcp-server \
+	  MCP_IMAGE=$(OPENSHIFT_MCP_INTERNAL_IMAGE) \
+	  MCP_COMMAND=/openshift-mcp-server \
+	  MCP_CONFIG_MOUNT=/etc/mcp \
+	  TOOLSETS_ADDITIONAL=$(or $(TOOLSETS_ADDITIONAL),$(OPENSHIFT_MCP_TOOLSETS))
+
+setup-kubernetes-mcp: ## Deploy upstream kubernetes-mcp-server (namespace kubernetes-mcp-server)
+	$(MAKE) _mcp-setup \
+	  MCP_NS=$(KUBERNETES_MCP_NS) \
+	  MCP_DEPLOYMENT=kubernetes-mcp-server \
+	  MCP_IMAGE=$(KUBERNETES_MCP_IMAGE) \
+	  MCP_COMMAND=/app/kubernetes-mcp-server \
+	  MCP_CONFIG_MOUNT=/etc/kubernetes-mcp-server \
+	  TOOLSETS_ADDITIONAL=$(or $(TOOLSETS_ADDITIONAL),$(KUBERNETES_MCP_TOOLSETS))
+
+.PHONY: _mcp-setup
+_mcp-setup:
 	@set -e; \
 	ns='$(MCP_NS)'; \
+	name='$(MCP_DEPLOYMENT)'; \
 	echo "==> Creating namespace $$ns..."; \
 	oc create namespace "$$ns" --dry-run=client -o yaml | oc apply -f -; \
-	echo "==> Creating ServiceAccount..."; \
+	echo "==> Creating ServiceAccount $$name..."; \
 	{ \
 	  echo 'apiVersion: v1'; \
 	  echo 'kind: ServiceAccount'; \
 	  echo 'metadata:'; \
-	  echo '  name: openshift-mcp-server'; \
+	  echo "  name: $$name"; \
 	  echo "  namespace: $$ns"; \
 	} | oc apply -f -; \
 	echo "==> Granting cluster-admin to ServiceAccount..."; \
-	oc create clusterrolebinding openshift-mcp-server-admin \
+	oc create clusterrolebinding "$$name-admin" \
 	  --clusterrole=cluster-admin \
-	  "--serviceaccount=$$ns:openshift-mcp-server" \
+	  "--serviceaccount=$$ns:$$name" \
 	  --dry-run=client -o yaml | oc apply -f -; \
 	oc adm policy add-cluster-role-to-user cluster-admin \
-	  "system:serviceaccount:$$ns:openshift-mcp-server"
-	$(MAKE) mcp-config
+	  "system:serviceaccount:$$ns:$$name"
+	$(MAKE) _mcp-config \
+	  MCP_NS='$(MCP_NS)' \
+	  MCP_DEPLOYMENT='$(MCP_DEPLOYMENT)' \
+	  TOOLSETS_ADDITIONAL='$(TOOLSETS_ADDITIONAL)'
 	@set -e; \
 	ns='$(MCP_NS)'; \
-	image='$(OPENSHIFT_MCP_INTERNAL_IMAGE)'; \
-	echo "==> Creating Deployment..."; \
+	name='$(MCP_DEPLOYMENT)'; \
+	image='$(MCP_IMAGE)'; \
+	mcp_cmd='$(MCP_COMMAND)'; \
+	config_mount='$(MCP_CONFIG_MOUNT)'; \
+	config_file='$(MCP_CONFIG_MOUNT)/config.toml'; \
+	echo "==> Creating Deployment $$name (image=$$image)..."; \
 	{ \
 	  echo 'apiVersion: apps/v1'; \
 	  echo 'kind: Deployment'; \
 	  echo 'metadata:'; \
-	  echo '  name: openshift-mcp-server'; \
+	  echo "  name: $$name"; \
 	  echo "  namespace: $$ns"; \
 	  echo 'spec:'; \
 	  echo '  replicas: 1'; \
 	  echo '  selector:'; \
 	  echo '    matchLabels:'; \
-	  echo '      app: openshift-mcp-server'; \
+	  echo "      app: $$name"; \
 	  echo '  template:'; \
 	  echo '    metadata:'; \
 	  echo '      labels:'; \
-	  echo '        app: openshift-mcp-server'; \
+	  echo "        app: $$name"; \
 	  echo '    spec:'; \
-	  echo '      serviceAccountName: openshift-mcp-server'; \
+	  echo "      serviceAccountName: $$name"; \
 	  echo '      containers:'; \
-	  echo '      - name: openshift-mcp-server'; \
+	  echo "      - name: $$name"; \
 	  echo "        image: $$image"; \
-	  echo '        command: ["/openshift-mcp-server"]'; \
-	  echo '        args: ["--config", "/etc/mcp/config.toml"]'; \
+	  echo "        command: [\"$$mcp_cmd\"]"; \
+	  echo "        args: [\"--config\", \"$$config_file\"]"; \
 	  echo '        ports:'; \
 	  echo '        - containerPort: 8080'; \
 	  echo '        volumeMounts:'; \
 	  echo '        - name: mcp-config'; \
-	  echo '          mountPath: /etc/mcp'; \
+	  echo "          mountPath: $$config_mount"; \
 	  echo '      volumes:'; \
 	  echo '      - name: mcp-config'; \
 	  echo '        configMap:'; \
 	  echo '          name: mcp-config'; \
 	} | oc apply -f -; \
-	echo "==> Creating Service..."; \
+	echo "==> Creating Service $$name..."; \
 	{ \
 	  echo 'apiVersion: v1'; \
 	  echo 'kind: Service'; \
 	  echo 'metadata:'; \
-	  echo '  name: openshift-mcp-server'; \
+	  echo "  name: $$name"; \
 	  echo "  namespace: $$ns"; \
 	  echo 'spec:'; \
 	  echo '  selector:'; \
-	  echo '    app: openshift-mcp-server'; \
+	  echo "    app: $$name"; \
 	  echo '  ports:'; \
 	  echo '  - port: 8080'; \
 	  echo '    targetPort: 8080'; \
 	} | oc apply -f -; \
 	echo "==> Exposing OpenShift Route..."; \
-	oc get route openshift-mcp-server -n "$$ns" &>/dev/null \
-	  || oc expose service openshift-mcp-server -n "$$ns"; \
-	route_host="$$(oc get route openshift-mcp-server -n "$$ns" \
+	oc get route "$$name" -n "$$ns" &>/dev/null \
+	  || oc expose service "$$name" -n "$$ns"; \
+	route_host="$$(oc get route "$$name" -n "$$ns" \
 	  -o jsonpath='{.spec.host}' 2>/dev/null)"; \
 	echo ""; \
-	echo "==> MCP server installed! Endpoint: http://$$route_host";
+	echo "==> MCP server installed in $$ns! Route: http://$$route_host"; \
+	echo "==> In-cluster URL: http://$$name.$$ns.svc.cluster.local:8080/mcp"
 
-.PHONY: mcp-config
-mcp-config: ## Rebuild mcp-config ConfigMap and restart the pod if already running
+.PHONY: mcp-config openshift-mcp-config kubernetes-mcp-config _mcp-config
+mcp-config: openshift-mcp-config ## Alias: rebuild openshift-mcp ConfigMap
+
+openshift-mcp-config: ## Rebuild openshift-mcp ConfigMap and restart the pod
+	$(MAKE) _mcp-config \
+	  MCP_NS=$(OPENSHIFT_MCP_NS) \
+	  MCP_DEPLOYMENT=openshift-mcp-server \
+	  TOOLSETS_ADDITIONAL=$(or $(TOOLSETS_ADDITIONAL),$(OPENSHIFT_MCP_TOOLSETS))
+
+kubernetes-mcp-config: ## Rebuild kubernetes-mcp-server ConfigMap and restart the pod
+	$(MAKE) _mcp-config \
+	  MCP_NS=$(KUBERNETES_MCP_NS) \
+	  MCP_DEPLOYMENT=kubernetes-mcp-server \
+	  TOOLSETS_ADDITIONAL=$(or $(TOOLSETS_ADDITIONAL),$(KUBERNETES_MCP_TOOLSETS))
+
+_mcp-config:
 	@set -e; \
 	ns='$(MCP_NS)'; \
+	name='$(MCP_DEPLOYMENT)'; \
 	istio_ns='$(MCP_ISTIO_NS)'; \
 	additional="$$(printf '%s' '$(TOOLSETS_ADDITIONAL)' | tr -d '"')"; \
-	echo "==> Building mcp-config ConfigMap (toolsets: core,config,$$additional)..."; \
+	echo "==> Building mcp-config in $$ns (toolsets: core,config,$$additional)..."; \
 	ts='["core","config"'; \
 	IFS=,; \
 	for t in $$additional; do \
@@ -134,22 +183,33 @@ mcp-config: ## Rebuild mcp-config ConfigMap and restart the pod if already runni
 	  --from-file=config.toml=/tmp/_mcp-config.toml \
 	  -n "$$ns" --dry-run=client -o yaml | oc apply -f -; \
 	rm -f /tmp/_mcp-config.toml; \
-	if oc get deployment openshift-mcp-server -n "$$ns" &>/dev/null; then \
-	  echo "==> Restarting openshift-mcp-server to pick up new config..."; \
-	  oc rollout restart deployment/openshift-mcp-server -n "$$ns"; \
-	  oc rollout status deployment/openshift-mcp-server -n "$$ns"; \
+	if oc get deployment "$$name" -n "$$ns" &>/dev/null; then \
+	  echo "==> Restarting $$name to pick up new config..."; \
+	  oc rollout restart "deployment/$$name" -n "$$ns"; \
+	  oc rollout status "deployment/$$name" -n "$$ns"; \
 	else \
-	  echo "==> Deployment not found — skipping restart (run 'make setup-openshift-mcp' first)."; \
+	  echo "==> Deployment $$name not found — skipping restart."; \
 	fi
 
-.PHONY: connect-ols-mcp
-connect-ols-mcp: ## Patch OLSConfig/cluster to register the openshift-mcp MCP server and restart OLS
+.PHONY: connect-ols-mcp connect-ols-openshift-mcp connect-ols-kubernetes-mcp _connect-ols-mcp
+connect-ols-mcp: connect-ols-openshift-mcp ## Alias: register openshift-mcp in OLSConfig
+
+connect-ols-openshift-mcp: ## Register openshift-mcp-server in OLSConfig/cluster
+	$(MAKE) _connect-ols-mcp \
+	  MCP_OLS_NAME=openshift-mcp \
+	  MCP_URL=http://openshift-mcp-server.$(OPENSHIFT_MCP_NS):8080/mcp
+
+connect-ols-kubernetes-mcp: ## Register kubernetes-mcp-server in OLSConfig/cluster
+	$(MAKE) _connect-ols-mcp \
+	  MCP_OLS_NAME=kubernetes-mcp \
+	  MCP_URL=http://kubernetes-mcp-server.$(KUBERNETES_MCP_NS):8080/mcp
+
+_connect-ols-mcp:
 	@set -e; \
-	mcp_url="http://openshift-mcp-server.$(MCP_NS):8080/mcp"; \
-	echo "==> Patching OLSConfig/cluster with mcpServers (url=$$mcp_url)..."; \
+	echo "==> Patching OLSConfig/cluster (name=$(MCP_OLS_NAME), url=$(MCP_URL))..."; \
 	patch="$$(printf \
-	  '{"spec":{"featureGates":["MCPServer"],"mcpServers":[{"name":"openshift-mcp","headers":[{"name":"kubernetes-authorization","valueFrom":{"type":"kubernetes"}}],"url":"%s","timeout":30}]}}' \
-	  "$$mcp_url")"; \
+	  '{"spec":{"featureGates":["MCPServer"],"mcpServers":[{"name":"%s","headers":[{"name":"kubernetes-authorization","valueFrom":{"type":"kubernetes"}}],"url":"%s","timeout":120}]}}' \
+	  '$(MCP_OLS_NAME)' '$(MCP_URL)')"; \
 	oc patch olsconfig cluster --type=merge -p "$$patch"; \
 	echo "==> OLSConfig/cluster updated."; \
 	echo "==> Restarting lightspeed-app-server to pick up new config..."; \
@@ -157,21 +217,34 @@ connect-ols-mcp: ## Patch OLSConfig/cluster to register the openshift-mcp MCP se
 	oc rollout status deployment/lightspeed-app-server -n "$(OLS_NS)"; \
 	echo "==> OLS is ready."
 
-.PHONY: teardown-openshift-mcp
-teardown-openshift-mcp: ## Remove the OpenShift MCP server and disconnect it from OLS
+.PHONY: teardown-openshift-mcp teardown-kubernetes-mcp _teardown-mcp
+teardown-openshift-mcp: ## Remove openshift-mcp namespace and disconnect from OLS
+	$(MAKE) _teardown-mcp \
+	  MCP_NS=$(OPENSHIFT_MCP_NS) \
+	  MCP_DEPLOYMENT=openshift-mcp-server \
+	  MCP_OLS_NAME=openshift-mcp
+
+teardown-kubernetes-mcp: ## Remove kubernetes-mcp-server namespace and disconnect from OLS
+	$(MAKE) _teardown-mcp \
+	  MCP_NS=$(KUBERNETES_MCP_NS) \
+	  MCP_DEPLOYMENT=kubernetes-mcp-server \
+	  MCP_OLS_NAME=kubernetes-mcp
+
+_teardown-mcp:
 	@set -e; \
 	ns='$(MCP_NS)'; \
-	echo "==> Disconnecting openshift-mcp from OLSConfig/cluster..."; \
+	name='$(MCP_DEPLOYMENT)'; \
+	echo "==> Removing MCP server $(MCP_OLS_NAME) from OLSConfig/cluster..."; \
 	oc patch olsconfig cluster --type=json \
-	  -p '[{"op":"remove","path":"/spec/mcpServers"}]' 2>/dev/null || true; \
+	  -p='[{"op":"remove","path":"/spec/mcpServers"}]' 2>/dev/null || true; \
 	echo "==> Restarting lightspeed-app-server..."; \
 	oc rollout restart deployment/lightspeed-app-server -n "$(OLS_NS)" 2>/dev/null || true; \
-	echo "==> Removing MCP server resources from $$ns..."; \
-	oc delete deployment  openshift-mcp-server -n "$$ns" --ignore-not-found; \
-	oc delete service     openshift-mcp-server -n "$$ns" --ignore-not-found; \
-	oc delete route       openshift-mcp-server -n "$$ns" --ignore-not-found; \
-	oc delete configmap   mcp-config           -n "$$ns" --ignore-not-found; \
-	oc delete clusterrolebinding openshift-mcp-server-admin --ignore-not-found; \
-	oc delete serviceaccount openshift-mcp-server -n "$$ns" --ignore-not-found; \
+	echo "==> Removing MCP resources from $$ns..."; \
+	oc delete deployment  "$$name" -n "$$ns" --ignore-not-found; \
+	oc delete service     "$$name" -n "$$ns" --ignore-not-found; \
+	oc delete route       "$$name" -n "$$ns" --ignore-not-found; \
+	oc delete configmap   mcp-config -n "$$ns" --ignore-not-found; \
+	oc delete clusterrolebinding "$$name-admin" --ignore-not-found; \
+	oc delete serviceaccount "$$name" -n "$$ns" --ignore-not-found; \
 	oc delete namespace "$$ns" --ignore-not-found; \
-	echo "==> Teardown complete."
+	echo "==> Teardown complete ($$ns)."

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Reproducible OpenShift scenarios for AI-assisted troubleshooting. Each scenario 
 |-------|-------------|
 | [generic/](generic/) | General OpenShift fault-injection scenarios (database connection exhaustion, cascading alert storm). |
 | [kiali-ossm/](kiali-ossm/) | Service-mesh troubleshooting scenarios using Kiali/OSSM MCP tools and OpenShift Lightspeed. |
+| [netobserv/](netobserv/) | Network observability troubleshooting scenarios using the NetObserv MCP toolset and OpenShift Lightspeed. |
 
 ### generic
 
@@ -20,16 +21,20 @@ Reproducible OpenShift scenarios for AI-assisted troubleshooting. Each scenario 
 
 Evaluation scenarios that test AI-assisted diagnosis of Istio/Kiali mesh problems. See [`kiali-ossm/README.md`](kiali-ossm/README.md) for setup instructions and a full description of each scenario.
 
+### netobserv
+
+Evaluation scenarios that test AI-assisted investigation of NetObserv network observability signals (DNS, packet drops, TLS, TCP RTT). See [`netobserv/README.md`](netobserv/README.md) for setup instructions and a full description of each scenario.
+
 ---
 
 ## Lightspeed evaluation setup
 
-The `kiali-ossm` scenarios are evaluated using [`lightspeed-evaluation`](https://github.com/lightspeed-core/lightspeed-evaluation), a framework that sends queries to an [OpenShift Lightspeed](https://github.com/openshift/lightspeed-service) (OLS) instance and scores responses with a judge LLM.
+The `kiali-ossm` and `netobserv` scenarios are evaluated using [`lightspeed-evaluation`](https://github.com/lightspeed-core/lightspeed-evaluation), a framework that sends queries to an [OpenShift Lightspeed](https://github.com/openshift/lightspeed-service) (OLS) instance and scores responses with a judge LLM.
 
 ### Requirements
 
 - Python 3.11, 3.12, or 3.13 (`lightspeed-evaluation` does not support 3.14+)
-- A running OLS instance reachable from your machine (configure `api.api_base` in `kiali-ossm/system.yaml`)
+- A running OLS instance reachable from your machine — `https://localhost:8443` via port-forward, or the cluster Route (see eval suite README; operator listens on HTTPS **8443**, not 8080)
 - `OPENAI_API_KEY` exported in your shell (used by the judge LLM)
 - An OpenShift cluster accessible via `oc`
 
@@ -47,15 +52,31 @@ This creates `./venv` and installs `lightspeed-evaluation` directly from the `li
 
 ## OpenShift MCP Server setup
 
-The MCP server gives OLS live access to the cluster through a set of configurable toolsets. The following Make targets manage its full lifecycle from the repository root.
+The MCP server gives OLS live access to the cluster through configurable toolsets (`core`, `config`, plus extras). Deploy from the repository root:
+
+```bash
+make setup-openshift-mcp
+make connect-ols-mcp
+```
+
+For **Kiali/OSSM** evals the default toolset is `ossm`. For **NetObserv** evals, enable the `netobserv` toolset:
+
+```bash
+make setup-openshift-mcp TOOLSETS_ADDITIONAL=netobserv
+make connect-ols-mcp
+```
+
+Both suites use the same Red Hat `openshift-mcp-server` image in the `openshift-mcp` namespace.
 
 ### 1. Deploy the MCP server
 
 ```bash
 make setup-openshift-mcp
+# or: make setup-openshift-mcp TOOLSETS_ADDITIONAL=netobserv
+# or: make setup-openshift-mcp TOOLSETS_ADDITIONAL=ossm,netobserv
 ```
 
-This single command:
+This:
 
 1. Creates the `openshift-mcp` namespace
 2. Creates a `ServiceAccount` and grants it `cluster-admin`
@@ -63,15 +84,28 @@ This single command:
 4. Deploys the MCP server pod
 5. Creates a `Service` and exposes an OpenShift `Route`
 
-The MCP server endpoint is printed at the end of the run.
+The MCP server Route is printed at the end of the run.
 
 #### Key variables
 
 | Variable | Default | Description |
 |---|---|---|
-| `MCP_NS` | `openshift-mcp` | Namespace where the MCP server is deployed |
-| `MCP_IMAGE_TAG` | `latest` | Tag for the MCP server image |
-| `TOOLSETS_ADDITIONAL` | `ossm` | Extra toolsets to enable (comma-separated) |
+| `OPENSHIFT_MCP_NS` | `openshift-mcp` | Namespace for openshift-mcp-server |
+| `OPENSHIFT_MCP_INTERNAL_IMAGE` | (fixed in Makefile) | Red Hat `openshift-mcp-server-rhel9` digest — not overridable |
+| `OPENSHIFT_MCP_TOOLSETS` | `ossm` | Extra toolsets when `TOOLSETS_ADDITIONAL` is unset |
+| `TOOLSETS_ADDITIONAL` | `ossm` | Comma-separated extra toolsets (`netobserv`, `ossm`, …) |
+
+#### Testing upstream PRs (optional)
+
+Before a toolset lands in `openshift-mcp-server`, you can deploy upstream [kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) with a custom image in a separate namespace:
+
+```bash
+KUBERNETES_MCP_IMAGE=quay.io/<you>/kubernetes-mcp-server:<pr-tag> \
+  make setup-kubernetes-mcp
+make connect-ols-kubernetes-mcp
+```
+
+See `make help` for `kubernetes-mcp-config` and `teardown-kubernetes-mcp`. This path is for PR validation only — eval docs assume the openshift-mcp flow above.
 
 ### 2. Toolsets
 
@@ -101,22 +135,23 @@ url = "https://kiali.istio-system:20001/"
 insecure = true
 ```
 
-To update the configuration on a live deployment without a full reinstall:
+To update configuration on a live deployment without a full reinstall:
 
 ```bash
-make mcp-config                                       # rebuild ConfigMap and restart the pod
-make mcp-config TOOLSETS_ADDITIONAL=ossm,mytoolset    # change toolsets on the fly
+make mcp-config TOOLSETS_ADDITIONAL=ossm,mytoolset
 ```
+
+(`make mcp-config` is an alias for `openshift-mcp-config`.)
 
 ### 3. Connect OLS to the MCP server
 
-Once the MCP server is running, register it with OpenShift Lightspeed by patching `OLSConfig/cluster`:
+Once the MCP server is running, register it with OpenShift Lightspeed:
 
 ```bash
 make connect-ols-mcp
 ```
 
-This patches `OLSConfig/cluster` to add the MCP server under `spec.mcpServers`, then restarts `lightspeed-app-server` so OLS picks up the new configuration:
+This patches `OLSConfig/cluster` to add the MCP server under `spec.mcpServers`, then restarts `lightspeed-app-server`:
 
 ```yaml
 spec:
@@ -134,23 +169,22 @@ The `OLS_NS` variable controls which namespace OLS is installed in (default: `op
 
 ### 4. Teardown
 
-To remove the MCP server completely and disconnect it from OLS:
-
 ```bash
 make teardown-openshift-mcp
 ```
 
-This performs a full cleanup in order:
+This:
 
-1. Removes `spec.mcpServers` from `OLSConfig/cluster` so OLS stops routing to the MCP server
-2. Restarts `lightspeed-app-server` to apply the disconnection
-3. Deletes all cluster resources in `openshift-mcp`: Deployment, Service, Route, ConfigMap, ClusterRoleBinding, ServiceAccount
+1. Removes `spec.mcpServers` from `OLSConfig/cluster`
+2. Restarts `lightspeed-app-server`
+3. Deletes Deployment, Service, Route, ConfigMap, ClusterRoleBinding, ServiceAccount in the flavor namespace
 4. Deletes the `openshift-mcp` namespace
 
-All steps are idempotent — safe to run even on a partially cleaned state.
+All steps are idempotent.
 
 ### 5. Other lifecycle targets
 
 ```bash
-make mcp-config              # rebuild config and restart pod (live reconfiguration)
+make mcp-config              # rebuild config and restart pod
+make setup-kubernetes-mcp    # optional: upstream image for PR testing
 ```

--- a/netobserv/Makefile
+++ b/netobserv/Makefile
@@ -1,0 +1,100 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# netobserv/Makefile — NetObserv evaluation targets
+#
+# Run `make setup-ols-evaluation` from the repository root once to create
+# ../venv with lightspeed-eval (not from lightspeed-service).
+#
+# OLS runs in-cluster on HTTPS port 8443 (not 8080). Reach it via Route or port-forward:
+#   OLS_URL=$(make -s ols-route-url) make dns_nxdomain-test
+#   make ols-port-forward   # https://localhost:8443
+# ──────────────────────────────────────────────────────────────────────────────
+
+EVALS = ./evals.yaml
+RESULTS_DIR = ./results
+SYSTEM_CONFIG_SRC = ./system.yaml
+SYSTEM_CONFIG = $(RESULTS_DIR)/system-runtime.yaml
+
+OLS_NS ?= openshift-lightspeed
+OLS_ROUTE ?= ols
+OLS_PORT ?= 8443
+OLS_URL ?= https://localhost:$(OLS_PORT)
+
+_AUTHTOKEN = $(shell oc whoami -t 2>/dev/null)
+
+EVAL_BASE = API_KEY=$(_AUTHTOKEN) \
+            ../venv/bin/lightspeed-eval \
+            --system-config $(SYSTEM_CONFIG) \
+            --output-dir $(RESULTS_DIR) \
+            --eval-data $(EVALS)
+
+$(SYSTEM_CONFIG): $(SYSTEM_CONFIG_SRC)
+	@mkdir -p $(RESULTS_DIR)
+	@sed 's|^  api_base: .*|  api_base: $(OLS_URL)|' $(SYSTEM_CONFIG_SRC) > $(SYSTEM_CONFIG)
+
+.PHONY: check-ols ols-port-forward ols-route-url deploy-flowcollector
+check-ols: ## Verify OLS API is reachable at OLS_URL (default https://localhost:8443)
+	@printf 'Checking OLS at %s …\n' '$(OLS_URL)'
+	@case '$(OLS_URL)' in \
+	  https://*) curl -k -sf --connect-timeout 3 '$(OLS_URL)/docs' >/dev/null 2>&1 ;; \
+	  *) curl -sf --connect-timeout 3 '$(OLS_URL)/docs' >/dev/null 2>&1 ;; \
+	esac || \
+	  { printf '\033[0;31mERROR:\033[0m OLS not reachable at %s\n' '$(OLS_URL)'; \
+	    printf '\nOperator OLS listens on **HTTPS port 8443** (not 8080).\n\n'; \
+	    printf 'Option A — cluster Route (no port-forward):\n'; \
+	    printf '  OLS_URL=$$(make -s ols-route-url) make dns_nxdomain-test\n\n'; \
+	    printf 'Option B — port-forward in another terminal:\n'; \
+	    printf '  make ols-port-forward\n'; \
+	    printf '  # oc port-forward -n %s deployment/lightspeed-app-server %s:8443\n\n' '$(OLS_NS)' '$(OLS_PORT)'; \
+	    exit 1; }
+	@printf 'OLS API OK at %s\n' '$(OLS_URL)'
+
+ols-route-url: ## Print https:// URL for the openshift-lightspeed Route (eval OLS_URL)
+	@host="$$(oc get route '$(OLS_ROUTE)' -n '$(OLS_NS)' -o jsonpath='{.spec.host}' 2>/dev/null)"; \
+	if [ -z "$$host" ]; then \
+	  printf 'ERROR: Route %s not found in %s\n' '$(OLS_ROUTE)' '$(OLS_NS)' >&2; \
+	  exit 1; \
+	fi; \
+	printf 'https://%s\n' "$$host"
+
+ols-port-forward: ## Forward in-cluster OLS (HTTPS 8443) to localhost:$(OLS_PORT)
+	oc port-forward -n $(OLS_NS) deployment/lightspeed-app-server $(OLS_PORT):8443
+
+.PHONY: deploy-flowcollector
+deploy-flowcollector: ## Apply eval FlowCollector (sampling 1, features, MCP network policy)
+	oc apply -f build/flowcollector.yaml
+	oc wait flowcollector/cluster --for=condition=Ready --timeout=10m
+
+.PHONY: test dns_latency-test dns_nxdomain-test packet_drops_kernel-test \
+        packet_drops_policy-test tls_issues-test tcp_rtt-test
+
+test: check-ols $(SYSTEM_CONFIG) \
+      dns_latency-test \
+      dns_nxdomain-test \
+      packet_drops_kernel-test \
+      packet_drops_policy-test \
+      tls_issues-test \
+      tcp_rtt-test
+
+dns_latency-test: check-ols $(SYSTEM_CONFIG)
+	$(EVAL_BASE) \
+	  --tag dns_latency
+
+dns_nxdomain-test: check-ols $(SYSTEM_CONFIG)
+	$(EVAL_BASE) \
+	  --tag dns_nxdomain
+
+packet_drops_kernel-test: check-ols $(SYSTEM_CONFIG)
+	$(EVAL_BASE) \
+	  --tag packet_drops_kernel
+
+packet_drops_policy-test: check-ols $(SYSTEM_CONFIG)
+	$(EVAL_BASE) \
+	  --tag packet_drops_policy
+
+tls_issues-test: check-ols $(SYSTEM_CONFIG)
+	$(EVAL_BASE) \
+	  --tag tls_issues
+
+tcp_rtt-test: check-ols $(SYSTEM_CONFIG)
+	$(EVAL_BASE) \
+	  --tag tcp_rtt

--- a/netobserv/Makefile
+++ b/netobserv/Makefile
@@ -9,6 +9,8 @@
 #   make ols-port-forward   # https://localhost:8443
 # ──────────────────────────────────────────────────────────────────────────────
 
+include build/netobserv.mk
+
 EVALS = ./evals.yaml
 RESULTS_DIR = ./results
 SYSTEM_CONFIG_SRC = ./system.yaml
@@ -60,9 +62,7 @@ ols-port-forward: ## Forward in-cluster OLS (HTTPS 8443) to localhost:$(OLS_PORT
 	oc port-forward -n $(OLS_NS) deployment/lightspeed-app-server $(OLS_PORT):8443
 
 .PHONY: deploy-flowcollector
-deploy-flowcollector: ## Apply eval FlowCollector (sampling 1, features, MCP network policy)
-	oc apply -f build/flowcollector.yaml
-	oc wait flowcollector/cluster --for=condition=Ready --timeout=10m
+deploy-flowcollector: netobserv-install-flowcollector ## Apply eval FlowCollector (alias for netobserv-install-flowcollector)
 
 .PHONY: test dns_latency-test dns_nxdomain-test packet_drops_kernel-test \
         packet_drops_policy-test tls_issues-test tcp_rtt-test

--- a/netobserv/README.md
+++ b/netobserv/README.md
@@ -1,0 +1,166 @@
+# NetObserv Troubleshooting Evaluation Scenarios
+
+Evaluation scenarios that test how well an AI assistant — backed by the OpenShift MCP server with the NetObserv toolset and OpenShift Lightspeed — can investigate network observability problems on a live OpenShift cluster.
+
+---
+
+## Prerequisites
+
+### 1. Cluster login and NetObserv
+
+You must be logged in to a running OpenShift cluster with NetObserv installed (`FlowCollector` named `cluster`, Ready).
+
+```bash
+oc login <cluster-api-url>
+oc get flowcollector cluster
+```
+
+If NetObserv is not installed yet, follow [`build/README.md`](build/README.md).
+
+### 2. MCP server with NetObserv toolset
+
+Same path as [kiali-ossm](../kiali-ossm/README.md): deploy **openshift-mcp-server** from the repository root with the `netobserv` toolset enabled:
+
+```bash
+make setup-openshift-mcp TOOLSETS_ADDITIONAL=netobserv
+make connect-ols-mcp
+```
+
+See the root [README](../README.md#openshift-mcp-server-setup). To test an upstream PR before the toolset ships in openshift-mcp-server, use `make setup-kubernetes-mcp` with `KUBERNETES_MCP_IMAGE` — see [`build/README.md`](build/README.md).
+
+### 3. OpenShift Lightspeed (OLS)
+
+Evals call OLS `/v1/query`. The operator serves **HTTPS on port 8443** inside the pod (`lightspeed-service-api`, container port `https`) — not HTTP on 8080.
+
+**Option A — cluster Route** (simplest, no port-forward):
+
+```bash
+export OPENAI_API_KEY=<your-key>
+OLS_URL=$(make -s ols-route-url) make dns_nxdomain-test
+```
+
+**Option B — port-forward** to localhost:
+
+Terminal 1:
+
+```bash
+make ols-port-forward
+# oc port-forward -n openshift-lightspeed deployment/lightspeed-app-server 8443:8443
+```
+
+Terminal 2:
+
+```bash
+export OPENAI_API_KEY=<your-key>
+make dns_nxdomain-test   # default OLS_URL=https://localhost:8443
+```
+
+See [openshift/lightspeed-service](https://github.com/openshift/lightspeed-service) for operator install and `OLSConfig`.
+
+---
+
+## Scenarios
+
+Each scenario deploys synthetic traffic, waits for NetObserv export, asks OLS to investigate, and scores the response. Scenarios with a `setup_script` in [`evals.yaml`](evals.yaml) deploy workloads before the conversation and clean up afterwards.
+
+| Tag | Category | Description |
+|-----|----------|-------------|
+| `dns_latency` | DNS | Slow DNS lookups — flow metrics and `DnsLatencyMs` |
+| `dns_nxdomain` | DNS | DNS failures / NXDOMAIN — `DnsFlagsResponseCode`, flow DNS fields |
+| `packet_drops_kernel` | Drops | Kernel packet drops — `PktDrop*` flow fields |
+| `packet_drops_policy` | Drops | NetworkPolicy denials — `OVS_DROP_EXPLICIT`, policy drop flows |
+| `tls_issues` | Ingress/TLS | HTTPS/TLS errors — failed connections on port 443 |
+| `tcp_rtt` | Latency | Slow TCP RTT — `TimeFlowRttNs` and RTT flow metrics |
+
+Setup scripts wait for workload traffic, then **`wait_for_netobserv_warmup`** (default **120s**) so flows reach Loki before OLS is queried. Override with `NETOBSERV_WARMUP_SECS=180` on slow clusters.
+
+### `dns_latency`
+
+**Tag:** `dns_latency`
+
+Applications report slow DNS lookups. The agent must use NetObserv flow metrics or flow logs to identify affected workloads.
+
+```bash
+make dns_latency-test
+```
+
+### `dns_nxdomain`
+
+**Tag:** `dns_nxdomain`
+
+DNS resolution failures in `netobserv-eval-dns-nxdomain`. The agent must find NXDOMAIN evidence in flow metrics and/or flow logs.
+
+```bash
+make dns_nxdomain-test
+```
+
+### `packet_drops_kernel`
+
+**Tag:** `packet_drops_kernel`
+
+Kernel-level packet drops in `netobserv-eval-drops-kernel`. The agent must distinguish kernel drops from policy drops using NetObserv flow data.
+
+```bash
+make packet_drops_kernel-test
+```
+
+### `packet_drops_policy`
+
+**Tag:** `packet_drops_policy`
+
+NetworkPolicy blocking traffic in `netobserv-eval-drops-policy`. The agent must find policy-related drops (`OVS_DROP_EXPLICIT`, `packetLoss=dropped`) between workloads.
+
+```bash
+make packet_drops_policy-test
+```
+
+### `tls_issues`
+
+**Tag:** `tls_issues`
+
+HTTPS/TLS connection problems in `netobserv-eval-tls`. The agent must investigate failed connections and TLS-related flow evidence.
+
+```bash
+make tls_issues-test
+```
+
+### `tcp_rtt`
+
+**Tag:** `tcp_rtt`
+
+High TCP round-trip time in `netobserv-eval-tcp-rtt`. The agent must cite elevated RTT in flow metrics and `TimeFlowRttNs` in flows.
+
+```bash
+make tcp_rtt-test
+```
+
+---
+
+## Running all scenarios
+
+From the **repository root**, install the evaluation CLI once (creates `venv/` with `lightspeed-eval`):
+
+```bash
+make setup-ols-evaluation
+```
+
+The judge LLM requires an OpenAI API key. Export it before running any test target:
+
+```bash
+export OPENAI_API_KEY=<your-key>
+```
+
+Then run scenarios from this directory (with OLS reachable — see [Prerequisites §3](README.md#3-openshift-lightspeed-ols)):
+
+```bash
+make test              # all scenarios
+make dns_latency-test  # single scenario
+```
+
+Results are written to `results/`.
+
+---
+
+## Evaluation framework
+
+Scenarios are scored by a judge LLM (configured in [`system.yaml`](system.yaml)) using the `custom:answer_correctness` metric per turn. The framework is [`lightspeed-eval`](https://github.com/lightspeed-core/lightspeed-evaluation); install it with `make setup-ols-evaluation` from the repository root (see [`Makefile`](../Makefile)).

--- a/netobserv/README.md
+++ b/netobserv/README.md
@@ -6,18 +6,25 @@ Evaluation scenarios that test how well an AI assistant — backed by the OpenSh
 
 ## Prerequisites
 
-### 1. Cluster login and NetObserv
+### 1. Cluster login
 
-You must be logged in to a running OpenShift cluster with NetObserv installed (`FlowCollector` named `cluster`, Ready).
+You must be logged in to a running OpenShift cluster.
 
 ```bash
 oc login <cluster-api-url>
-oc get flowcollector cluster
 ```
 
-If NetObserv is not installed yet, follow [`build/README.md`](build/README.md).
+### 2. NetObserv operator and FlowCollector
 
-### 2. MCP server with NetObserv toolset
+All scenarios assume NetObserv is installed and `FlowCollector/cluster` is Ready. See [`build/README.md`](build/README.md) for a full description of every step and all available variables.
+
+```bash
+make setup-netobserv-openshift
+```
+
+Installs the NetObserv operator via OLM, applies [`build/flowcollector.yaml`](build/flowcollector.yaml) (a `FlowCollector` tuned for these scenarios — sampling 1, eBPF features, MCP network policy; `installDemoLoki: true` deploys Loki), and waits for `FlowCollector/cluster` Ready.
+
+### 3. MCP server with NetObserv toolset
 
 Same path as [kiali-ossm](../kiali-ossm/README.md): deploy **openshift-mcp-server** from the repository root with the `netobserv` toolset enabled:
 
@@ -28,7 +35,7 @@ make connect-ols-mcp
 
 See the root [README](../README.md#openshift-mcp-server-setup). To test an upstream PR before the toolset ships in openshift-mcp-server, use `make setup-kubernetes-mcp` with `KUBERNETES_MCP_IMAGE` — see [`build/README.md`](build/README.md).
 
-### 3. OpenShift Lightspeed (OLS)
+### 4. OpenShift Lightspeed (OLS)
 
 Evals call OLS `/v1/query`. The operator serves **HTTPS on port 8443** inside the pod (`lightspeed-service-api`, container port `https`) — not HTTP on 8080.
 
@@ -150,7 +157,7 @@ The judge LLM requires an OpenAI API key. Export it before running any test targ
 export OPENAI_API_KEY=<your-key>
 ```
 
-Then run scenarios from this directory (with OLS reachable — see [Prerequisites §3](README.md#3-openshift-lightspeed-ols)):
+Then run scenarios from this directory (with OLS reachable — see [Prerequisites §4](README.md#4-openshift-lightspeed-ols)):
 
 ```bash
 make test              # all scenarios

--- a/netobserv/build/README.md
+++ b/netobserv/build/README.md
@@ -1,0 +1,73 @@
+# NetObserv Prerequisites
+
+NetObserv evaluation scenarios assume a live OpenShift cluster with the Network Observability operator installed and a `FlowCollector` resource named `cluster` in Ready state.
+
+## Cluster login
+
+```bash
+oc login <cluster-api-url>
+oc get flowcollector cluster -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+```
+
+## NetObserv operator
+
+Install the operator and Loki from the upstream [netobserv-operator](https://github.com/netobserv/netobserv-operator) repository ([`deploy` target](https://github.com/netobserv/netobserv-operator/blob/main/Makefile#L417)):
+
+```bash
+USER=netobserv make deploy deploy-loki
+```
+
+Do **not** use `make deploy-sample-cr` — its defaults are unsuitable for evals (sampling 50, no eBPF features, non-privileged agent, network policy blocks the MCP server).
+
+Apply the eval `FlowCollector` from this repository instead:
+
+```bash
+oc apply -f build/flowcollector.yaml
+oc wait flowcollector/cluster --for=condition=Ready --timeout=10m
+```
+
+Or from `netobserv/`:
+
+```bash
+make deploy-flowcollector
+```
+
+| Setting | Sample CR | Eval `flowcollector.yaml` |
+|---------|-----------|---------------------------|
+| `sampling` | 50 | 1 |
+| `privileged` | false | true |
+| eBPF features | commented out | DNSTracking, PacketDrop, FlowRTT, NetworkEvents |
+| `networkPolicy.additionalNamespaces` | `[]` | `openshift-mcp` |
+
+`NetworkEvents` requires OpenShift 4.19+. All scenarios and their required features:
+
+| Scenario | FlowCollector eBPF feature |
+|----------|---------------------------|
+| `dns_latency`, `dns_nxdomain` | `DNSTracking` |
+| `packet_drops_kernel` | `PacketDrop` |
+| `packet_drops_policy` | `NetworkEvents` |
+| `tls_issues` | `NetworkEvents` |
+| `tcp_rtt` | `FlowRTT` |
+
+## MCP server
+
+Eval scenarios use the **netobserv** toolset on **openshift-mcp-server** (same as kiali-ossm uses `ossm`). From the **repository root**:
+
+```bash
+make setup-openshift-mcp TOOLSETS_ADDITIONAL=netobserv
+make connect-ols-mcp
+```
+
+### Testing upstream PRs (optional)
+
+Before the NetObserv toolset lands in openshift-mcp-server, deploy upstream [kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) with a custom image:
+
+```bash
+KUBERNETES_MCP_IMAGE=quay.io/<you>/kubernetes-mcp-server:<pr-tag> \
+  make setup-kubernetes-mcp
+make connect-ols-kubernetes-mcp
+```
+
+Update `flowcollector.yaml` `networkPolicy.additionalNamespaces` to `kubernetes-mcp-server` if you use this path. Teardown: `make teardown-kubernetes-mcp`.
+
+See the root [README](../../README.md#openshift-mcp-server-setup) for the full MCP lifecycle.

--- a/netobserv/build/README.md
+++ b/netobserv/build/README.md
@@ -37,7 +37,7 @@ make deploy-flowcollector
 | `sampling` | 50 | 1 |
 | `privileged` | false | true |
 | eBPF features | commented out | DNSTracking, PacketDrop, FlowRTT, NetworkEvents |
-| `networkPolicy.additionalNamespaces` | `[]` | `openshift-mcp` |
+| `networkPolicy.additionalNamespaces` | `[]` | `openshift-mcp`, `kubernetes-mcp-server` |
 
 `NetworkEvents` requires OpenShift 4.19+. All scenarios and their required features:
 
@@ -68,6 +68,6 @@ KUBERNETES_MCP_IMAGE=quay.io/<you>/kubernetes-mcp-server:<pr-tag> \
 make connect-ols-kubernetes-mcp
 ```
 
-Update `flowcollector.yaml` `networkPolicy.additionalNamespaces` to `kubernetes-mcp-server` if you use this path. Teardown: `make teardown-kubernetes-mcp`.
+Both MCP namespaces are already allowed in `flowcollector.yaml`. Teardown: `make teardown-kubernetes-mcp`.
 
 See the root [README](../../README.md#openshift-mcp-server-setup) for the full MCP lifecycle.

--- a/netobserv/build/README.md
+++ b/netobserv/build/README.md
@@ -1,36 +1,79 @@
-# NetObserv Prerequisites
+# NetObserv Installation
 
-NetObserv evaluation scenarios assume a live OpenShift cluster with the Network Observability operator installed and a `FlowCollector` resource named `cluster` in Ready state.
+Installs the Network Observability operator and eval `FlowCollector` on OpenShift. Loki is deployed by the operator via `spec.loki.monolithic.installDemoLoki`. Requires an active cluster login before running any `make` target.
 
-## Cluster login
+## Prerequisites
 
-```bash
-oc login <cluster-api-url>
-oc get flowcollector cluster -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
-```
+- `oc` configured and logged in: `oc login <cluster-api-url>`
+- Cluster-admin privileges (OLM operator install)
+- OpenShift 4.19+ recommended (`NetworkEvents` eBPF feature in eval `FlowCollector`)
 
-## NetObserv operator
+---
 
-Install the operator and Loki from the upstream [netobserv-operator](https://github.com/netobserv/netobserv-operator) repository ([`deploy` target](https://github.com/netobserv/netobserv-operator/blob/main/Makefile#L417)):
-
-```bash
-USER=netobserv make deploy deploy-loki
-```
-
-Do **not** use `make deploy-sample-cr` — its defaults are unsuitable for evals (sampling 50, no eBPF features, non-privileged agent, network policy blocks the MCP server).
-
-Apply the eval `FlowCollector` from this repository instead:
+## Automated setup
 
 ```bash
-oc apply -f build/flowcollector.yaml
-oc wait flowcollector/cluster --for=condition=Ready --timeout=10m
+make setup-netobserv-openshift
 ```
 
-Or from `netobserv/`:
+What this does, step by step:
+
+1. **Installs the NetObserv operator** via OLM (`install-netobserv-release.sh install-operator`).
+2. **Applies the eval `FlowCollector`** from `build/flowcollector.yaml` (sampling 1, all eBPF features, MCP network policy allowances, `installDemoLoki: true`).
+3. **Waits for `FlowCollector/cluster` Ready** — the operator deploys demo Loki and the pipeline in `spec.namespace`.
+
+### Cleanup
 
 ```bash
-make deploy-flowcollector
+make clean-netobserv-openshift
 ```
+
+Removes the FlowCollector (and operator-managed demo Loki) plus operator Subscription/CSV (and the operator namespace when `NETOBSERV_DELETE_OPERATOR_NAMESPACE=yes`, the default).
+
+### Troubleshooting OLM install
+
+NetObserv only supports **All namespaces** install mode. If the Subscription fails with `UnsupportedOperatorGroup` / `OwnNamespace InstallModeType not supported`, patch or replace the OperatorGroup (no `targetNamespaces`):
+
+```bash
+oc apply -f - <<'EOF'
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: netobserv-operator-group
+  namespace: openshift-netobserv-operator
+spec:
+  upgradeStrategy: Default
+EOF
+oc delete subscription netobserv-operator -n openshift-netobserv-operator --wait=true
+make setup-netobserv-openshift
+```
+
+`install-netobserv-release.sh` applies this OperatorGroup automatically and removes a failed Subscription before recreating it.
+
+### Customisation
+
+| Variable | Default | Description |
+|---|---|---|
+| `NETOBSERV_NS` | `netobserv` | Pipeline namespace (`spec.namespace`) |
+| `NETOBSERV_OPERATOR_NS` | `openshift-netobserv-operator` | OLM operator namespace |
+| `NETOBSERV_CATALOG_SOURCE` | `redhat` | `redhat` or `community` (OpenShift marketplace) |
+| `NETOBSERV_CHANNEL` | _(auto)_ | OLM channel (`stable` for redhat, `community` for community) |
+| `NETOBSERV_FLOWCOLLECTOR_FILE` | `build/flowcollector.yaml` | FlowCollector manifest to apply |
+| `NETOBSERV_FLOWCOLLECTOR_WAIT_TIMEOUT` | `10m` | `oc wait` timeout for FlowCollector Ready |
+
+### Individual steps
+
+```bash
+make netobserv-install-operator      # Operator only
+make netobserv-install-flowcollector # FlowCollector only (operator should exist)
+make netobserv-status                # Operator, Loki, FlowCollector status
+```
+
+---
+
+## Eval FlowCollector vs operator sample CR
+
+Do **not** use `deploy-sample-cr` from netobserv-operator — its defaults are unsuitable for evals.
 
 | Setting | Sample CR | Eval `flowcollector.yaml` |
 |---------|-----------|---------------------------|
@@ -38,8 +81,9 @@ make deploy-flowcollector
 | `privileged` | false | true |
 | eBPF features | commented out | DNSTracking, PacketDrop, FlowRTT, NetworkEvents |
 | `networkPolicy.additionalNamespaces` | `[]` | `openshift-mcp`, `kubernetes-mcp-server` |
+| `loki.monolithic.installDemoLoki` | commented out | `true` |
 
-`NetworkEvents` requires OpenShift 4.19+. All scenarios and their required features:
+Scenario → required eBPF feature:
 
 | Scenario | FlowCollector eBPF feature |
 |----------|---------------------------|
@@ -49,9 +93,27 @@ make deploy-flowcollector
 | `tls_issues` | `NetworkEvents` |
 | `tcp_rtt` | `FlowRTT` |
 
+---
+
+## Manual install from source (alternative)
+
+For operator development or non-OLM clusters, install from the [netobserv-operator](https://github.com/netobserv/netobserv-operator) repository:
+
+```bash
+USER=netobserv make deploy
+```
+
+Then apply the eval FlowCollector (Loki is created by the operator when `installDemoLoki: true`):
+
+```bash
+make deploy-flowcollector
+```
+
+---
+
 ## MCP server
 
-Eval scenarios use the **netobserv** toolset on **openshift-mcp-server** (same as kiali-ossm uses `ossm`). From the **repository root**:
+Eval scenarios use the **netobserv** toolset on **openshift-mcp-server**. From the **repository root**:
 
 ```bash
 make setup-openshift-mcp TOOLSETS_ADDITIONAL=netobserv
@@ -60,14 +122,12 @@ make connect-ols-mcp
 
 ### Testing upstream PRs (optional)
 
-Before the NetObserv toolset lands in openshift-mcp-server, deploy upstream [kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) with a custom image:
-
 ```bash
 KUBERNETES_MCP_IMAGE=quay.io/<you>/kubernetes-mcp-server:<pr-tag> \
   make setup-kubernetes-mcp
 make connect-ols-kubernetes-mcp
 ```
 
-Both MCP namespaces are already allowed in `flowcollector.yaml`. Teardown: `make teardown-kubernetes-mcp`.
+Both MCP namespaces are allowed in `flowcollector.yaml`. Teardown: `make teardown-kubernetes-mcp`.
 
 See the root [README](../../README.md#openshift-mcp-server-setup) for the full MCP lifecycle.

--- a/netobserv/build/flowcollector.yaml
+++ b/netobserv/build/flowcollector.yaml
@@ -1,0 +1,49 @@
+# FlowCollector for NetObserv troubleshooting evals (name must be "cluster").
+#
+# Differs from netobserv-operator deploy-sample-cr:
+#   - sampling: 1 (reliable flow export for short-lived eval workloads)
+#   - privileged: true + all eBPF features used by eval scenarios
+#   - networkPolicy.additionalNamespaces: openshift-mcp (MCP from make setup-openshift-mcp)
+#
+# Requires: NetObserv operator + Loki (USER=netobserv make deploy deploy-loki in netobserv-operator).
+# NetworkEvents requires OpenShift 4.19+.
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  namespace: netobserv
+  deploymentModel: Service
+  networkPolicy:
+    enable: true
+    additionalNamespaces:
+      - openshift-mcp
+  agent:
+    type: eBPF
+    ebpf:
+      sampling: 1
+      privileged: true
+      cacheActiveTimeout: 15s
+      cacheMaxFlows: 120000
+      features:
+        - DNSTracking
+        - PacketDrop
+        - FlowRTT
+        - NetworkEvents
+      excludeInterfaces:
+        - lo
+  processor:
+    consumerReplicas: 1
+    metrics:
+      disableAlerts: []
+  loki:
+    enable: true
+    mode: Monolithic
+    monolithic:
+      url: http://loki.netobserv.svc.cluster.local.:3100/
+  prometheus:
+    querier:
+      enable: true
+  consolePlugin:
+    enable: true
+  exporters: []

--- a/netobserv/build/flowcollector.yaml
+++ b/netobserv/build/flowcollector.yaml
@@ -3,7 +3,7 @@
 # Differs from netobserv-operator deploy-sample-cr:
 #   - sampling: 1 (reliable flow export for short-lived eval workloads)
 #   - privileged: true + all eBPF features used by eval scenarios
-#   - networkPolicy.additionalNamespaces: openshift-mcp (MCP from make setup-openshift-mcp)
+#   - networkPolicy.additionalNamespaces: openshift-mcp + kubernetes-mcp-server (both MCP deploy paths)
 #
 # Requires: NetObserv operator + Loki (USER=netobserv make deploy deploy-loki in netobserv-operator).
 # NetworkEvents requires OpenShift 4.19+.
@@ -18,6 +18,7 @@ spec:
     enable: true
     additionalNamespaces:
       - openshift-mcp
+      - kubernetes-mcp-server
   agent:
     type: eBPF
     ebpf:

--- a/netobserv/build/flowcollector.yaml
+++ b/netobserv/build/flowcollector.yaml
@@ -5,7 +5,7 @@
 #   - privileged: true + all eBPF features used by eval scenarios
 #   - networkPolicy.additionalNamespaces: openshift-mcp + kubernetes-mcp-server (both MCP deploy paths)
 #
-# Requires: NetObserv operator + Loki (USER=netobserv make deploy deploy-loki in netobserv-operator).
+# Requires: NetObserv operator only — Loki is deployed by the operator via installDemoLoki.
 # NetworkEvents requires OpenShift 4.19+.
 apiVersion: flows.netobserv.io/v1beta2
 kind: FlowCollector
@@ -41,7 +41,7 @@ spec:
     enable: true
     mode: Monolithic
     monolithic:
-      url: http://loki.netobserv.svc.cluster.local.:3100/
+      installDemoLoki: true
   prometheus:
     querier:
       enable: true

--- a/netobserv/build/netobserv.mk
+++ b/netobserv/build/netobserv.mk
@@ -1,0 +1,63 @@
+##@ NetObserv install
+
+NETOBSERV_INSTALL_SCRIPT := $(abspath $(CURDIR)/build/scripts/install-netobserv-release.sh)
+NETOBSERV_NS ?= netobserv
+NETOBSERV_OPERATOR_NS ?= openshift-netobserv-operator
+KUBERNETES_CLI ?= oc
+NETOBSERV_CATALOG_SOURCE ?= redhat
+NETOBSERV_CHANNEL ?=
+NETOBSERV_FLOWCOLLECTOR_FILE ?= $(abspath $(CURDIR)/build/flowcollector.yaml)
+NETOBSERV_FLOWCOLLECTOR_WAIT_TIMEOUT ?= 10m
+NETOBSERV_DELETE_OPERATOR_NAMESPACE ?= yes
+
+NETOBSERV_INSTALL_FLAGS = -c '$(KUBERNETES_CLI)' \
+  -ns '$(NETOBSERV_NS)' \
+  -ons '$(NETOBSERV_OPERATOR_NS)' \
+  -cs '$(NETOBSERV_CATALOG_SOURCE)' \
+  -fc '$(NETOBSERV_FLOWCOLLECTOR_FILE)'
+
+ifneq ($(strip $(NETOBSERV_CHANNEL)),)
+NETOBSERV_INSTALL_FLAGS += -ch '$(NETOBSERV_CHANNEL)'
+endif
+
+.PHONY: setup-netobserv-openshift
+setup-netobserv-openshift: ## OpenShift: install NetObserv operator and eval FlowCollector
+	@test -f '$(NETOBSERV_INSTALL_SCRIPT)' || { echo "Missing $(NETOBSERV_INSTALL_SCRIPT)"; exit 1; }
+	@echo "==> NetObserv: installing operator (catalog=$(NETOBSERV_CATALOG_SOURCE)) ..."
+	NETOBSERV_FLOWCOLLECTOR_WAIT_TIMEOUT='$(NETOBSERV_FLOWCOLLECTOR_WAIT_TIMEOUT)' \
+	  bash '$(NETOBSERV_INSTALL_SCRIPT)' $(NETOBSERV_INSTALL_FLAGS) install
+	@echo "==> setup-netobserv-openshift: done."
+
+.PHONY: netobserv-install-operator netobserv-install-flowcollector
+netobserv-install-operator: ## Install only the NetObserv operator via OLM
+	@test -f '$(NETOBSERV_INSTALL_SCRIPT)' || { echo "Missing $(NETOBSERV_INSTALL_SCRIPT)"; exit 1; }
+	bash '$(NETOBSERV_INSTALL_SCRIPT)' $(NETOBSERV_INSTALL_FLAGS) install-operator
+
+netobserv-install-flowcollector: ## Apply eval FlowCollector and wait for Ready
+	@test -f '$(NETOBSERV_INSTALL_SCRIPT)' || { echo "Missing $(NETOBSERV_INSTALL_SCRIPT)"; exit 1; }
+	NETOBSERV_FLOWCOLLECTOR_WAIT_TIMEOUT='$(NETOBSERV_FLOWCOLLECTOR_WAIT_TIMEOUT)' \
+	  bash '$(NETOBSERV_INSTALL_SCRIPT)' $(NETOBSERV_INSTALL_FLAGS) install-flowcollector
+
+.PHONY: netobserv-status
+netobserv-status: ## Show NetObserv operator, Loki, and FlowCollector status
+	@test -f '$(NETOBSERV_INSTALL_SCRIPT)' || { echo "Missing $(NETOBSERV_INSTALL_SCRIPT)"; exit 1; }
+	bash '$(NETOBSERV_INSTALL_SCRIPT)' $(NETOBSERV_INSTALL_FLAGS) status
+
+.PHONY: clean-netobserv-openshift
+clean-netobserv-openshift: ## Remove eval FlowCollector and NetObserv operator
+	@test -f '$(NETOBSERV_INSTALL_SCRIPT)' || { echo "Missing $(NETOBSERV_INSTALL_SCRIPT)"; exit 1; }
+	@set -e; \
+	flags='$(NETOBSERV_INSTALL_FLAGS)'; \
+	echo "==> NetObserv: deleting FlowCollector ..."; \
+	bash '$(NETOBSERV_INSTALL_SCRIPT)' $$flags delete-flowcollector; \
+	echo "==> NetObserv: deleting operator ..."; \
+	if [ '$(NETOBSERV_DELETE_OPERATOR_NAMESPACE)' = yes ]; then \
+	  bash '$(NETOBSERV_INSTALL_SCRIPT)' $$flags -don delete-operator; \
+	else \
+	  bash '$(NETOBSERV_INSTALL_SCRIPT)' $$flags delete-operator; \
+	fi; \
+	echo "==> clean-netobserv-openshift: done."
+
+ifeq ($(words $(MAKEFILE_LIST)),1)
+.DEFAULT_GOAL := setup-netobserv-openshift
+endif

--- a/netobserv/build/scripts/check_prereqs.sh
+++ b/netobserv/build/scripts/check_prereqs.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Shared prerequisites and helpers for NetObserv troubleshooting eval scenarios.
+# Requires NetObserv (FlowCollector) and kubernetes-mcp-server with the netobserv toolset.
+
+set -euo pipefail
+
+NETOBSERV_NS="${NETOBSERV_NS:-netobserv}"
+TARGET_NS="${TARGET_NS:-netobserv}"
+
+# Optional space-separated FlowCollector eBPF features (e.g. "DNSTracking PacketDrop").
+REQUIRED_NETOBSERV_FEATURES="${REQUIRED_NETOBSERV_FEATURES:-}"
+
+check_netobserv_feature() {
+  local feature="$1"
+  local fc_json="$2"
+  if echo "${fc_json}" | jq -e --arg f "${feature}" '
+    [.items[0].spec.agent.ebpf.features[]? | if type == "string" then . else .name end] | index($f)
+  ' >/dev/null; then
+    return 0
+  fi
+  echo "WARN: FlowCollector does not list eBPF feature '${feature}' — NetObserv may not export related metrics/flows"
+  return 1
+}
+
+check_netobserv_prereqs() {
+  if ! command -v oc >/dev/null 2>&1; then
+    echo "ERROR: oc is required for NetObserv scenarios"
+    exit 1
+  fi
+
+  if ! oc whoami >/dev/null 2>&1; then
+    echo "ERROR: not logged in to OpenShift (oc whoami failed)"
+    exit 1
+  fi
+
+  if ! oc api-resources --api-group=flows.netobserv.io 2>/dev/null | grep -q flowcollectors; then
+    echo "ERROR: FlowCollector CRD (flows.netobserv.io) not found — install NetObserv operator first"
+    exit 1
+  fi
+
+  FC_JSON="$(oc get flowcollector -A -o json 2>/dev/null || true)"
+  if [[ -z "${FC_JSON}" || "$(echo "${FC_JSON}" | jq '.items | length')" == "0" ]]; then
+    echo "ERROR: no FlowCollector resource found in the cluster"
+    exit 1
+  fi
+
+  FC_NAME="$(echo "${FC_JSON}" | jq -r '.items[0].metadata.name')"
+  FC_READY="$(echo "${FC_JSON}" | jq -r '.items[0].status.conditions[]? | select(.type=="Ready") | .status' | head -n1)"
+
+  echo "FlowCollector: ${FC_NAME} (Ready=${FC_READY:-unknown})"
+
+  if [[ "${FC_READY}" != "True" ]]; then
+    echo "WARN: FlowCollector is not Ready — NetObserv metrics/logs may be incomplete"
+  fi
+
+  if ! oc get namespace "${TARGET_NS}" >/dev/null 2>&1; then
+    echo "WARN: target namespace '${TARGET_NS}' does not exist — agent may still answer cluster-wide"
+  fi
+
+  if [[ -n "${REQUIRED_NETOBSERV_FEATURES}" ]]; then
+    for feat in ${REQUIRED_NETOBSERV_FEATURES}; do
+      check_netobserv_feature "${feat}" "${FC_JSON}" || true
+    done
+  fi
+
+  echo "NetObserv prerequisites OK (TARGET_NS=${TARGET_NS}, NETOBSERV_NS=${NETOBSERV_NS})"
+  echo "OLS must have MCP access via kubernetes-mcp-server with the netobserv toolset enabled."
+}
+
+# OpenShift restricted SCC requires runAsUser inside the namespace UID allocation.
+openshift_namespace_uid_min() {
+  local ns="$1"
+  local uid_range
+  uid_range="$(oc get namespace "${ns}" -o jsonpath='{.metadata.annotations.openshift\.io/sa\.scc\.uid-range}' 2>/dev/null || true)"
+  if [[ -z "${uid_range}" || "${uid_range}" != */* ]]; then
+    return 1
+  fi
+  echo "${uid_range%%/*}"
+}
+
+# Patch busybox/python/iperf containers to the namespace min UID; skip images with a fixed non-root USER.
+patch_openshift_deployments() {
+  local ns="$1"
+  local uid_min
+  if ! uid_min="$(openshift_namespace_uid_min "${ns}")"; then
+    echo "No OpenShift UID range on ${ns} — using manifest runAsUser values"
+    return 0
+  fi
+
+  echo "OpenShift: patching deployments in ${ns} to runAsUser=${uid_min}"
+  local deploy
+  for deploy in $(oc get deploy -n "${ns}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+    [[ -z "${deploy}" ]] && continue
+    local json container_count i
+    json="$(oc get deploy "${deploy}" -n "${ns}" -o json)"
+    container_count="$(echo "${json}" | jq '.spec.template.spec.containers | length')"
+    i=0
+    while [[ "${i}" -lt "${container_count}" ]]; do
+      local image
+      image="$(echo "${json}" | jq -r ".spec.template.spec.containers[${i}].image")"
+      case "${image}" in
+        *nginx-unprivileged* | *curlimages/curl*)
+          i=$((i + 1))
+          continue
+          ;;
+      esac
+      oc patch deploy "${deploy}" -n "${ns}" --type=json \
+        -p="[{\"op\":\"add\",\"path\":\"/spec/template/spec/containers/${i}/securityContext/runAsUser\",\"value\":${uid_min}}]" \
+        2>/dev/null \
+        || oc patch deploy "${deploy}" -n "${ns}" --type=json \
+          -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/${i}/securityContext/runAsUser\",\"value\":${uid_min}}]"
+      i=$((i + 1))
+    done
+  done
+}
+
+wait_for_namespace_gone() {
+  local ns="$1"
+  local max_attempts="${2:-90}"
+  local attempt
+  for attempt in $(seq 1 "${max_attempts}"); do
+    if ! oc get namespace "${ns}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "WARN: namespace ${ns} still terminating after $((max_attempts * 2))s"
+  return 1
+}
+
+deploy_netobserv_fixture() {
+  local fixture_dir="$1"
+  local ns="$2"
+  local recreate="${NETOBSERV_EVAL_RECREATE_NS:-true}"
+
+  if [[ "${recreate}" == "true" ]] && oc get namespace "${ns}" >/dev/null 2>&1; then
+    echo "Recreating eval namespace ${ns} for a clean fixture deploy…"
+    oc delete namespace "${ns}" --ignore-not-found --wait=false
+    wait_for_namespace_gone "${ns}" || true
+  fi
+
+  oc apply -f "${fixture_dir}/manifest.yaml"
+
+  local attempt
+  for attempt in $(seq 1 15); do
+    if openshift_namespace_uid_min "${ns}" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+  patch_openshift_deployments "${ns}"
+
+  echo "Deployed fixture in namespace ${ns}"
+}
+
+cleanup_netobserv_fixture() {
+  local ns="$1"
+  if oc get namespace "${ns}" >/dev/null 2>&1; then
+    oc delete namespace "${ns}" --ignore-not-found --wait=false
+    echo "Deleted namespace ${ns}"
+  else
+    echo "Namespace ${ns} not present — nothing to clean up"
+  fi
+}

--- a/netobserv/build/scripts/func-log.sh
+++ b/netobserv/build/scripts/func-log.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+##########################################################
+#
+# Simple logging helpers for NetObserv install scripts.
+#
+##########################################################
+
+errormsg() {
+  echo -e "\U0001F6A8 ERROR: ${1}"
+}
+
+infomsg() {
+  echo -e "\U0001F4C4 ${1}"
+}
+
+warnmsg() {
+  echo -e "\U000026A0\uFE0F  WARN: ${1}"
+}

--- a/netobserv/build/scripts/func-netobserv.sh
+++ b/netobserv/build/scripts/func-netobserv.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+
+##########################################################
+#
+# Functions for managing NetObserv operator and FlowCollector.
+#
+##########################################################
+
+set -u
+
+wait_for_cluster_crd() {
+  local crd_name="${1}"
+  local human="${2:-${crd_name}}"
+  local max_wait="${3:-720}"
+  local waited=0
+  infomsg "Waiting for CRD [${crd_name}] (${human})..."
+  while ! ${OC} get crd "${crd_name}" >& /dev/null; do
+    if [ "${waited}" -ge "${max_wait}" ]; then
+      errormsg "Timeout after ${max_wait}s waiting for CRD [${crd_name}] (${human}). Check the operator Subscription in ${NETOBSERV_OPERATOR_NAMESPACE}."
+      exit 1
+    fi
+    echo -n "."
+    sleep 5
+    waited=$((waited + 5))
+  done
+  echo ""
+  if ! ${OC} wait --for condition=established "crd/${crd_name}" --timeout=3m; then
+    errormsg "CRD [${crd_name}] did not become Established within 3m."
+    exit 1
+  fi
+  infomsg "CRD [${crd_name}] is ready"
+}
+
+wait_for_operator_deployment() {
+  local max_wait="${NETOBSERV_OPERATOR_WAIT_SECONDS:-720}"
+  local waited=0
+  local deploy_name="netobserv-controller-manager"
+
+  infomsg "Waiting for deployment/${deploy_name} in [${NETOBSERV_OPERATOR_NAMESPACE}] (up to ${max_wait}s)..."
+  while ! ${OC} get "deployment/${deploy_name}" -n "${NETOBSERV_OPERATOR_NAMESPACE}" -o name >/dev/null 2>&1; do
+    if [ "${waited}" -ge "${max_wait}" ]; then
+      errormsg "Timeout after ${max_wait}s waiting for deployment/${deploy_name} in [${NETOBSERV_OPERATOR_NAMESPACE}]. Check Subscription and InstallPlans."
+      exit 1
+    fi
+    echo -n "."
+    sleep 5
+    waited=$((waited + 5))
+  done
+  echo ""
+  ${OC} rollout status "deployment/${deploy_name}" -n "${NETOBSERV_OPERATOR_NAMESPACE}" --timeout="${NETOBSERV_OPERATOR_ROLLOUT_TIMEOUT:-600s}"
+}
+
+install_netobserv_operator() {
+  local catalog_source="${1}"
+
+  if [ "${IS_OPENSHIFT}" == "false" ]; then
+    infomsg "Installing NetObserv operator from OperatorHub.io"
+    ${OC} apply -f https://operatorhub.io/install/netobserv-operator.yaml
+    return
+  fi
+
+  local subscription_source subscription_channel subscription_name
+
+  case ${catalog_source} in
+    redhat)
+      subscription_source="redhat-operators"
+      subscription_channel="${NETOBSERV_CHANNEL:-stable}"
+      subscription_name="netobserv-operator"
+      ;;
+    community)
+      subscription_source="community-operators"
+      subscription_channel="${NETOBSERV_CHANNEL:-community}"
+      subscription_name="netobserv-operator"
+      ;;
+    *)
+      subscription_source="${catalog_source}"
+      subscription_channel="${NETOBSERV_CHANNEL:-stable}"
+      subscription_name="netobserv-operator"
+      ;;
+  esac
+
+  infomsg "Ensuring namespace [${NETOBSERV_OPERATOR_NAMESPACE}] exists"
+  ${OC} create namespace "${NETOBSERV_OPERATOR_NAMESPACE}" --dry-run=client -o yaml | ${OC} apply -f -
+
+  # NetObserv CSV only supports AllNamespaces — do not set targetNamespaces (that selects OwnNamespace).
+  infomsg "Ensuring AllNamespaces OperatorGroup in [${NETOBSERV_OPERATOR_NAMESPACE}]"
+  cat <<EOM | ${OC} apply -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: netobserv-operator-group
+  namespace: ${NETOBSERV_OPERATOR_NAMESPACE}
+spec:
+  upgradeStrategy: Default
+EOM
+
+  # Recover from a prior failed Subscription/InstallPlan (e.g. UnsupportedOperatorGroup).
+  if ${OC} get subscription netobserv-operator -n "${NETOBSERV_OPERATOR_NAMESPACE}" -o name >/dev/null 2>&1; then
+    local sub_reason sub_state
+    sub_reason="$(${OC} get subscription netobserv-operator -n "${NETOBSERV_OPERATOR_NAMESPACE}" -o jsonpath='{.status.conditions[0].reason}' 2>/dev/null || true)"
+    sub_state="$(${OC} get subscription netobserv-operator -n "${NETOBSERV_OPERATOR_NAMESPACE}" -o jsonpath='{.status.state}' 2>/dev/null || true)"
+    if [ "${sub_reason}" = "UnsupportedOperatorGroup" ] || [ "${sub_state}" = "UpgradeFailed" ] || [ "${sub_state}" = "InstallPlanFailed" ]; then
+      warnmsg "Removing failed Subscription netobserv-operator (reason=${sub_reason:-unknown}, state=${sub_state:-unknown}) before recreate"
+      ${OC} delete subscription netobserv-operator -n "${NETOBSERV_OPERATOR_NAMESPACE}" --ignore-not-found=true --wait=true
+      local csv
+      csv="$(${OC} get csv -n "${NETOBSERV_OPERATOR_NAMESPACE}" -o name 2>/dev/null | grep netobserv || true)"
+      if [ -n "${csv}" ]; then
+        echo "${csv}" | while IFS= read -r c; do
+          [ -n "${c}" ] && ${OC} delete "${c}" -n "${NETOBSERV_OPERATOR_NAMESPACE}" --ignore-not-found=true --wait=true
+        done
+      fi
+    fi
+  fi
+
+  infomsg "Installing NetObserv operator from catalog [${catalog_source}] (source=${subscription_source}, channel=${subscription_channel})"
+  cat <<EOM | ${OC} apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: netobserv-operator
+  namespace: ${NETOBSERV_OPERATOR_NAMESPACE}
+spec:
+  channel: ${subscription_channel}
+  installPlanApproval: Automatic
+  name: ${subscription_name}
+  source: ${subscription_source}
+  sourceNamespace: openshift-marketplace
+EOM
+}
+
+install_netobserv_flowcollector() {
+  local flowcollector_file="${1}"
+
+  if [ ! -f "${flowcollector_file}" ]; then
+    errormsg "FlowCollector manifest not found [${flowcollector_file}]"
+    exit 1
+  fi
+
+  wait_for_cluster_crd "flowcollectors.flows.netobserv.io" "NetObserv FlowCollector" "${NETOBSERV_CRD_WAIT_SECONDS:-720}"
+
+  infomsg "Ensuring namespace [${NETOBSERV_NAMESPACE}] exists"
+  ${OC} create namespace "${NETOBSERV_NAMESPACE}" --dry-run=client -o yaml | ${OC} apply -f -
+
+  infomsg "Applying FlowCollector from [${flowcollector_file}] (Loki via spec.loki.monolithic.installDemoLoki)"
+  ${OC} apply -f "${flowcollector_file}"
+
+  infomsg "Waiting for FlowCollector/cluster to become Ready (timeout=${NETOBSERV_FLOWCOLLECTOR_WAIT_TIMEOUT:-10m})"
+  if ! ${OC} wait flowcollector/cluster --for=condition=Ready --timeout="${NETOBSERV_FLOWCOLLECTOR_WAIT_TIMEOUT:-10m}"; then
+    errormsg "FlowCollector/cluster did not become Ready in time"
+    ${OC} get flowcollector cluster -o yaml 2>/dev/null | tail -40 || true
+    exit 1
+  fi
+}
+
+validate_netobserv_ready() {
+  local ready_status
+  ready_status="$(${OC} get flowcollector cluster -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)"
+  if [ "${ready_status}" != "True" ]; then
+    errormsg "FlowCollector/cluster Ready=${ready_status:-<missing>}"
+    exit 1
+  fi
+
+  infomsg "FlowCollector/cluster is Ready"
+  ${OC} get flowcollector cluster -o wide 2>/dev/null || true
+  ${OC} get pods -n "${NETOBSERV_NAMESPACE}" 2>/dev/null || true
+}
+
+delete_netobserv_flowcollector() {
+  infomsg "Deleting FlowCollector/cluster (operator-managed demo Loki is removed with it)"
+  ${OC} delete flowcollector cluster --ignore-not-found=true --wait=false
+}
+
+delete_netobserv_operator() {
+  if [ "${IS_OPENSHIFT}" == "false" ]; then
+    infomsg "Deleting NetObserv operator subscription (OperatorHub install)"
+    ${OC} delete -f https://operatorhub.io/install/netobserv-operator.yaml --ignore-not-found=true || true
+    return
+  fi
+
+  infomsg "Deleting NetObserv operator Subscription in [${NETOBSERV_OPERATOR_NAMESPACE}]"
+  ${OC} delete subscription netobserv-operator -n "${NETOBSERV_OPERATOR_NAMESPACE}" --ignore-not-found=true
+
+  local csv
+  csv="$(${OC} get csv -n "${NETOBSERV_OPERATOR_NAMESPACE}" -o name 2>/dev/null | grep netobserv || true)"
+  if [ -n "${csv}" ]; then
+    infomsg "Deleting CSV(s): ${csv}"
+    echo "${csv}" | while IFS= read -r c; do
+      [ -n "${c}" ] && ${OC} delete "${c}" -n "${NETOBSERV_OPERATOR_NAMESPACE}" --ignore-not-found=true
+    done
+  fi
+
+  if [ "${NETOBSERV_DELETE_OPERATOR_NAMESPACE:-}" = "yes" ]; then
+    infomsg "Deleting operator namespace [${NETOBSERV_OPERATOR_NAMESPACE}]"
+    ${OC} delete namespace "${NETOBSERV_OPERATOR_NAMESPACE}" --ignore-not-found=true --wait=false
+  fi
+}
+
+status_netobserv() {
+  echo ""
+  echo "=== NetObserv operator (${NETOBSERV_OPERATOR_NAMESPACE}) ==="
+  ${OC} get subscription,csv,deployment -n "${NETOBSERV_OPERATOR_NAMESPACE}" 2>/dev/null || true
+  echo ""
+  echo "=== Loki (${NETOBSERV_NAMESPACE}, operator-managed) ==="
+  ${OC} get pods,svc -n "${NETOBSERV_NAMESPACE}" -l app=loki 2>/dev/null || true
+  echo ""
+  echo "=== FlowCollector ==="
+  ${OC} get flowcollector -A 2>/dev/null || true
+  ${OC} get flowcollector cluster -o jsonpath='{range .status.conditions[*]}{.type}={.status} {.reason}{"\n"}{end}' 2>/dev/null || true
+  echo ""
+  echo "=== NetObserv pipeline pods (${NETOBSERV_NAMESPACE}) ==="
+  ${OC} get pods -n "${NETOBSERV_NAMESPACE}" 2>/dev/null || true
+}

--- a/netobserv/build/scripts/install-netobserv-release.sh
+++ b/netobserv/build/scripts/install-netobserv-release.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+##########################################################
+#
+# Installs NetObserv operator and eval FlowCollector.
+#
+##########################################################
+
+set -u
+
+SCRIPT_ROOT="$( cd "$(dirname "$0")" ; pwd -P )"
+cd "${SCRIPT_ROOT}"
+
+source "${SCRIPT_ROOT}/func-log.sh"
+source "${SCRIPT_ROOT}/func-netobserv.sh"
+
+netobserv_install_require_opt_value() {
+  local flag="$1"
+  local val="${2:-}"
+  if [ -z "${val}" ] || [ "${val#-}" != "${val}" ]; then
+    errormsg "Option [${flag}] requires a value. The next argument is missing or starts with '-'."
+    exit 1
+  fi
+}
+
+DEFAULT_OC="oc"
+DEFAULT_CATALOG_SOURCE="redhat"
+DEFAULT_NETOBSERV_NAMESPACE="netobserv"
+DEFAULT_NETOBSERV_OPERATOR_NAMESPACE="openshift-netobserv-operator"
+DEFAULT_FLOWCOLLECTOR_FILE="${SCRIPT_ROOT}/../flowcollector.yaml"
+
+_CMD=""
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+
+    install)              _CMD="install"              ; shift ;;
+    install-operator)     _CMD="install-operator"     ; shift ;;
+    install-flowcollector) _CMD="install-flowcollector" ; shift ;;
+    delete-operator)      _CMD="delete-operator"      ; shift ;;
+    delete-flowcollector) _CMD="delete-flowcollector" ; shift ;;
+    status)               _CMD="status"               ; shift ;;
+
+    -c|--client)                    netobserv_install_require_opt_value "${key}" "${2:-}"; OC="${2}" ; shift;shift ;;
+    -cs|--catalog-source)           netobserv_install_require_opt_value "${key}" "${2:-}"; CATALOG_SOURCE="${2}" ; shift;shift ;;
+    -ch|--channel)                   netobserv_install_require_opt_value "${key}" "${2:-}"; NETOBSERV_CHANNEL="${2}" ; shift;shift ;;
+    -fc|--flowcollector-file)        netobserv_install_require_opt_value "${key}" "${2:-}"; FLOWCOLLECTOR_FILE="${2}" ; shift;shift ;;
+    -ns|--namespace)                 netobserv_install_require_opt_value "${key}" "${2:-}"; NETOBSERV_NAMESPACE="${2}" ; shift;shift ;;
+    -ons|--operator-namespace)       netobserv_install_require_opt_value "${key}" "${2:-}"; NETOBSERV_OPERATOR_NAMESPACE="${2}" ; shift;shift ;;
+    -don|--delete-operator-namespace) NETOBSERV_DELETE_OPERATOR_NAMESPACE="yes" ; shift ;;
+
+    -h|--help)
+      cat <<HELPMSG
+
+$0 [option...] command
+
+Installs NetObserv for troubleshooting eval scenarios.
+
+Commands:
+  install                 Install operator and eval FlowCollector (full setup)
+  install-operator        Install only the NetObserv operator (OLM on OpenShift)
+  install-flowcollector   Apply eval FlowCollector and wait for Ready
+  delete-flowcollector    Delete FlowCollector/cluster
+  delete-operator         Remove operator Subscription/CSV
+  status                  Show operator, Loki, and FlowCollector status
+
+Options:
+  -c|--client <path>              oc/kubectl client (default: ${DEFAULT_OC})
+  -cs|--catalog-source <name>      redhat | community (OpenShift only; default: ${DEFAULT_CATALOG_SOURCE})
+  -ch|--channel <name>             OLM channel (default: stable for redhat, community for community)
+  -fc|--flowcollector-file <path>  FlowCollector manifest (default: build/flowcollector.yaml)
+  -ns|--namespace <name>           NetObserv pipeline namespace (default: ${DEFAULT_NETOBSERV_NAMESPACE})
+  -ons|--operator-namespace <name> Operator namespace (default: ${DEFAULT_NETOBSERV_OPERATOR_NAMESPACE})
+  -don|--delete-operator-namespace With delete-operator: also delete the operator namespace
+
+Environment:
+  NETOBSERV_FLOWCOLLECTOR_WAIT_TIMEOUT   oc wait timeout (default: 10m)
+  NETOBSERV_OPERATOR_WAIT_SECONDS        Seconds to wait for operator deployment (default: 720)
+
+HELPMSG
+      exit 0
+      ;;
+
+    *)
+      errormsg "Unknown argument [${key}]. See --help."
+      exit 1
+      ;;
+  esac
+done
+
+OC="${OC:-${DEFAULT_OC}}"
+CATALOG_SOURCE="${CATALOG_SOURCE:-${DEFAULT_CATALOG_SOURCE}}"
+NETOBSERV_NAMESPACE="${NETOBSERV_NAMESPACE:-${DEFAULT_NETOBSERV_NAMESPACE}}"
+NETOBSERV_OPERATOR_NAMESPACE="${NETOBSERV_OPERATOR_NAMESPACE:-${DEFAULT_NETOBSERV_OPERATOR_NAMESPACE}}"
+FLOWCOLLECTOR_FILE="${FLOWCOLLECTOR_FILE:-${DEFAULT_FLOWCOLLECTOR_FILE}}"
+
+if [ -z "${_CMD}" ]; then
+  errormsg "Missing command. See --help."
+  exit 1
+fi
+
+if ! command -v "${OC}" >/dev/null 2>&1; then
+  errormsg "Client not found [${OC}]. Use --client to set oc or kubectl."
+  exit 1
+fi
+
+if ${OC} api-resources --api-group=route.openshift.io -o name 2>/dev/null | grep -q .; then
+  IS_OPENSHIFT="true"
+else
+  IS_OPENSHIFT="false"
+fi
+
+if [ "${IS_OPENSHIFT}" = "true" ]; then
+  if ! ${OC} whoami >& /dev/null; then
+    errormsg "Not logged in. Run '${OC} login' and retry."
+    exit 1
+  fi
+elif [ "$(basename -- "${OC}")" = "oc" ]; then
+  if ! ${OC} whoami >& /dev/null; then
+    errormsg "Not logged in. Run '${OC} login' and retry."
+    exit 1
+  fi
+fi
+
+if [ "${IS_OPENSHIFT}" = "true" ] && [ "${CATALOG_SOURCE}" != "redhat" ] && [ "${CATALOG_SOURCE}" != "community" ]; then
+  warnmsg "Catalog source [${CATALOG_SOURCE}] is not redhat or community; using it as a custom marketplace source name."
+fi
+
+case "${_CMD}" in
+  install-operator)
+    install_netobserv_operator "${CATALOG_SOURCE}"
+    wait_for_cluster_crd "flowcollectors.flows.netobserv.io" "NetObserv FlowCollector" "${NETOBSERV_CRD_WAIT_SECONDS:-720}"
+    wait_for_operator_deployment
+    ;;
+  install-flowcollector)
+    install_netobserv_flowcollector "${FLOWCOLLECTOR_FILE}"
+    validate_netobserv_ready
+    ;;
+  install)
+    install_netobserv_operator "${CATALOG_SOURCE}"
+    wait_for_cluster_crd "flowcollectors.flows.netobserv.io" "NetObserv FlowCollector" "${NETOBSERV_CRD_WAIT_SECONDS:-720}"
+    wait_for_operator_deployment
+    install_netobserv_flowcollector "${FLOWCOLLECTOR_FILE}"
+    validate_netobserv_ready
+    ;;
+  delete-flowcollector)
+    delete_netobserv_flowcollector
+    ;;
+  delete-operator)
+    delete_netobserv_operator
+    ;;
+  status)
+    status_netobserv
+    ;;
+  *)
+    errormsg "Unknown command [${_CMD}]. See --help."
+    exit 1
+    ;;
+esac

--- a/netobserv/build/scripts/wait_for.sh
+++ b/netobserv/build/scripts/wait_for.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Wait helpers for NetObserv eval scenarios.
+
+wait_for_rollout() {
+  local ns="$1"
+  local deployment="$2"
+  local timeout="${3:-120s}"
+  if oc wait --for=condition=available "deployment/${deployment}" -n "$ns" --timeout="$timeout"; then
+    return 0
+  fi
+  echo "ERROR: deployment/${deployment} not available in ${ns} within ${timeout}"
+  oc get pods -n "$ns" -l "app=${deployment}" -o wide 2>/dev/null \
+    || oc get pods -n "$ns" -o wide 2>/dev/null || true
+  local pod
+  for pod in $(oc get pods -n "$ns" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+    echo "--- oc describe pod/${pod} -n ${ns} (last events) ---"
+    oc describe pod "${pod}" -n "$ns" 2>/dev/null | tail -25 || true
+  done
+  return 1
+}
+
+wait_for_log_pattern() {
+  local ns="$1"
+  local selector="$2"
+  local pattern="$3"
+  local max_attempts="${4:-40}"
+  local sleep_secs="${5:-3}"
+
+  local attempt
+  for attempt in $(seq 1 "$max_attempts"); do
+    if oc logs -n "$ns" -l "$selector" --tail=30 2>/dev/null | grep -qE "$pattern"; then
+      echo "Log pattern matched (attempt ${attempt}/${max_attempts})"
+      return 0
+    fi
+    echo "  attempt ${attempt}/${max_attempts}: waiting for log /${pattern}/ …"
+    sleep "$sleep_secs"
+  done
+  echo "ERROR: log pattern not found within timeout"
+  oc get pods -n "$ns" -l "$selector" 2>/dev/null || true
+  oc logs -n "$ns" -l "$selector" --tail=20 2>/dev/null || true
+  return 1
+}
+
+# Require at least min_count log lines matching pattern (sustained traffic before NetObserv export).
+wait_for_min_log_matches() {
+  local ns="$1"
+  local selector="$2"
+  local pattern="$3"
+  local min_count="${4:-3}"
+  local max_attempts="${5:-50}"
+  local sleep_secs="${6:-3}"
+
+  local attempt count
+  for attempt in $(seq 1 "$max_attempts"); do
+    count="$(oc logs -n "$ns" -l "$selector" --tail=80 2>/dev/null | grep -cE "$pattern" || true)"
+    if [[ "${count}" -ge "${min_count}" ]]; then
+      echo "Log pattern matched ${count} times (need >= ${min_count}, attempt ${attempt}/${max_attempts})"
+      return 0
+    fi
+    echo "  attempt ${attempt}/${max_attempts}: ${count}/${min_count} log lines matching /${pattern}/ …"
+    sleep "$sleep_secs"
+  done
+  echo "ERROR: fewer than ${min_count} log lines matched /${pattern}/ within timeout"
+  oc logs -n "$ns" -l "$selector" --tail=30 2>/dev/null || true
+  return 1
+}
+
+# NetObserv eBPF → flowlogs-pipeline → Loki needs time after traffic starts.
+# Override with NETOBSERV_WARMUP_SECS (default 120).
+wait_for_netobserv_warmup() {
+  local secs="${NETOBSERV_WARMUP_SECS:-120}"
+  echo "Waiting ${secs}s for NetObserv to export flows/metrics (NETOBSERV_WARMUP_SECS)…"
+  sleep "$secs"
+  echo "NetObserv warmup complete"
+}

--- a/netobserv/dns_latency/cleanup.sh
+++ b/netobserv/dns_latency/cleanup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../common/check_prereqs.sh
+source "${SCRIPT_DIR}/../build/scripts/check_prereqs.sh"
+cleanup_netobserv_fixture "netobserv-eval-dns-latency"

--- a/netobserv/dns_latency/fixtures/manifest.yaml
+++ b/netobserv/dns_latency/fixtures/manifest.yaml
@@ -1,0 +1,57 @@
+# Generates DNS traffic to cluster DNS and external resolvers (DNSTracking).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netobserv-eval-dns-latency
+  labels:
+    purpose: netobserv-eval
+    netobserv.openshift.io/eval-scenario: dns-latency
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dns-latency-prober
+  namespace: netobserv-eval-dns-latency
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dns-latency-prober
+  template:
+    metadata:
+      labels:
+        app: dns-latency-prober
+        netobserv.openshift.io/eval-scenario: dns-latency
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: prober
+          # busybox includes nslookup — ubi-minimal needs a runtime microdnf install that often
+          # fails or exceeds the eval setup timeout before DNS lines appear in pod logs.
+          image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "DNS latency prober: querying cluster DNS and external resolvers"
+              i=0
+              while true; do
+                nslookup kubernetes.default.svc.cluster.local 2>&1 || true
+                nslookup "slow-probe-${i}.netobserv-eval.example.com" 2>&1 || true
+                nslookup google.com 8.8.8.8 2>&1 || true
+                i=$((i + 1))
+                sleep 2
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 128Mi

--- a/netobserv/dns_latency/setup.sh
+++ b/netobserv/dns_latency/setup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET_NS="netobserv-eval-dns-latency"
+export TARGET_NS
+export REQUIRED_NETOBSERV_FEATURES="DNSTracking"
+
+# shellcheck source=../common/check_prereqs.sh
+source "${SCRIPT_DIR}/../build/scripts/check_prereqs.sh"
+# shellcheck source=../common/wait_for.sh
+source "${SCRIPT_DIR}/../build/scripts/wait_for.sh"
+
+check_netobserv_prereqs
+deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
+
+wait_for_rollout "${TARGET_NS}" "dns-latency-prober" "180s"
+echo "Waiting for DNS prober traffic (NetObserv export may take a few minutes)…"
+wait_for_log_pattern "${TARGET_NS}" "app=dns-latency-prober" "kubernetes\\.default|Name:|Address" 30 3
+wait_for_netobserv_warmup
+echo "Scenario dns_latency ready (TARGET_NS=${TARGET_NS})"

--- a/netobserv/dns_nxdomain/cleanup.sh
+++ b/netobserv/dns_nxdomain/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/../build/scripts/check_prereqs.sh"
+cleanup_netobserv_fixture "netobserv-eval-dns-nxdomain"

--- a/netobserv/dns_nxdomain/fixtures/manifest.yaml
+++ b/netobserv/dns_nxdomain/fixtures/manifest.yaml
@@ -1,0 +1,56 @@
+# Generates NXDOMAIN and DNS error responses (DNSTracking).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netobserv-eval-dns-nxdomain
+  labels:
+    purpose: netobserv-eval
+    netobserv.openshift.io/eval-scenario: dns-nxdomain
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dns-nxdomain-prober
+  namespace: netobserv-eval-dns-nxdomain
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dns-nxdomain-prober
+  template:
+    metadata:
+      labels:
+        app: dns-nxdomain-prober
+        netobserv.openshift.io/eval-scenario: dns-nxdomain
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: prober
+          # busybox includes nslookup — ubi-minimal needs a runtime microdnf install that often
+          # fails or exceeds the eval setup timeout before NXDOMAIN lines appear in pod logs.
+          image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "NXDOMAIN prober: resolving non-existent names"
+              i=0
+              while true; do
+                nslookup "does-not-exist-${i}.netobserv-eval.invalid" 2>&1 || true
+                nslookup "nxdomain-${i}.netobserv-eval.invalid" 2>&1 || true
+                i=$((i + 1))
+                sleep 1
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 128Mi

--- a/netobserv/dns_nxdomain/setup.sh
+++ b/netobserv/dns_nxdomain/setup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET_NS="netobserv-eval-dns-nxdomain"
+export TARGET_NS
+export REQUIRED_NETOBSERV_FEATURES="DNSTracking"
+
+source "${SCRIPT_DIR}/../build/scripts/check_prereqs.sh"
+source "${SCRIPT_DIR}/../build/scripts/wait_for.sh"
+
+check_netobserv_prereqs
+deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
+
+wait_for_rollout "${TARGET_NS}" "dns-nxdomain-prober" "180s"
+wait_for_log_pattern "${TARGET_NS}" "app=dns-nxdomain-prober" "NXDOMAIN|can't find|can't resolve|server can't find|SERVFAIL|not found" 40 3
+wait_for_netobserv_warmup
+echo "Scenario dns_nxdomain ready (TARGET_NS=${TARGET_NS})"

--- a/netobserv/evals.yaml
+++ b/netobserv/evals.yaml
@@ -1,0 +1,133 @@
+# NetObserv evaluation scenarios — requires live cluster + NetObserv + kubernetes-mcp-server (netobserv toolset)
+
+# --- DNS latency (DNSTracking) ---
+- conversation_group_id: dns_latency
+  tag: dns_latency
+  description: "NetObserv DNS latency — investigate slow DNS using flow metrics or flow logs"
+
+  turns:
+    - turn_id: dns_latency
+      query: >
+        Applications in namespace netobserv-eval-dns-latency report slow DNS lookups over
+        the last hour. Use NetObserv network observability data to investigate DNS latency
+        and identify which workloads or queries are affected.
+      expected_response: >
+        Evidence-based investigation using NetObserv tools (netobserv_get_flow_metrics,
+        netobserv_list_flows): DNS-related flow metrics or flow fields (DnsLatencyMs, DnsName).
+        Identifies namespaces or workloads with elevated latency, cites concrete values from
+        tool output, and mentions DNSTracking or missing data if flows/metrics are unavailable.
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: ./dns_latency/setup.sh
+  cleanup_script: ./dns_latency/cleanup.sh
+
+# --- DNS NXDOMAIN / DNS errors ---
+- conversation_group_id: dns_nxdomain
+  tag: dns_nxdomain
+  description: "NetObserv DNS errors — NXDOMAIN and DNS failure investigation"
+
+  turns:
+    - turn_id: dns_nxdomain
+      query: >
+        Namespace netobserv-eval-dns-nxdomain has DNS resolution failures. Use NetObserv
+        flow metrics and flow logs for the last hour to find NXDOMAIN responses or failing
+        query names. Report what is failing with evidence from tool output.
+      expected_response: >
+        Uses NetObserv flow metrics and/or netobserv_list_flows showing NXDOMAIN responses
+        (DnsFlagsResponseCode, failing DnsName such as does-not-exist-*.netobserv-eval.invalid).
+        Names the target namespace netobserv-eval-dns-nxdomain, cites sample failing query names
+        or counts from tool output, and explains the DNS resolution failure pattern.
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: ./dns_nxdomain/setup.sh
+  cleanup_script: ./dns_nxdomain/cleanup.sh
+
+# --- Kernel packet drops ---
+- conversation_group_id: packet_drops_kernel
+  tag: packet_drops_kernel
+  description: "NetObserv packet drops — kernel-level drops (PacketDropsByKernel)"
+
+  turns:
+    - turn_id: packet_drops_kernel
+      query: >
+        Network traffic in namespace netobserv-eval-drops-kernel shows packet loss. Investigate
+        kernel-level packet drops using NetObserv flow metrics and flow logs. Which nodes or
+        workloads are affected and what drop causes appear?
+      expected_response: >
+        Investigates kernel packet drops with NetObserv tools: flow metrics or netobserv_list_flows
+        with drop fields (PktDrop*, packetLoss=dropped). Identifies nodes, namespaces, or workloads
+        with drops, cites drop causes from flow data when available, and distinguishes kernel drops
+        from policy drops.
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: ./packet_drops_kernel/setup.sh
+  cleanup_script: ./packet_drops_kernel/cleanup.sh
+
+# --- Network policy packet drops ---
+- conversation_group_id: packet_drops_policy
+  tag: packet_drops_policy
+  description: "NetObserv packet drops — network policy denials (NetpolDenied)"
+
+  turns:
+    - turn_id: packet_drops_policy
+      query: >
+        In namespace netobserv-eval-drops-policy, pods cannot reach each other and we suspect
+        NetworkPolicy is blocking traffic. Use NetObserv to find network policy related drops
+        or denials in the last hour.
+      expected_response: >
+        Identifies NetworkPolicy-related denials in netobserv-eval-drops-policy using flow metrics
+        and/or flows with OVS_DROP_EXPLICIT and packetLoss=dropped between policy-frontend and
+        policy-backend. Names the restrictive policy (deny-frontend-to-backend) or src/dst workloads,
+        cites evidence from tool output, and recommends NetworkPolicy review.
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: ./packet_drops_policy/setup.sh
+  cleanup_script: ./packet_drops_policy/cleanup.sh
+
+# --- TLS / HTTPS / ingress connectivity ---
+- conversation_group_id: tls_issues
+  tag: tls_issues
+  description: "NetObserv TLS and ingress errors — HTTPS failures and IPsec issues"
+
+  turns:
+    - turn_id: tls_issues
+      query: >
+        Namespace netobserv-eval-tls has HTTPS and TLS connection problems between workloads
+        over the last hour. Use NetObserv flow metrics and flows to investigate failed
+        connections, TLS errors, or related connectivity issues.
+      expected_response: >
+        Investigates TLS/HTTPS/connectivity using NetObserv tools: flow metrics and/or
+        netobserv_list_flows showing failed connections on TCP:443 or related error patterns.
+        Explains whether the issue appears to be TLS termination, backend unreachable, or
+        misconfiguration based on flow evidence from tool output.
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: ./tls_issues/setup.sh
+  cleanup_script: ./tls_issues/cleanup.sh
+
+# --- Slow TCP RTT ---
+- conversation_group_id: tcp_rtt
+  tag: tcp_rtt
+  description: "NetObserv TCP RTT — high round-trip latency (FlowRTT)"
+
+  turns:
+    - turn_id: tcp_rtt
+      query: >
+        Application teams report slow TCP connections and high network latency between
+        services in namespace netobserv-eval-tcp-rtt. Use NetObserv to analyze TCP round-trip
+        time trends in the last hour.
+      expected_response: >
+        Analyzes TCP RTT using NetObserv flow metrics and/or flows with TimeFlowRttNs or
+        related RTT fields. Identifies namespaces or paths with elevated RTT in
+        netobserv-eval-tcp-rtt, cites numeric evidence from tool output, and notes if FlowRTT
+        data is missing.
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: ./tcp_rtt/setup.sh
+  cleanup_script: ./tcp_rtt/cleanup.sh

--- a/netobserv/packet_drops_kernel/cleanup.sh
+++ b/netobserv/packet_drops_kernel/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/../build/scripts/check_prereqs.sh"
+cleanup_netobserv_fixture "netobserv-eval-drops-kernel"

--- a/netobserv/packet_drops_kernel/fixtures/manifest.yaml
+++ b/netobserv/packet_drops_kernel/fixtures/manifest.yaml
@@ -1,0 +1,117 @@
+# High-rate UDP between pods to encourage kernel-level packet loss (PacketDrop feature).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netobserv-eval-drops-kernel
+  labels:
+    purpose: netobserv-eval
+    netobserv.openshift.io/eval-scenario: drops-kernel
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iperf-server
+  namespace: netobserv-eval-drops-kernel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: iperf-server
+  template:
+    metadata:
+      labels:
+        app: iperf-server
+        netobserv.openshift.io/eval-scenario: drops-kernel
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: iperf
+          image: networkstatic/iperf3:latest@sha256:07dcca91c0e47d82d83d91de8c3d46b840eef4180499456b4fa8d6dadb46b6c8
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
+          args: ["-s"]
+          ports:
+            - containerPort: 5201
+              protocol: UDP
+            - containerPort: 5201
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: iperf-server
+  namespace: netobserv-eval-drops-kernel
+spec:
+  selector:
+    app: iperf-server
+  ports:
+    # iperf3 uses TCP 5201 for session setup even during UDP tests.
+    - name: tcp
+      port: 5201
+      protocol: TCP
+      targetPort: 5201
+    - name: udp
+      port: 5201
+      protocol: UDP
+      targetPort: 5201
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iperf-udp-flood
+  namespace: netobserv-eval-drops-kernel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: iperf-udp-flood
+  template:
+    metadata:
+      labels:
+        app: iperf-udp-flood
+        netobserv.openshift.io/eval-scenario: drops-kernel
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: flood
+          image: networkstatic/iperf3:latest@sha256:07dcca91c0e47d82d83d91de8c3d46b840eef4180499456b4fa8d6dadb46b6c8
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Starting sustained UDP load to iperf-server (may cause kernel drops)"
+              # Brief TCP probe — UDP tests still require the TCP control channel on 5201.
+              for i in $(seq 1 60); do
+                if iperf3 -c iperf-server -p 5201 -t 1 2>&1 | grep -qE 'Connecting to host|connected'; then
+                  echo "iperf-server reachable (attempt ${i})"
+                  break
+                fi
+                echo "waiting for iperf-server TCP control channel (attempt ${i}/60)…"
+                sleep 2
+              done
+              exec iperf3 -c iperf-server -p 5201 -u -b 80M -l 1400 -i 1 -t 86400 --get-server-output
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              memory: 128Mi

--- a/netobserv/packet_drops_kernel/setup.sh
+++ b/netobserv/packet_drops_kernel/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET_NS="netobserv-eval-drops-kernel"
+export TARGET_NS
+export REQUIRED_NETOBSERV_FEATURES="PacketDrop"
+
+source "${SCRIPT_DIR}/../build/scripts/check_prereqs.sh"
+source "${SCRIPT_DIR}/../build/scripts/wait_for.sh"
+
+check_netobserv_prereqs
+deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
+
+wait_for_rollout "${TARGET_NS}" "iperf-server" "180s"
+wait_for_rollout "${TARGET_NS}" "iperf-udp-flood" "180s"
+wait_for_log_pattern "${TARGET_NS}" "app=iperf-udp-flood" 'Connecting to host|Mbits/sec|Lost/Total Datagrams|[0-9]+/[0-9]+ \([0-9.]+%\)' 40 5
+wait_for_netobserv_warmup
+echo "Scenario packet_drops_kernel ready (TARGET_NS=${TARGET_NS})"

--- a/netobserv/packet_drops_policy/cleanup.sh
+++ b/netobserv/packet_drops_policy/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/../build/scripts/check_prereqs.sh"
+cleanup_netobserv_fixture "netobserv-eval-drops-policy"

--- a/netobserv/packet_drops_policy/fixtures/manifest.yaml
+++ b/netobserv/packet_drops_policy/fixtures/manifest.yaml
@@ -1,0 +1,121 @@
+# Frontend cannot reach backend due to restrictive NetworkPolicy (NetworkEvents / NetpolDenied).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netobserv-eval-drops-policy
+  labels:
+    purpose: netobserv-eval
+    netobserv.openshift.io/eval-scenario: drops-policy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-backend
+  namespace: netobserv-eval-drops-policy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: policy-backend
+  template:
+    metadata:
+      labels:
+        app: policy-backend
+        tier: backend
+        netobserv.openshift.io/eval-scenario: drops-policy
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: backend
+          # Image USER 101 — do not set runAsUser (OpenShift SCC rejects UID 101 outside project range).
+          image: nginxinc/nginx-unprivileged:1.27-alpine@sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: policy-backend
+  namespace: netobserv-eval-drops-policy
+spec:
+  selector:
+    app: policy-backend
+  ports:
+    - port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-frontend
+  namespace: netobserv-eval-drops-policy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: policy-frontend
+  template:
+    metadata:
+      labels:
+        app: policy-frontend
+        tier: frontend
+        netobserv.openshift.io/eval-scenario: drops-policy
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: frontend
+          image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              while true; do
+                echo "Probing policy-backend:8080 …"
+                if wget -q -O- -T 3 http://policy-backend:8080/; then
+                  echo "unexpected success"
+                else
+                  echo "ERROR: connection blocked or timed out (expected — NetworkPolicy)"
+                fi
+                sleep 5
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-frontend-to-backend
+  namespace: netobserv-eval-drops-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: policy-backend
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              tier: backend
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/netobserv/packet_drops_policy/setup.sh
+++ b/netobserv/packet_drops_policy/setup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET_NS="netobserv-eval-drops-policy"
+export TARGET_NS
+# OVS_DROP_EXPLICIT in flows needs PacketDrop; NetpolDenied metric needs NetworkEvents.
+export REQUIRED_NETOBSERV_FEATURES="NetworkEvents PacketDrop"
+
+source "${SCRIPT_DIR}/../build/scripts/check_prereqs.sh"
+source "${SCRIPT_DIR}/../build/scripts/wait_for.sh"
+
+check_netobserv_prereqs
+deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
+
+wait_for_rollout "${TARGET_NS}" "policy-backend" "120s"
+wait_for_rollout "${TARGET_NS}" "policy-frontend" "120s"
+# Probe every ~5s — need several blocked attempts before NetObserv/Loki show OVS drops.
+wait_for_min_log_matches "${TARGET_NS}" "app=policy-frontend" "connection blocked|timed out" 5 60 5
+wait_for_netobserv_warmup
+echo "Scenario packet_drops_policy ready (TARGET_NS=${TARGET_NS})"

--- a/netobserv/system.yaml
+++ b/netobserv/system.yaml
@@ -1,0 +1,118 @@
+# LightSpeed Evaluation Framework Configuration — NetObserv Evals
+# OLS backend (api): model sent to OLS /query — must match cluster OLSConfig.
+# Judge (llm): OpenAI scores responses.
+#
+# api_base: OLS /query endpoint (HTTPS). Makefile overrides via OLS_URL.
+# Operator pod listens on container port 8443 (scheme HTTPS), not 8080.
+# Route: make -s ols-route-url  |  Port-forward: make ols-port-forward
+
+core:
+  max_threads: 5
+
+llm:
+  provider: "openai"
+  model: "gpt-4o-mini"
+  temperature: 0.0
+  max_tokens: 5000
+  timeout: 300
+  num_retries: 3
+  cache_enabled: false
+
+api:
+  enabled: true
+  api_base: https://localhost:8443
+  endpoint_type: query
+  timeout: 600
+  # Must match llm_providers[].name in cluster OLSConfig (e.g. openai).
+  provider: "openai"
+  model: "gpt-4o-mini"
+  no_tools: null
+  system_prompt: null
+  cache_enabled: false
+  extra_request_params:
+    mode: troubleshooting
+
+embedding:
+  cache_enabled: false
+
+metrics_metadata:
+  turn_level:
+    "custom:answer_correctness":
+      description: "Correctness vs expected answer using custom LLM evaluation"
+      default: false
+
+    "geval:generic_troubleshooting_experience":
+      description: "Evidence-based NetObserv investigation using real cluster data from tools"
+      criteria: |
+        The agent is investigating a network observability problem with NetObserv tools from
+        kubernetes-mcp-server (netobserv_list_flows, netobserv_get_flow_metrics). Evaluate:
+          - The response must use real data from tool calls (flow metrics, flow logs), not generic advice
+          - Evidence should reference NetObserv-specific signals (flow fields, namespaces, workloads)
+          - Generic Kubernetes troubleshooting without NetObserv data must be penalized
+          - If data is missing, the agent should state that clearly and mention required FlowCollector features
+      evaluation_params:
+        - query
+        - response
+        - contexts
+      evaluation_steps:
+        - "Step 1: Check if the response cites real NetObserv tool output (flow metrics, flow logs) or only generic suggestions."
+        - "Step 2: Check if the analysis addresses the network observability symptom in the query."
+        - "Step 3: Check if namespaces, workloads, or metric/log values from the cluster are named in the response."
+        - "Step 4: If data is absent, check whether the agent explains missing NetObserv features or export config."
+
+  conversation_level:
+    "deepeval:conversation_completeness":
+      default: false
+
+    "deepeval:conversation_relevancy":
+      default: false
+
+    "deepeval:knowledge_retention":
+      default: false
+
+output:
+  output_dir: "./eval_output"
+  base_filename: "evaluation"
+  enabled_outputs:
+    - csv
+    - json
+  csv_columns:
+    - "conversation_group_id"
+    - "turn_id"
+    - "metric_identifier"
+    - "score"
+    - "threshold"
+    - "result"
+    - "reason"
+    - "query"
+    - "response"
+    - "execution_time"
+
+visualization:
+  figsize: [12, 8]
+  dpi: 300
+  enabled_graphs:
+    - "score_distribution"
+    - "status_breakdown"
+
+environment:
+  DEEPEVAL_TELEMETRY_OPT_OUT: "YES"
+  DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"
+  # DeepEval tries to upload GEval scores to Confident AI unless disabled (needs CONFIDENT_API_KEY).
+  CONFIDENT_METRIC_LOGGING_ENABLED: "0"
+  CONFIDENT_METRIC_LOGGING_VERBOSE: "0"
+  LITELLM_LOG: ERROR
+
+logging:
+  source_level: INFO
+  package_level: ERROR
+  log_format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+  show_timestamps: true
+  package_overrides:
+    httpx: ERROR
+    urllib3: ERROR
+    requests: ERROR
+    matplotlib: ERROR
+    LiteLLM: WARNING
+    DeepEval: WARNING
+    ragas: WARNING

--- a/netobserv/tcp_rtt/cleanup.sh
+++ b/netobserv/tcp_rtt/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/../build/scripts/check_prereqs.sh"
+cleanup_netobserv_fixture "netobserv-eval-tcp-rtt"

--- a/netobserv/tcp_rtt/fixtures/manifest.yaml
+++ b/netobserv/tcp_rtt/fixtures/manifest.yaml
@@ -1,0 +1,121 @@
+# HTTP server with artificial delay on responses (FlowRTT); client polls continuously.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netobserv-eval-tcp-rtt
+  labels:
+    purpose: netobserv-eval
+    netobserv.openshift.io/eval-scenario: tcp-rtt
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slow-http-server
+  namespace: netobserv-eval-tcp-rtt
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: slow-http-server
+  template:
+    metadata:
+      labels:
+        app: slow-http-server
+        netobserv.openshift.io/eval-scenario: tcp-rtt
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: server
+          image: python:3.12-alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              cat >/tmp/server.py <<'PY'
+              import time
+              from http.server import BaseHTTPRequestHandler, HTTPServer
+              class H(BaseHTTPRequestHandler):
+                  def do_GET(self):
+                      time.sleep(0.35)
+                      self.send_response(200)
+                      self.end_headers()
+                      self.wfile.write(b"slow\n")
+                  def log_message(self, *a): pass
+              HTTPServer(("0.0.0.0", 8080), H).serve_forever()
+              PY
+              exec python /tmp/server.py
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: slow-http-server
+  namespace: netobserv-eval-tcp-rtt
+spec:
+  selector:
+    app: slow-http-server
+  ports:
+    - port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rtt-client
+  namespace: netobserv-eval-tcp-rtt
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rtt-client
+  template:
+    metadata:
+      labels:
+        app: rtt-client
+        netobserv.openshift.io/eval-scenario: tcp-rtt
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: client
+          image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              while true; do
+                start=$(date +%s)
+                if wget -q -O- -T 10 http://slow-http-server:8080/; then
+                  end=$(date +%s)
+                  echo "OK round-trip $((end - start))s (expect elevated RTT)"
+                else
+                  echo "ERROR: request failed"
+                fi
+                sleep 3
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi

--- a/netobserv/tcp_rtt/setup.sh
+++ b/netobserv/tcp_rtt/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET_NS="netobserv-eval-tcp-rtt"
+export TARGET_NS
+export REQUIRED_NETOBSERV_FEATURES="FlowRTT"
+
+source "${SCRIPT_DIR}/../build/scripts/check_prereqs.sh"
+source "${SCRIPT_DIR}/../build/scripts/wait_for.sh"
+
+check_netobserv_prereqs
+deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
+
+wait_for_rollout "${TARGET_NS}" "slow-http-server" "120s"
+wait_for_rollout "${TARGET_NS}" "rtt-client" "120s"
+wait_for_log_pattern "${TARGET_NS}" "app=rtt-client" "OK round-trip|elevated RTT" 40 3
+wait_for_netobserv_warmup
+echo "Scenario tcp_rtt ready (TARGET_NS=${TARGET_NS})"

--- a/netobserv/tls_issues/cleanup.sh
+++ b/netobserv/tls_issues/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/../build/scripts/check_prereqs.sh"
+cleanup_netobserv_fixture "netobserv-eval-tls"

--- a/netobserv/tls_issues/fixtures/manifest.yaml
+++ b/netobserv/tls_issues/fixtures/manifest.yaml
@@ -1,0 +1,143 @@
+# TLS server with self-signed cert; client performs HTTPS handshakes (TLS/connection errors on mismatch).
+# tls-server-cert Secret is created by setup.sh (openssl) — not stored in git.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netobserv-eval-tls
+  labels:
+    purpose: netobserv-eval
+    netobserv.openshift.io/eval-scenario: tls
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tls-nginx-config
+  namespace: netobserv-eval-tls
+data:
+  nginx.conf: |
+    # Required for nginx-unprivileged on OpenShift (non-root cannot write /run/nginx.pid).
+    pid /tmp/nginx.pid;
+    worker_processes 1;
+    error_log /dev/stderr warn;
+    events { worker_connections 1024; }
+    http {
+      access_log /dev/stdout;
+      server {
+        listen 8443 ssl;
+        ssl_certificate     /etc/tls/tls.crt;
+        ssl_certificate_key /etc/tls/tls.key;
+        location / { return 200 "ok\n"; }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tls-server
+  namespace: netobserv-eval-tls
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tls-server
+  template:
+    metadata:
+      labels:
+        app: tls-server
+        netobserv.openshift.io/eval-scenario: tls
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: nginx
+          # Image USER 101 — do not set runAsUser (OpenShift SCC rejects UID 101 outside project range).
+          image: nginxinc/nginx-unprivileged:1.27-alpine@sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0
+          ports:
+            - containerPort: 8443
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/tls
+              readOnly: true
+            - name: config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: tls
+          secret:
+            secretName: tls-server-cert
+        - name: config
+          configMap:
+            name: tls-nginx-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tls-server
+  namespace: netobserv-eval-tls
+spec:
+  selector:
+    app: tls-server
+  ports:
+    - name: https
+      port: 8443
+      targetPort: 8443
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tls-client
+  namespace: netobserv-eval-tls
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tls-client
+  template:
+    metadata:
+      labels:
+        app: tls-client
+        netobserv.openshift.io/eval-scenario: tls
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: client
+          image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              while true; do
+                echo "Probing HTTPS (expect TLS/certificate errors)…"
+                if wget -q -O- -T 5 "https://tls-server:8443/" 2>&1; then
+                  echo "unexpected HTTPS success"
+                else
+                  echo "ERROR: TLS/certificate verification failed (expected — self-signed cert)"
+                fi
+                echo "Probing plain HTTP on TLS port (expect protocol mismatch)…"
+                if wget -q -O- -T 5 "http://tls-server:8443/" 2>&1; then
+                  echo "unexpected HTTP success"
+                else
+                  echo "ERROR: protocol mismatch on TLS port (expected)"
+                fi
+                sleep 8
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 128Mi

--- a/netobserv/tls_issues/setup.sh
+++ b/netobserv/tls_issues/setup.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET_NS="netobserv-eval-tls"
+TLS_SECRET_NAME="tls-server-cert"
+TLS_CN="tls-server.netobserv-eval-tls.svc.cluster.local"
+export TARGET_NS
+
+source "${SCRIPT_DIR}/../build/scripts/check_prereqs.sh"
+source "${SCRIPT_DIR}/../build/scripts/wait_for.sh"
+
+check_netobserv_prereqs
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "ERROR: openssl is required to generate the eval TLS certificate"
+  exit 1
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
+  -keyout "${TMPDIR}/tls.key" -out "${TMPDIR}/tls.crt" \
+  -subj "/CN=${TLS_CN}" 2>/dev/null
+
+oc create secret tls "${TLS_SECRET_NAME}" \
+  --cert="${TMPDIR}/tls.crt" --key="${TMPDIR}/tls.key" \
+  -n "${TARGET_NS}" --dry-run=client -o yaml > "${TMPDIR}/secret.yaml"
+
+if [[ "${NETOBSERV_EVAL_RECREATE_NS:-true}" == "true" ]] && oc get namespace "${TARGET_NS}" >/dev/null 2>&1; then
+  echo "Recreating eval namespace ${TARGET_NS} for a clean fixture deploy…"
+  oc delete namespace "${TARGET_NS}" --ignore-not-found --wait=false
+  wait_for_namespace_gone "${TARGET_NS}" || true
+fi
+
+oc apply -f "${SCRIPT_DIR}/fixtures/manifest.yaml" -f "${TMPDIR}/secret.yaml"
+
+for attempt in $(seq 1 15); do
+  if openshift_namespace_uid_min "${TARGET_NS}" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+patch_openshift_deployments "${TARGET_NS}"
+echo "Deployed fixture in namespace ${TARGET_NS}"
+
+if ! wait_for_rollout "${TARGET_NS}" "tls-server" "180s"; then
+  echo "tls-server rollout failed — pod status:"
+  oc get pods -n "${TARGET_NS}" -l app=tls-server
+  oc logs -n "${TARGET_NS}" -l app=tls-server -c nginx --tail=30 2>/dev/null || true
+  oc describe pod -n "${TARGET_NS}" -l app=tls-server | tail -40
+  exit 1
+fi
+wait_for_rollout "${TARGET_NS}" "tls-client" "120s"
+wait_for_log_pattern "${TARGET_NS}" "app=tls-client" "TLS/certificate|protocol mismatch|certificate|SSL|ERROR|failed|unable|refused" 40 3
+wait_for_netobserv_warmup
+echo "Scenario tls_issues ready (TARGET_NS=${TARGET_NS})"


### PR DESCRIPTION
## Summary

Adds a **netobserv/** eval suite (same pattern as `kiali-ossm/`) for network observability troubleshooting with OpenShift Lightspeed and the NetObserv MCP toolset.

https://github.com/containers/kubernetes-mcp-server/pull/1159

## What's new

**Six scenarios** — each with setup/cleanup scripts, fixtures, and `evals.yaml` entries:

- `dns_latency`, `dns_nxdomain`
- `packet_drops_kernel`, `packet_drops_policy`
- `tls_issues`, `tcp_rtt`

**NetObserv-specific setup**

- `netobserv/build/flowcollector.yaml` — eval `FlowCollector` (sampling 1, privileged agent, required eBPF features, network policy allows `openshift-mcp`)
- `netobserv/build/README.md` — operator install + FlowCollector (not `deploy-sample-cr`)

**Makefile**

- Optional `setup-kubernetes-mcp` + `KUBERNETES_MCP_IMAGE` to test upstream PRs before the toolset lands in openshift-mcp-server
- OLS eval helpers in `netobserv/Makefile` (`ols-port-forward`, `ols-route-url` — operator API is HTTPS **8443**)

---

## Testings

From [netobserv operator](https://github.com/netobserv/netobserv-operator) repo:
```
USER=netobserv make deploy deploy-loki
```

From this repo:
```
make setup-ols-evaluation

KUBERNETES_MCP_IMAGE=quay.io/jpinsonn/kubernetes-mcp-server:dev TOOLSETS_ADDITIONAL=netobserv make setup-kubernetes-mcp
make connect-ols-kubernetes-mcp

cd netobserv
make deploy-flowcollector
make ols-port-forward
```

From another terminal in `netobserv` folder in this repo:
```
make test
```

## Results

**6/6 PASS** · mean score **0.65** · total agent time **~117s** · total run time **~144s**

| Scenario | Namespace | Result | Score | Agent latency (s) | Total time (s) |
|----------|-----------|--------|-------|-----------|-----------|
| `dns_latency` | `netobserv-eval-dns-latency` | PASS | 0.6 | 9.4 | 12.5 |
| `dns_nxdomain` | `netobserv-eval-dns-nxdomain` | PASS | 0.5 | 43.6 | 48.7 |
| `packet_drops_kernel` | `netobserv-eval-drops-kernel` | PASS | 0.8 | 22.7 | 26.3 |
| `packet_drops_policy` | `netobserv-eval-drops-policy` | PASS | 0.6 | 16.8 | 19.9 |
| `tcp_rtt` | `netobserv-eval-tcp-rtt` | PASS | 0.6 | 6.4 | 10.7 |
| `tls_issues` | `netobserv-eval-tls` | PASS | 0.8 | 22.1 | 25.9 |

Judge: `custom:answer_correctness` (gpt-4o-mini) · OLS: `https://localhost:8443` · mode: `troubleshooting`