### PR TITLE
feat(kiali): Read only mode

### DIFF
--- a/kiali-ossm/Makefile
+++ b/kiali-ossm/Makefile
@@ -5,8 +5,8 @@ SCENARIOS = check_mesh_status \
             check_istio_objects_status \
             check_bookinfo_services \
             check_latency_bookinfo_issue \
-            fix_bookinfo_routing \
-            fix_bookinfo_fault_injection \
+            diagnose_bookinfo_routing \
+            diagnose_bookinfo_fault_injection \
             troubleshoot_latency_trace
 
 # Cluster platform

--- a/kiali-ossm/README.md
+++ b/kiali-ossm/README.md
@@ -40,7 +40,7 @@ make check_istio_objects_status-eval
 
 ### `diagnose_bookinfo_routing`
 
-`reviews-v3` has weight 0 in the `reviews` VirtualService, so the product page never shows red stars. The agent must identify the zero-weight subset and patch the VirtualService.
+`reviews-v3` has weight 0 in the `reviews` VirtualService, so the product page never shows red stars. The agent should identify the zero-weight subset and describe the likely routing correction.
 
 ```bash
 make diagnose_bookinfo_routing-eval
@@ -48,7 +48,7 @@ make diagnose_bookinfo_routing-eval
 
 ### `diagnose_bookinfo_fault_injection`
 
-A 100% fault-injection abort (HTTP 503) on the `ratings` VirtualService. The agent must find the abort rule and offer to remove it.
+A 100% fault-injection abort (HTTP 503) on the `ratings` VirtualService. The agent should identify the abort rule as the root cause and explain what would restore normal service.
 
 ```bash
 make diagnose_bookinfo_fault_injection-eval

--- a/kiali-ossm/README.md
+++ b/kiali-ossm/README.md
@@ -38,20 +38,20 @@ A misconfigured `VirtualService` (`reviews-bad-config`) is deployed with four Ki
 make check_istio_objects_status-eval
 ```
 
-### `fix_bookinfo_routing`
+### `diagnose_bookinfo_routing`
 
 `reviews-v3` has weight 0 in the `reviews` VirtualService, so the product page never shows red stars. The agent must identify the zero-weight subset and patch the VirtualService.
 
 ```bash
-make fix_bookinfo_routing-eval
+make diagnose_bookinfo_routing-eval
 ```
 
-### `fix_bookinfo_fault_injection`
+### `diagnose_bookinfo_fault_injection`
 
 A 100% fault-injection abort (HTTP 503) on the `ratings` VirtualService. The agent must find the abort rule and offer to remove it.
 
 ```bash
-make fix_bookinfo_fault_injection-eval
+make diagnose_bookinfo_fault_injection-eval
 ```
 
 ### `troubleshoot_latency_trace`

--- a/kiali-ossm/evals.yaml
+++ b/kiali-ossm/evals.yaml
@@ -88,10 +88,8 @@
         the reviews VirtualService routes 0% of traffic to subset v3 (weight: 0),
         meaning reviews-v3 — the version that renders red stars — never receives
         requests. All workload pods should be confirmed as running and healthy. The
-        agent should explain that fixing the issue requires patching the reviews
-        VirtualService to assign a non-zero weight to v3 (either 100% to v3 or
-        distributing across v1/v2/v3), and that doing so would allow the product
-        page to show red stars.
+        agent may note that assigning a non-zero weight to v3 (either 100% to v3 or
+        distributing across v1/v2/v3) would allow the product page to show red stars.
       turn_metrics:
         - custom:answer_correctness
 
@@ -119,9 +117,8 @@
         for ratings is correctly defined and not contributing to the issue. It should
         identify the 100% fault injection abort as the root cause of the 503 errors
         seen on the product page, and may note this is typically used for chaos or
-        resilience testing. The agent should explain that the fix would involve
-        removing the abort block or setting its percentage to 0 to restore normal
-        service, and may provide the corrected VirtualService spec as a reference.
+        resilience testing. The agent may note that removing the abort block or
+        setting its percentage to 0 would restore normal service.
       turn_metrics:
         - custom:answer_correctness
 

--- a/kiali-ossm/evals.yaml
+++ b/kiali-ossm/evals.yaml
@@ -73,8 +73,9 @@
   setup_script: ./invalid_istio_object/setup.sh
   cleanup_script: ./invalid_istio_object/cleanup.sh
 
-# ── fix_bookinfo_routing ──────────────────────────────────────────────────────
-- conversation_group_id: fix_bookinfo_routing
+# ── diagnose_bookinfo_routing ─────────────────────────────────────────────────
+- conversation_group_id: diagnose_bookinfo_routing
+  tag: diagnose_bookinfo_routing
   description: "reviews-v3 has weight 0 so never gets traffic. Agent investigates and identifies the routing issue."
 
   turns:
@@ -97,9 +98,9 @@
   setup_script: ./fix_bookinfo_routing/setup.sh
   cleanup_script: ./fix_bookinfo_routing/cleanup.sh
 
-# ── fix_bookinfo_fault_injection ──────────────────────────────────────────────
-- conversation_group_id: fix_bookinfo_fault_injection
-  tag: fault_injection_bookinfo
+# ── diagnose_bookinfo_fault_injection ────────────────────────────────────────
+- conversation_group_id: diagnose_bookinfo_fault_injection
+  tag: diagnose_bookinfo_fault_injection
   description: "A 100% fault injection on ratings causes 503 errors. Agent investigates and identifies the root cause."
 
   turns:

--- a/kiali-ossm/evals.yaml
+++ b/kiali-ossm/evals.yaml
@@ -75,37 +75,35 @@
 
 # ── fix_bookinfo_routing ──────────────────────────────────────────────────────
 - conversation_group_id: fix_bookinfo_routing
-  tag: fix_bookinfo_routing
-  description: 'Multi-turn: reviews-v3 has weight 0 so never gets traffic. Agent
-    investigates, identifies the routing issue, and fixes weights.'
+  description: "reviews-v3 has weight 0 so never gets traffic. Agent investigates and identifies the routing issue."
+
   turns:
     - turn_id: investigate
       query: >
-        In our Bookinfo app, the product page only ever shows black or no stars.It
-        never shows red stars.  All Istio resources and services are deployed in
-        the 'bookinfo' namespace. Can you investigate and fix it?
+        In our Bookinfo app, the product page only ever shows black or no stars. It never shows red stars. All Istio resources and services are deployed in the 'bookinfo' namespace. Can you investigate what is causing the issue?
       expected_response: >
         The agent should inspect workloads, the reviews VirtualService, and the
         reviews DestinationRule in the bookinfo namespace. It should identify that
         the reviews VirtualService routes 0% of traffic to subset v3 (weight: 0),
         meaning reviews-v3 — the version that renders red stars — never receives
-        requests. All workload pods should be confirmed as running and healthy.
-        The
-        agent should apply a fix by patching the reviews VirtualService to send
-        traffic to v3 (either 100% to v3 or distributing across v1/v2/v3), confirm
-        the patch by reporting the updated spec, and explain that the product page
-        should now show red stars.
-      turn_metrics: [custom:answer_correctness]
+        requests. All workload pods should be confirmed as running and healthy. The
+        agent should explain that fixing the issue requires patching the reviews
+        VirtualService to assign a non-zero weight to v3 (either 100% to v3 or
+        distributing across v1/v2/v3), and that doing so would allow the product
+        page to show red stars.
+      turn_metrics:
+        - custom:answer_correctness
+
   setup_script: ./fix_bookinfo_routing/setup.sh
   cleanup_script: ./fix_bookinfo_routing/cleanup.sh
 
 # ── fix_bookinfo_fault_injection ──────────────────────────────────────────────
 - conversation_group_id: fix_bookinfo_fault_injection
-  tag: fix_bookinfo_fault_injection
-  description: "Multi-turn: a 100% fault injection on ratings causes 503 errors. Agent investigates, identifies root cause, and fixes it."
+  tag: fault_injection_bookinfo
+  description: "A 100% fault injection on ratings causes 503 errors. Agent investigates and identifies the root cause."
 
   turns:
-    - turn_id: investigate_and_fix
+    - turn_id: investigate
       query: >
         Some users are seeing errors on the Bookinfo product page — it looks like
         the ratings service is broken. All pods are running and mTLS / auth policies
@@ -119,23 +117,23 @@
         all traffic with no match conditions. It should confirm the DestinationRule
         for ratings is correctly defined and not contributing to the issue. It should
         identify the 100% fault injection abort as the root cause of the 503 errors
-        seen on the product page, and may note this is typically used for chaos
-        or
-        resilience testing. The agent should offer to remove the fault injection
-        rule
-        (e.g. by deleting the abort block or setting percentage to 0) to restore
-        normal service, and may provide the corrected VirtualService spec.
-      turn_metrics: [custom:answer_correctness]
+        seen on the product page, and may note this is typically used for chaos or
+        resilience testing. The agent should explain that the fix would involve
+        removing the abort block or setting its percentage to 0 to restore normal
+        service, and may provide the corrected VirtualService spec as a reference.
+      turn_metrics:
+        - custom:answer_correctness
+
   setup_script: ./fix_bookinfo_fault_injection/setup.sh
   cleanup_script: ./fix_bookinfo_fault_injection/cleanup.sh
 
 # ── troubleshoot_latency_trace ────────────────────────────────────────────────
 - conversation_group_id: troubleshoot_latency_trace
   tag: troubleshoot_latency_trace
-  description: A 3-second delay fault is injected on the ratings service. The agent
-    must identify the latency root cause using traces and fix the delay.
+  description: "A 3-second delay fault is injected on the ratings service. The agent must identify the latency root cause using traces."
+
   turns:
-    - turn_id: investigate_and_fix
+    - turn_id: investigate
       query: >
         The Bookinfo product page is loading very slow — requests to the page
         are taking several seconds. All pods are running fine. Can you investigate
@@ -155,10 +153,12 @@
         making all upstream services (reviews, productpage) appear slow.
         The agent should name ratings as the responsible service, cite the relevant
         VirtualService spec (fault.delay.fixedDelay: 3s, percentage.value: 100),
-        explain that this pattern is typical of intentional chaos/resilience testing,
-        and offer to remove the fault injection block from the ratings VirtualService
-        to restore normal page load times.
-      turn_metrics: [custom:answer_correctness]
+        and explain that this pattern is typical of intentional chaos/resilience testing.
+        The agent should note that removing the fault injection block from the ratings
+        VirtualService would restore normal page load times.
+      turn_metrics:
+        - custom:answer_correctness
+
   setup_script: ./troubleshoot_latency_trace/setup.sh
   cleanup_script: ./troubleshoot_latency_trace/cleanup.sh
 

--- a/kiali-ossm/system.yaml
+++ b/kiali-ossm/system.yaml
@@ -9,26 +9,33 @@
 # Limits concurrent evaluations to avoid OpenAI API rate limiting.
 core:
   max_threads: 5
-# Judge LLM — scores OLS responses against expected answers
-llm:
-  provider: openai
-  model: gpt-5.4-mini  # gpt-5-mini does not produce valid JSON for DeepEval metrics
-  temperature: 0.0
-  max_tokens: 5000
-  timeout: 300
-  num_retries: 3
   cache_enabled: true
-# OLS API — the system under test (model must match OLSConfig, e.g. openai_lseval uses gpt-4o-mini)
+# Judge LLM pool — scores OLS responses against expected answers
+llm_pool:
+  defaults:
+    timeout: 300
+    num_retries: 3
+  models:
+    judge:
+      provider: openai
+      model: gpt-5.4-mini  # gpt-5-mini does not produce valid JSON for DeepEval metrics
+      parameters:
+        temperature: 0.0
+        max_completion_tokens: 5000
+# Judge panel — selects which model(s) from llm_pool act as judge
+judge_panel:
+  judges:
+    - judge
+# OLS API — the system under test (must match OLSConfig defaultProvider/defaultModel)
 api:
   enabled: true
   api_base: http://0.0.0.0:8080
   endpoint_type: query
   timeout: 300
-  provider: openai
-  model: gpt-5  # must match olsconfig-openai.yaml default_model
+  provider: openAICompatible
+  model: gemini-2.5-flash
   no_tools:
   system_prompt:
-  cache_enabled: false
   extra_request_params:
     mode: troubleshooting
 # Metrics evaluated per conversation turn
@@ -77,24 +84,25 @@ metrics_metadata:
         - score_range: [8, 10]
           expected_outcome: Perfect continuity. References specific historical data
             to provide a conclusive fix.
-# Output Configuration
-output:
-  output_dir: ./eval_output
-  base_filename: evaluation
-  enabled_outputs: [csv, json]
-  csv_columns:
-    - conversation_group_id
-    - turn_id
-    - metric_identifier
-    - score
-    - threshold
-    - result
-    - reason
-    - query
-    - response
-    - tool_calls
-    - expected_tool_calls
-    - execution_time
+# Storage Configuration
+storage:
+  - type: file
+    output_dir: ./eval_output
+    base_filename: evaluation
+    enabled_outputs: [csv, json]
+    csv_columns:
+      - conversation_group_id
+      - turn_id
+      - metric_identifier
+      - score
+      - threshold
+      - result
+      - reason
+      - query
+      - response
+      - tool_calls
+      - expected_tool_calls
+      - execution_time
 # Visualization settings
 visualization:
   figsize: [12, 8]

--- a/kiali-ossm/system.yaml
+++ b/kiali-ossm/system.yaml
@@ -32,8 +32,8 @@ api:
   api_base: http://0.0.0.0:8080
   endpoint_type: query
   timeout: 300
-  provider: openAICompatible
-  model: gemini-2.5-flash
+  provider: openai
+  model: gpt-5  # must match olsconfig-openai.yaml default_model
   no_tools:
   system_prompt:
   extra_request_params:


### PR DESCRIPTION
At the moment, there is no support for write mode, so, a couple of changes have been done: 
- Remove `read_only_mode: false` from the configuration. 
- Adapt the test scenarios so no fix is expected. 

Remove DEPRECATION warnings: 
```
🚀 LightSpeed Evaluation Framework
==================================================
🔧 Loading Configuration & Setting up environment...
DEPRECATION: 'output' configuration is deprecated. Please migrate to 'storage' format. See docs/configuration.md for the new format.
DEPRECATION: Component-level caching is deprecated. Please use 'core.cache_enabled' and 'core.cache_base_dir' instead.
DEPRECATION: 'llm' configuration is deprecated. Please migrate to 'llm_pool' format.
```
