### PR TITLE
kubevirt: add VM troubleshooting scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 **/_output/
 **/.caches/
 venv/
+
+# Secrets / credentials — never commit API keys
+.env
+*.env
+credentials.yaml
+secrets/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ##@ Linting
 
-LINT_DIRS ?= generic kiali-ossm netobserv
+LINT_DIRS ?= generic kiali-ossm kubevirt netobserv
 
 .PHONY: lint lint-shell lint-yaml
 
@@ -43,6 +43,7 @@ help: ## Show available targets
 	@echo ""
 	@echo "  Per-team workflow (run from team directory):"
 	@echo "    cd kiali-ossm && make setup && make evals && make cleanup"
+	@echo "    cd kubevirt   && make setup && make evals && make cleanup"
 	@echo "    cd netobserv  && make setup && make evals && make cleanup"
 	@echo ""
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) to add a new eval suite.
 |-------|-------------|
 | [kiali-ossm/](kiali-ossm/) | Service-mesh troubleshooting using Kiali/OSSM MCP tools |
 | [netobserv/](netobserv/) | Network observability using the NetObserv MCP toolset |
+| [kubevirt/](kubevirt/) | OpenShift Virtualization troubleshooting using the KubeVirt MCP toolset |
 | [generic/](generic/) | Standalone fault-injection scenarios (not using the eval framework) |
 
 ## Requirements

--- a/kubevirt/Makefile
+++ b/kubevirt/Makefile
@@ -1,0 +1,68 @@
+# kubevirt evaluation scenarios
+
+# Scenarios (must match tag: values in evals.yaml)
+SCENARIOS = vm_storage_failure vm_crashloop vm_migration_failure
+KVM_SCENARIOS = vm_crashloop vm_migration_failure
+
+# MCP config — kubevirt toolset needed for VM diagnostics
+MCP_TOOLSETS = core,config,kubevirt
+
+# KVM-aware evals: skip scenarios that require KVM when no devices are available
+.PHONY: evals
+evals:
+	@if bash build/require-kvm.sh --check 2>/dev/null; then \
+	  tags="$(foreach s,$(SCENARIOS),--tag $(s))"; \
+	else \
+	  echo "WARNING: No KVM devices on worker nodes. Skipping: $(KVM_SCENARIOS)"; \
+	  tags="$(foreach s,$(filter-out $(KVM_SCENARIOS),$(SCENARIOS)),--tag $(s))"; \
+	fi; \
+	if [ -z "$$tags" ]; then echo "No scenarios to evaluate."; exit 0; fi; \
+	bash $(SCRIPTS_DIR)/run-evals.sh \
+	  --system-config $(SYSTEM_CONFIG) --evals $(EVALS) \
+	  --results-dir $(RESULTS_DIR) --ols-url $(OLS_URL) \
+	  $$tags
+
+# Shared infrastructure (included after evals override to avoid recipe conflict)
+include ../scripts/eval.mk
+
+# Install CNV operator (idempotent — skips if already present)
+.PHONY: install-cnv
+install-cnv:
+	@bash build/install-cnv.sh
+
+# Setup: shared infra + install/verify OpenShift Virtualization + deploy broken VMs
+.PHONY: setup
+setup: _setup-shared install-cnv
+	@bash build/check-cnv.sh
+	@$(MAKE) setup-scenarios
+
+# Cleanup: remove broken VMs + CNV operator + shared infra
+.PHONY: cleanup
+cleanup:
+	@$(MAKE) cleanup-scenarios
+	@bash build/uninstall-cnv.sh
+	$(MAKE) _cleanup-shared
+
+# Deploy all broken VM scenarios (stops on first failure)
+.PHONY: setup-scenarios
+setup-scenarios:
+	@for s in $(SCENARIOS); do \
+	  echo "==> Setting up $$s"; \
+	  bash ./$$s/setup.sh || exit 1; \
+	done
+
+# Remove all scenario resources (reports failures but cleans all scenarios)
+.PHONY: cleanup-scenarios
+cleanup-scenarios:
+	@failed=""; \
+	for s in $(SCENARIOS); do \
+	  echo "==> Cleaning up $$s"; \
+	  if ! bash ./$$s/cleanup.sh 2>&1; then \
+	    failed="$$failed $$s"; \
+	    echo "    WARNING: cleanup of $$s returned an error"; \
+	  fi; \
+	done; \
+	if [ -n "$$failed" ]; then \
+	  echo "WARNING: cleanup errors in:$$failed"; \
+	  exit 1; \
+	fi

--- a/kubevirt/README.md
+++ b/kubevirt/README.md
@@ -1,0 +1,92 @@
+# KubeVirt Troubleshooting Scenarios
+
+Evaluation scenarios that test AI-assisted diagnosis of OpenShift Virtualization (KubeVirt) problems using the `kubevirt` MCP toolset and OpenShift Lightspeed.
+
+## Prerequisites
+
+- OpenShift 4.16+ cluster
+- `oc` CLI authenticated with cluster-admin
+- `OPENAI_API_KEY` exported (used for OLS credentials and the judge LLM)
+- Python 3.11, 3.12, or 3.13
+
+## KVM Requirements
+
+OpenShift Virtualization requires KVM (Kernel-based Virtual Machine) to run VMs. On bare-metal clusters, KVM is natively available. On cloud environments like AWS, only metal instance types (e.g. `m5.metal`, `c5.metal`, `m6i.metal`) expose the `/dev/kvm` device needed for hardware virtualization.
+
+When no KVM devices are detected on worker nodes, `make setup` automatically enables QEMU software emulation by setting `KVM_EMULATION=true` on the CNV operator Subscription. This allows all scenarios to run without hardware KVM, but VMs will be significantly slower. **Software emulation is not supported by Red Hat and should only be used in test/dev environments.**
+
+Scenarios that require a running VM (`vm_crashloop`, `vm_migration_failure`) are skipped if neither KVM devices nor emulation are available. The `vm_storage_failure` scenario always runs since the VM never reaches the scheduling phase.
+
+## Scenarios
+
+| Scenario | VM | Fault | Signal |
+|----------|-----|-------|--------|
+| [vm_storage_failure](vm_storage_failure/) | `production-db-vm` | Non-existent StorageClass `premium-nvme-storage` | VM stuck in `Provisioning`, DV has no phase |
+| [vm_crashloop](vm_crashloop/) | `web-server-vm` | cloud-init `runcmd: shutdown -h now` | VM repeatedly starts and stops (~35s cycle) |
+| [vm_migration_failure](vm_migration_failure/) | `critical-app-vm` | `nodeSelector` pins VM to one node | Live migration fails (no valid target) |
+
+All VMs use the modern instancetype-based format (matching the console "Custom configuration" default):
+- `spec.instancetype.name: u1.small`
+- `spec.preference.name: fedora`
+- `containerDisk` for boot (crashloop and migration scenarios) to avoid storage quota issues
+
+## Quick Start
+
+```bash
+export OPENAI_API_KEY=<your-key>
+
+cd kubevirt
+make setup    # install venv + OLS + MCP (with kubevirt toolset) + deploy broken VMs
+make evals    # run all scenarios
+make cleanup  # remove broken VMs + CNV operator + MCP server
+```
+
+Run a single scenario:
+
+```bash
+make vm_storage_failure-eval
+make vm_crashloop-eval
+make vm_migration_failure-eval
+```
+
+### What `make setup` does
+
+1. Creates a Python venv with `lightspeed-eval` (skips if exists)
+2. Checks cluster access and OLS readiness
+3. Installs the OLS operator if not present (idempotent)
+4. Deploys the MCP server with `core,config,kubevirt` toolsets
+5. Connects OLS to the MCP server
+6. Installs OpenShift Virtualization if not present (idempotent), enables software emulation if no KVM devices are available
+7. Deploys all broken VM scenarios
+
+### Manual scenario management
+
+```bash
+# Deploy only scenario VMs (without shared infra)
+make setup-scenarios
+
+# Clean only scenario VMs
+make cleanup-scenarios
+```
+
+> **Note**: The migration failure scenario automatically triggers a `VirtualMachineInstanceMigration` during setup. No manual `virtctl migrate` step is needed.
+
+## Troubleshooting Prompts
+
+Sample questions to ask OpenShift Lightspeed (or any MCP-connected AI):
+
+1. **Storage failure**: "Why is VM production-db-vm not starting in namespace kubevirt-scenarios?"
+2. **Crashloop**: "VM web-server-vm keeps restarting. It starts but dies within seconds. Why?"
+3. **Migration failure**: "I tried to migrate VM critical-app-vm but it failed. Why?"
+
+## Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NAMESPACE` | `kubevirt-scenarios` | Namespace for scenario VMs |
+| `NODE_NAME` | First worker node | Node to pin migration VM to |
+| `KUBECTL` | `oc` | CLI tool (`oc` or `kubectl`) |
+| `CNV_NS` | `openshift-cnv` | Namespace for CNV operator |
+| `CNV_CHANNEL` | `stable` | OLM channel for CNV subscription |
+| `CNV_SOURCE` | `redhat-operators` | CatalogSource name |
+| `CNV_SOURCE_NS` | `openshift-marketplace` | CatalogSource namespace |

--- a/kubevirt/build/check-cnv.sh
+++ b/kubevirt/build/check-cnv.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Check that OpenShift Virtualization is installed and healthy.
+# Exits 0 if ready, 1 if not installed or not healthy.
+set -euo pipefail
+
+CNV_NS="${CNV_NS:-openshift-cnv}"
+KUBECTL="${KUBECTL:-oc}"
+
+echo "==> Checking OpenShift Virtualization..."
+
+csv=$($KUBECTL get csv -n "${CNV_NS}" --no-headers 2>/dev/null \
+  | awk '/kubevirt-hyperconverged/ {print $1; exit}')
+if [[ -z "${csv}" ]]; then
+  echo "ERROR: OpenShift Virtualization is NOT installed in namespace ${CNV_NS}."
+  echo "  Install it from OperatorHub before running these scenarios."
+  exit 1
+fi
+
+phase=$($KUBECTL get csv "${csv}" -n "${CNV_NS}" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+if [[ "${phase}" != "Succeeded" ]]; then
+  echo "ERROR: CNV operator CSV is in phase '${phase}' (expected Succeeded)"
+  exit 1
+fi
+
+hco=$($KUBECTL get hyperconverged kubevirt-hyperconverged -n "${CNV_NS}" \
+  -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null || true)
+if [[ -z "${hco}" ]]; then
+  echo "ERROR: HyperConverged CR kubevirt-hyperconverged not found in ${CNV_NS}"
+  exit 1
+fi
+if [[ "${hco}" != "True" ]]; then
+  echo "ERROR: HyperConverged CR is not Available (status=${hco})"
+  exit 1
+fi
+
+echo "==> OpenShift Virtualization is healthy (${csv}, phase=${phase})"
+
+kvm_total=$($KUBECTL get nodes -l node-role.kubernetes.io/worker \
+  -o jsonpath='{range .items[*]}{.status.allocatable.devices\.kubevirt\.io/kvm}{"\n"}{end}' 2>/dev/null \
+  | awk '{s+=$1} END{print s+0}')
+if [[ "${kvm_total}" -gt 0 ]]; then
+  echo "==> KVM devices available on worker nodes."
+else
+  emulation=$($KUBECTL get kubevirt -n "${CNV_NS}" \
+    -o jsonpath='{.items[0].spec.configuration.developerConfiguration.useEmulation}' 2>/dev/null || true)
+  if [[ "${emulation}" == "true" ]]; then
+    echo "==> No KVM devices, but software emulation is enabled."
+  else
+    echo "==> No KVM devices on worker nodes. Enabling software emulation..."
+    $KUBECTL patch subscription hco-operatorhub -n "${CNV_NS}" --type=merge \
+      -p '{"spec":{"config":{"env":[{"name":"KVM_EMULATION","value":"true"}]}}}'
+    echo "==> Waiting for emulation to propagate..."
+    for _ in $(seq 1 60); do
+      emulation=$($KUBECTL get kubevirt -n "${CNV_NS}" \
+        -o jsonpath='{.items[0].spec.configuration.developerConfiguration.useEmulation}' 2>/dev/null || true)
+      if [[ "${emulation}" == "true" ]]; then
+        echo "==> Software emulation is active."
+        break
+      fi
+      sleep 5
+    done
+    if [[ "${emulation}" != "true" ]]; then
+      echo "WARNING: Emulation did not propagate after 300s. VM scenarios may be skipped."
+    fi
+  fi
+fi

--- a/kubevirt/build/install-cnv.sh
+++ b/kubevirt/build/install-cnv.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Install the OpenShift Virtualization operator if not already present.
+# Idempotent: skips installation if the CSV already exists and is Succeeded.
+set -euo pipefail
+
+CNV_NS="${CNV_NS:-openshift-cnv}"
+KUBECTL="${KUBECTL:-oc}"
+CNV_CHANNEL="${CNV_CHANNEL:-stable}"
+CNV_SOURCE="${CNV_SOURCE:-redhat-operators}"
+CNV_SOURCE_NS="${CNV_SOURCE_NS:-openshift-marketplace}"
+
+echo "==> Installing OpenShift Virtualization operator..."
+
+existing_csv=$(${KUBECTL} get csv -n "${CNV_NS}" --no-headers 2>/dev/null \
+  | awk '/kubevirt-hyperconverged/ {print $1; exit}')
+if [[ -n "${existing_csv}" ]]; then
+  phase=$(${KUBECTL} get csv "${existing_csv}" -n "${CNV_NS}" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  hco_available=$(${KUBECTL} get hyperconverged kubevirt-hyperconverged -n "${CNV_NS}" \
+    -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null || true)
+  if [[ "${phase}" == "Succeeded" && "${hco_available}" == "True" ]]; then
+    echo "==> CNV already installed (${existing_csv}). Skipping."
+    exit 0
+  fi
+fi
+
+${KUBECTL} create namespace "${CNV_NS}" --dry-run=client -o yaml | ${KUBECTL} apply -f -
+
+cat <<EOF | ${KUBECTL} apply -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kubevirt-hyperconverged-group
+  namespace: ${CNV_NS}
+spec:
+  targetNamespaces:
+    - ${CNV_NS}
+EOF
+
+cat <<EOF | ${KUBECTL} apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: hco-operatorhub
+  namespace: ${CNV_NS}
+spec:
+  source: ${CNV_SOURCE}
+  sourceNamespace: ${CNV_SOURCE_NS}
+  name: kubevirt-hyperconverged
+  channel: ${CNV_CHANNEL}
+  installPlanApproval: Automatic
+EOF
+
+echo "==> Waiting for CNV CSV to appear..."
+for _ in $(seq 1 60); do
+  csv=$(${KUBECTL} get csv -n "${CNV_NS}" --no-headers 2>/dev/null \
+    | awk '/kubevirt-hyperconverged/ {print $1; exit}')
+  if [[ -n "${csv}" ]]; then
+    break
+  fi
+  sleep 10
+done
+
+if [[ -z "${csv}" ]]; then
+  echo "ERROR: Timed out waiting for CNV CSV to appear."
+  exit 1
+fi
+
+echo "==> Waiting for CSV ${csv} to succeed..."
+${KUBECTL} wait --for=jsonpath='{.status.phase}'=Succeeded csv/"${csv}" \
+  -n "${CNV_NS}" --timeout=600s
+
+echo "==> Creating HyperConverged CR..."
+cat <<EOF | ${KUBECTL} apply -f -
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: ${CNV_NS}
+spec: {}
+EOF
+
+echo "==> Waiting for HyperConverged to become Available..."
+for _ in $(seq 1 60); do
+  status=$(${KUBECTL} get hyperconverged kubevirt-hyperconverged -n "${CNV_NS}" \
+    -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null || true)
+  if [[ "${status}" == "True" ]]; then
+    echo "==> OpenShift Virtualization installed and available."
+    exit 0
+  fi
+  sleep 10
+done
+
+echo "ERROR: Timed out waiting for HyperConverged CR to become Available."
+exit 1

--- a/kubevirt/build/require-kvm.sh
+++ b/kubevirt/build/require-kvm.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# KVM availability check for kubevirt scenarios.
+#
+# Sourced by setup.sh:  source require-kvm.sh; require_kvm
+#   Exits the caller with 0 (skip) if VMs cannot run.
+#
+# Standalone:  bash require-kvm.sh --check
+#   Exits 0 if VMs can run (KVM devices or emulation), 1 if not. No output.
+
+KUBECTL="${KUBECTL:-oc}"
+CNV_NS="${CNV_NS:-openshift-cnv}"
+
+_vms_can_run() {
+  local kvm_total
+  kvm_total=$(${KUBECTL} get nodes -l node-role.kubernetes.io/worker \
+    -o jsonpath='{range .items[*]}{.status.allocatable.devices\.kubevirt\.io/kvm}{"\n"}{end}' 2>/dev/null \
+    | awk '{s+=$1} END{print s+0}')
+  [[ "${kvm_total}" -gt 0 ]] && return 0
+
+  local emulation
+  emulation=$(${KUBECTL} get kubevirt -n "${CNV_NS}" \
+    -o jsonpath='{.items[0].spec.configuration.developerConfiguration.useEmulation}' 2>/dev/null)
+  [[ "${emulation}" == "true" ]]
+}
+
+require_kvm() {
+  if ! _vms_can_run; then
+    echo "SKIP: No KVM devices and emulation is not enabled. This scenario requires running VMs."
+    exit 0
+  fi
+}
+
+if [[ "${1:-}" == "--check" ]]; then
+  _vms_can_run
+fi

--- a/kubevirt/build/uninstall-cnv.sh
+++ b/kubevirt/build/uninstall-cnv.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Remove the OpenShift Virtualization operator and all its resources.
+# Idempotent: succeeds if CNV is already absent.
+set -euo pipefail
+
+CNV_NS="${CNV_NS:-openshift-cnv}"
+KUBECTL="${KUBECTL:-oc}"
+
+echo "==> Removing OpenShift Virtualization..."
+
+# 1. Delete the operand (triggers cleanup of all managed resources)
+${KUBECTL} delete hyperconverged kubevirt-hyperconverged -n "${CNV_NS}" --ignore-not-found --timeout=300s 2>/dev/null || true
+
+# 2. Delete the Subscription (stops OLM from reinstalling)
+${KUBECTL} delete subscription hco-operatorhub -n "${CNV_NS}" --ignore-not-found 2>/dev/null || true
+
+# 3. Delete the CSV
+csv=$(${KUBECTL} get csv -n "${CNV_NS}" --no-headers 2>/dev/null \
+  | awk '/kubevirt-hyperconverged/ {print $1; exit}')
+if [[ -n "${csv}" ]]; then
+  ${KUBECTL} delete csv "${csv}" -n "${CNV_NS}" --timeout=120s 2>/dev/null || true
+fi
+
+# 4. Delete the OperatorGroup
+${KUBECTL} delete operatorgroup kubevirt-hyperconverged-group -n "${CNV_NS}" --ignore-not-found 2>/dev/null || true
+
+# 5. Delete the namespace
+${KUBECTL} delete namespace "${CNV_NS}" --ignore-not-found --timeout=300s 2>/dev/null || true
+
+echo "==> OpenShift Virtualization removed."

--- a/kubevirt/evals.yaml
+++ b/kubevirt/evals.yaml
@@ -1,0 +1,75 @@
+---
+# KubeVirt troubleshooting evaluation scenarios.
+# tag: must match the name listed in SCENARIOS in the Makefile.
+
+- conversation_group_id: vm_storage_failure
+  tag: vm_storage_failure
+  description: >
+    VM stuck in Provisioning due to a non-existent StorageClass.
+    The AI should identify the missing StorageClass and recommend
+    removing it or replacing with a valid one.
+
+  turns:
+    - turn_id: diagnose
+      query: >
+        VM production-db-vm in namespace kubevirt-scenarios is not starting.
+        It has been stuck in Provisioning for over 10 minutes. Can you help?
+      expected_response: >
+        The agent should use the kubevirt MCP tools to inspect the VM and
+        identify that the DataVolume references a non-existent StorageClass
+        named 'premium-nvme-storage'. It should recommend switching to a
+        valid StorageClass or removing storageClassName to use the default.
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: ./vm_storage_failure/setup.sh
+  cleanup_script: ./vm_storage_failure/cleanup.sh
+
+- conversation_group_id: vm_crashloop
+  tag: vm_crashloop
+  description: >
+    VM repeatedly starts and shuts down due to a malicious cloud-init
+    runcmd that calls 'shutdown -h now'. The AI should inspect cloud-init
+    config and identify the offending command.
+
+  turns:
+    - turn_id: diagnose
+      query: >
+        VM web-server-vm in namespace kubevirt-scenarios keeps restarting.
+        It starts but dies within 30-60 seconds. Events show repeated
+        Started/Stopped cycles. Why is this happening?
+      expected_response: >
+        The agent should use the kubevirt MCP tools to inspect the VM spec
+        and identify that the cloud-init userData contains a runcmd entry
+        with 'shutdown -h now'. It should recommend removing or fixing the
+        offending cloud-init command.
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: ./vm_crashloop/setup.sh
+  cleanup_script: ./vm_crashloop/cleanup.sh
+
+- conversation_group_id: vm_migration_failure
+  tag: vm_migration_failure
+  description: >
+    Live migration fails because the VM has a nodeSelector pinning it
+    to a single node. The AI should identify the scheduling constraint
+    preventing migration.
+
+  turns:
+    - turn_id: diagnose
+      query: >
+        I tried to live migrate VM critical-app-vm in namespace
+        kubevirt-scenarios but the migration failed. The VM is running
+        fine otherwise. What went wrong?
+      expected_response: >
+        The agent should use the kubevirt MCP tools to inspect the VM and
+        identify the nodeSelector constraint pinning it to a specific node.
+        It should explain that live migration requires at least one other
+        schedulable node that matches the selector, and recommend removing
+        the nodeSelector or adding more matching nodes.
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: ./vm_migration_failure/setup.sh
+  cleanup_script: ./vm_migration_failure/cleanup.sh

--- a/kubevirt/system.yaml
+++ b/kubevirt/system.yaml
@@ -1,0 +1,60 @@
+---
+core:
+  max_threads: 5
+
+llm:
+  provider: "openai"
+  model: "gpt-4o-mini"
+  temperature: 0.0
+  max_tokens: 5000
+  timeout: 300
+  num_retries: 3
+  cache_enabled: false
+
+api:
+  enabled: true
+  api_base: https://localhost:8443
+  endpoint_type: query
+  timeout: 300
+  provider: "openai"
+  model: "gpt-4o-mini"
+  cache_enabled: false
+  extra_request_params:
+    mode: troubleshooting
+
+metrics_metadata:
+  turn_level:
+    "custom:answer_correctness":
+      description: "Correctness vs expected answer"
+      default: true
+
+output:
+  output_dir: "./eval_output"
+  base_filename: "evaluation"
+  enabled_outputs:
+    - csv
+    - json
+
+visualization:
+  figsize: [12, 8]
+  dpi: 300
+  enabled_graphs:
+    - "score_distribution"
+    - "status_breakdown"
+
+environment:
+  DEEPEVAL_TELEMETRY_OPT_OUT: "YES"
+  DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"
+  LITELLM_LOG: ERROR
+
+logging:
+  source_level: INFO
+  package_level: ERROR
+  log_format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+  show_timestamps: true
+  package_overrides:
+    httpx: ERROR
+    urllib3: ERROR
+    matplotlib: ERROR
+    LiteLLM: WARNING
+    DeepEval: WARNING

--- a/kubevirt/vm_crashloop/cleanup.sh
+++ b/kubevirt/vm_crashloop/cleanup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KUBECTL=${KUBECTL:-oc}
+NAMESPACE=${NAMESPACE:-kubevirt-scenarios}
+
+echo "==> Cleaning up vm_crashloop scenario..."
+${KUBECTL} delete vm web-server-vm -n "${NAMESPACE}" --ignore-not-found
+echo "==> Cleanup complete."

--- a/kubevirt/vm_crashloop/fixtures/vm.yaml
+++ b/kubevirt/vm_crashloop/fixtures/vm.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: web-server-vm
+  labels:
+    app: web-server
+    scenario: vm-crashloop
+spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        app: web-server
+    spec:
+      domain:
+        devices:
+          autoattachPodInterface: false
+          disks:
+            - bootOrder: 1
+              name: rootdisk
+            - name: cloudinitdisk
+              disk: {}
+          interfaces:
+            - masquerade: {}
+              name: default
+      networks:
+        - name: default
+          pod: {}
+      subdomain: headless
+      volumes:
+        - containerDisk:
+            image: quay.io/containerdisks/fedora:42
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              runcmd:
+                - ["shutdown", "-h", "now"]
+          name: cloudinitdisk

--- a/kubevirt/vm_crashloop/setup.sh
+++ b/kubevirt/vm_crashloop/setup.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KUBECTL=${KUBECTL:-oc}
+NAMESPACE=${NAMESPACE:-kubevirt-scenarios}
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+
+# shellcheck source=SCRIPTDIR/../build/require-kvm.sh disable=SC1091
+source "$(cd "$(dirname "$0")/../build" && pwd)/require-kvm.sh"
+require_kvm
+
+echo "==> Deploying VM crashloop scenario in namespace ${NAMESPACE}..."
+echo "    VM has a cloud-init runcmd that immediately shuts it down, causing a restart loop."
+
+${KUBECTL} create namespace "${NAMESPACE}" --dry-run=client -o yaml | ${KUBECTL} apply -f -
+${KUBECTL} apply -f "${FIXTURE_DIR}/vm.yaml" -n "${NAMESPACE}"
+
+echo "==> Waiting for crashloop to become visible (up to 180s)..."
+for _ in $(seq 1 18); do
+  vmi_phase=$(${KUBECTL} get vmi web-server-vm -n "${NAMESPACE}" \
+    -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  if [[ "${vmi_phase}" == "Succeeded" || "${vmi_phase}" == "Failed" ]]; then
+    # Wait for at least 2 restart cycles so the crashloop pattern is clearly visible
+    sleep 40
+    break
+  fi
+  vm_status=$(${KUBECTL} get vm web-server-vm -n "${NAMESPACE}" \
+    -o jsonpath='{.status.printableStatus}' 2>/dev/null || true)
+  if [[ "${vm_status}" == "CrashLoopBackOff" || "${vm_status}" == "Stopped" ]]; then
+    break
+  fi
+  sleep 10
+done
+
+echo "==> VM status:"
+${KUBECTL} get vm web-server-vm -n "${NAMESPACE}" -o wide 2>/dev/null || echo "    VM not found"
+echo ""
+echo "==> Recent events:"
+${KUBECTL} get events -n "${NAMESPACE}" --sort-by=.lastTimestamp 2>/dev/null \
+  | grep "web-server" \
+  | tail -10 || true
+echo ""
+echo "==> Setup complete. Ask the AI:"
+echo '    "VM web-server-vm in '"${NAMESPACE}"' keeps restarting. It starts but dies within seconds. Why?"'

--- a/kubevirt/vm_migration_failure/cleanup.sh
+++ b/kubevirt/vm_migration_failure/cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KUBECTL=${KUBECTL:-oc}
+NAMESPACE=${NAMESPACE:-kubevirt-scenarios}
+
+echo "==> Cleaning up vm_migration_failure scenario..."
+${KUBECTL} delete vm critical-app-vm -n "${NAMESPACE}" --ignore-not-found
+${KUBECTL} delete vmim -n "${NAMESPACE}" --all --ignore-not-found 2>/dev/null || true
+echo "==> Cleanup complete."

--- a/kubevirt/vm_migration_failure/fixtures/vm.yaml
+++ b/kubevirt/vm_migration_failure/fixtures/vm.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: critical-app-vm
+  labels:
+    app: critical-app
+    scenario: vm-migration-failure
+spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        app: critical-app
+    spec:
+      domain:
+        devices:
+          autoattachPodInterface: false
+          disks:
+            - bootOrder: 1
+              name: rootdisk
+            - name: cloudinitdisk
+              disk: {}
+          interfaces:
+            - masquerade: {}
+              name: default
+      networks:
+        - name: default
+          pod: {}
+      subdomain: headless
+      volumes:
+        - containerDisk:
+            image: quay.io/containerdisks/fedora:42
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+          name: cloudinitdisk

--- a/kubevirt/vm_migration_failure/setup.sh
+++ b/kubevirt/vm_migration_failure/setup.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KUBECTL=${KUBECTL:-oc}
+NAMESPACE=${NAMESPACE:-kubevirt-scenarios}
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+
+# shellcheck source=SCRIPTDIR/../build/require-kvm.sh disable=SC1091
+source "$(cd "$(dirname "$0")/../build" && pwd)/require-kvm.sh"
+require_kvm
+
+# Pin VM to a worker node (auto-detect if not provided)
+NODE_NAME="${NODE_NAME:-}"
+if [[ -z "${NODE_NAME}" ]]; then
+  # || true prevents set -e from aborting on non-zero exit (e.g., no nodes match label)
+  NODE_NAME=$(${KUBECTL} get nodes -l node-role.kubernetes.io/worker \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) || true
+  if [[ -z "${NODE_NAME}" ]]; then
+    # Fallback: pick the first schedulable node (compact/SNO clusters)
+    NODE_NAME=$(${KUBECTL} get nodes --no-headers 2>/dev/null \
+      | awk '!/SchedulingDisabled/ {print $1; exit}') || true
+  fi
+  if [[ -z "${NODE_NAME}" ]]; then
+    echo "ERROR: Could not determine a schedulable node. Set NODE_NAME or check cluster access."
+    exit 1
+  fi
+fi
+
+# Note: The scenario works on any cluster size. The hostname nodeSelector ensures
+# migration fails because no other node can match the exact same hostname.
+
+echo "==> Deploying VM migration failure scenario in namespace ${NAMESPACE}..."
+echo "    VM is pinned to node ${NODE_NAME} via nodeSelector. Migration will fail."
+
+${KUBECTL} create namespace "${NAMESPACE}" --dry-run=client -o yaml | ${KUBECTL} apply -f -
+
+# Apply base VM, then immediately patch nodeSelector before VMI is created.
+# runStrategy:Always starts the VM on apply; the patch lands before image pull completes.
+${KUBECTL} apply -f "${FIXTURE_DIR}/vm.yaml" -n "${NAMESPACE}"
+${KUBECTL} patch vm critical-app-vm -n "${NAMESPACE}" --type=merge -p \
+  "{\"spec\":{\"template\":{\"spec\":{\"nodeSelector\":{\"kubernetes.io/hostname\":\"${NODE_NAME}\"}}}}}"
+
+# Restart to ensure the VMI picks up the patched nodeSelector
+${KUBECTL} delete vmi critical-app-vm -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
+sleep 5
+
+echo "==> Waiting for VM to be ready..."
+if ! ${KUBECTL} wait --for=condition=Ready vm/critical-app-vm -n "${NAMESPACE}" --timeout=300s 2>/dev/null; then
+  echo "ERROR: VM not ready after 300s. Cannot trigger migration."
+  exit 1
+fi
+
+echo "==> VM status:"
+${KUBECTL} get vm critical-app-vm -n "${NAMESPACE}" -o wide
+echo ""
+echo "==> VMI running on node:"
+${KUBECTL} get vmi critical-app-vm -n "${NAMESPACE}" -o jsonpath='{.status.nodeName}' 2>/dev/null; echo ""
+
+echo ""
+echo "==> Triggering a migration so the failure state exists for the eval..."
+${KUBECTL} delete vmim critical-app-vm-migration -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
+cat <<EOF | ${KUBECTL} apply -n "${NAMESPACE}" -f -
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstanceMigration
+metadata:
+  name: critical-app-vm-migration
+spec:
+  vmiName: critical-app-vm
+EOF
+
+echo "==> Waiting for migration to fail (expected due to nodeSelector pinning)..."
+${KUBECTL} wait \
+  --for=jsonpath='{.status.phase}'=Failed \
+  vmim/critical-app-vm-migration \
+  -n "${NAMESPACE}" \
+  --timeout=180s 2>/dev/null || true
+
+echo ""
+echo "==> Migration status:"
+${KUBECTL} get vmim -n "${NAMESPACE}" 2>/dev/null || true
+migration_phase=$(${KUBECTL} get vmim critical-app-vm-migration -n "${NAMESPACE}" \
+  -o jsonpath='{.status.phase}' 2>/dev/null || true)
+echo "    Final VMIM phase: ${migration_phase:-unknown}"
+echo ""
+echo "==> Setup complete. Ask the AI:"
+echo '    "I tried to migrate VM critical-app-vm in '"${NAMESPACE}"' but it failed. Why?"'

--- a/kubevirt/vm_storage_failure/cleanup.sh
+++ b/kubevirt/vm_storage_failure/cleanup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KUBECTL=${KUBECTL:-oc}
+NAMESPACE=${NAMESPACE:-kubevirt-scenarios}
+
+echo "==> Cleaning up vm_storage_failure scenario..."
+${KUBECTL} delete vm production-db-vm -n "${NAMESPACE}" --ignore-not-found
+${KUBECTL} delete dv production-db-vm-volume -n "${NAMESPACE}" --ignore-not-found
+${KUBECTL} delete pvc production-db-vm-volume -n "${NAMESPACE}" --ignore-not-found
+echo "==> Cleanup complete."

--- a/kubevirt/vm_storage_failure/fixtures/vm.yaml
+++ b/kubevirt/vm_storage_failure/fixtures/vm.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: production-db-vm
+  labels:
+    app: production-db
+    scenario: vm-storage-failure
+spec:
+  dataVolumeTemplates:
+    - metadata:
+        name: production-db-vm-volume
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          storageClassName: premium-nvme-storage
+          resources:
+            requests:
+              storage: 30Gi
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        app: production-db
+    spec:
+      domain:
+        devices:
+          autoattachPodInterface: false
+          disks:
+            - bootOrder: 1
+              name: rootdisk
+            - name: cloudinitdisk
+              disk: {}
+          interfaces:
+            - masquerade: {}
+              name: default
+      networks:
+        - name: default
+          pod: {}
+      subdomain: headless
+      volumes:
+        - dataVolume:
+            name: production-db-vm-volume
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+          name: cloudinitdisk

--- a/kubevirt/vm_storage_failure/setup.sh
+++ b/kubevirt/vm_storage_failure/setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KUBECTL=${KUBECTL:-oc}
+NAMESPACE=${NAMESPACE:-kubevirt-scenarios}
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+
+echo "==> Deploying VM storage failure scenario in namespace ${NAMESPACE}..."
+echo "    VM uses non-existent StorageClass 'premium-nvme-storage' and will be stuck in Provisioning."
+
+${KUBECTL} create namespace "${NAMESPACE}" --dry-run=client -o yaml | ${KUBECTL} apply -f -
+${KUBECTL} apply -f "${FIXTURE_DIR}/vm.yaml" -n "${NAMESPACE}"
+
+echo "==> Waiting 15s for DataVolume to be created..."
+sleep 15
+
+echo "==> VM status:"
+${KUBECTL} get vm production-db-vm -n "${NAMESPACE}" -o wide 2>/dev/null || echo "    VM not found"
+echo ""
+echo "==> DataVolume status:"
+${KUBECTL} get dv production-db-vm-volume -n "${NAMESPACE}" 2>/dev/null || echo "    No DataVolume"
+echo ""
+echo "==> Setup complete. Ask the AI:"
+echo '    "Why is VM production-db-vm not starting in namespace '"${NAMESPACE}"'?"'


### PR DESCRIPTION
Add three KubeVirt evaluation scenarios for AI-assisted troubleshooting using the kubevirt MCP toolset and OpenShift Lightspeed:

- vm_storage_failure: VM stuck in Provisioning due to non-existent StorageClass
- vm_crashloop: VM crash-loops due to cloud-init shutdown command
- vm_migration_failure: Live migration fails due to nodeSelector pinning VM to single node

Includes:
- build/cnv.mk for automated CNV operator installation
- evals.yaml with evaluation definitions for lightspeed-evaluation
- Per-scenario setup.sh/cleanup.sh following existing suite patterns
- VM manifests using modern instancetype-based format