### PR TITLE
feat: add single-namespace deployment mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,8 @@ The fault: `reporting-service` v1.0.2 accumulates database connections without c
 
 Monitoring is wired via Prometheus ServiceMonitors and PrometheusRules with alerts on error rate (`PaymentErrorRateHigh`) and connection count (`PostgresqlConnectionsHigh`, `PostgresqlTooManyConnections`).
 
+**Single-namespace mode**: `make deploy SINGLE_NAMESPACE=1` deploys everything into the `payments` namespace. The deploy script transforms manifests on the fly (retargets namespace, rewrites PGHOST to same-namespace service name, fixes PromQL expressions). Operational scripts (break, fix, cleanup, etc.) auto-detect the deployment mode by checking whether the `shared-services` namespace exists.
+
 ### Key Paths
 
 - `generic/01-payments-api-failure/README.md` -- scenario overview and components

--- a/generic/01-payments-api-failure/Makefile
+++ b/generic/01-payments-api-failure/Makefile
@@ -15,15 +15,19 @@ help:
 	@echo "  fix-redherring    Fix red herring"
 	@echo "  break-network     Block egress from payments-api via NetworkPolicy"
 	@echo "  fix-network       Remove the deny-all-egress NetworkPolicy"
+	@echo ""
+	@echo "Options:"
+	@echo "  SINGLE_NAMESPACE=1  Deploy everything into the payments namespace"
+	@echo "                      (only needed for deploy/deploy-easy; other targets auto-detect)"
 
 update-images:
 	@./scripts/update-images.sh $(REGISTRY)
 
 deploy:
-	@SINGLE_USER=1 ./scripts/deploy.sh
+	@SINGLE_USER=1 SINGLE_NAMESPACE=$(SINGLE_NAMESPACE) ./scripts/deploy.sh
 
 deploy-easy:
-	@./scripts/deploy.sh
+	@SINGLE_NAMESPACE=$(SINGLE_NAMESPACE) ./scripts/deploy.sh
 
 break:
 	@./scripts/break.sh

--- a/generic/01-payments-api-failure/scripts/break-network.sh
+++ b/generic/01-payments-api-failure/scripts/break-network.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 set -e
 
+if oc get namespace shared-services &>/dev/null; then
+  SERVICES_NS="shared-services"
+else
+  SERVICES_NS="payments"
+fi
+
 echo "=== Applying payments-np-policy NetworkPolicy in payments namespace ==="
-oc apply -f - <<'EOF'
+oc apply -f - <<EOF
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -18,7 +24,7 @@ spec:
     - to:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: shared-services
+              kubernetes.io/metadata.name: ${SERVICES_NS}
       ports:
         - protocol: TCP
           port: 5432

--- a/generic/01-payments-api-failure/scripts/break-redherring.sh
+++ b/generic/01-payments-api-failure/scripts/break-redherring.sh
@@ -3,13 +3,20 @@ set -e
 
 echo "Scenario 01 — Payments API Failure"
 echo ""
+
+if oc get namespace shared-services &>/dev/null; then
+  SERVICES_NS="shared-services"
+else
+  SERVICES_NS="payments"
+fi
+
 echo "=== Misconfiguring probes on reconciliation-service ==="
-oc set probe deployment/reconciliation-service -n shared-services \
+oc set probe deployment/reconciliation-service -n "$SERVICES_NS" \
   --readiness --get-url=http://:8443/ --initial-delay-seconds=3 --period-seconds=5 --failure-threshold=3
-oc set probe deployment/reconciliation-service -n shared-services \
+oc set probe deployment/reconciliation-service -n "$SERVICES_NS" \
   --liveness --get-url=http://:8443/ --initial-delay-seconds=3 --period-seconds=5 --failure-threshold=3
 
-oc -n shared-services rollout status deployment/reconciliation-service --timeout=60s || true
+oc -n "$SERVICES_NS" rollout status deployment/reconciliation-service --timeout=60s || true
 
 echo ""
 echo "Done. reconciliation-service will enter CrashLoopBackOff (probes on wrong port)."

--- a/generic/01-payments-api-failure/scripts/break.sh
+++ b/generic/01-payments-api-failure/scripts/break.sh
@@ -3,9 +3,16 @@ set -e
 
 echo "Scenario 01 — Payments API Failure"
 echo ""
+
+if oc get namespace shared-services &>/dev/null; then
+  SERVICES_NS="shared-services"
+else
+  SERVICES_NS="payments"
+fi
+
 echo "=== Rolling out reporting-service v1.0.2 ==="
-oc -n shared-services set image deployment/reporting-service reporting-service=quay.io/afalossi/ts01-reporting-service:v1.0.2
-oc -n shared-services rollout status deployment/reporting-service --timeout=120s
+oc -n "$SERVICES_NS" set image deployment/reporting-service reporting-service=quay.io/afalossi/ts01-reporting-service:v1.0.2
+oc -n "$SERVICES_NS" rollout status deployment/reporting-service --timeout=120s
 
 ROUTE=$(oc -n payments get route payments-api -o jsonpath='{.spec.host}')
 TOKEN=$(oc whoami -t)

--- a/generic/01-payments-api-failure/scripts/delete-history.sh
+++ b/generic/01-payments-api-failure/scripts/delete-history.sh
@@ -28,15 +28,25 @@ echo "Restarting Prometheus pods..."
 oc delete pod -n "$USER_NS" prometheus-user-workload-0 prometheus-user-workload-1
 oc delete pod -n "$PLATFORM_NS" prometheus-k8s-0 prometheus-k8s-1
 
+if oc get namespace shared-services &>/dev/null; then
+  SERVICES_NS="shared-services"
+else
+  SERVICES_NS="payments"
+fi
+
 echo ""
 echo "=== Deleting events ==="
 oc delete events --all -n payments
-oc delete events --all -n shared-services
+if [ "$SERVICES_NS" != "payments" ]; then
+  oc delete events --all -n "$SERVICES_NS"
+fi
 
 echo ""
 echo "=== Restarting demo pods ==="
 oc delete pods --all -n payments
-oc delete pods --all -n shared-services
+if [ "$SERVICES_NS" != "payments" ]; then
+  oc delete pods --all -n "$SERVICES_NS"
+fi
 
 echo ""
 echo "Done. All Prometheus and demo pods are restarting."

--- a/generic/01-payments-api-failure/scripts/deploy.sh
+++ b/generic/01-payments-api-failure/scripts/deploy.sh
@@ -7,11 +7,15 @@ echo ""
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$SCRIPT_DIR"
 
-if [ "${SINGLE_USER:-}" = "1" ]; then
+if [ "${SINGLE_USER:-}" = "1" ] || [ "${SINGLE_NAMESPACE:-}" = "1" ]; then
   MANIFESTS=$(mktemp -d)
   trap 'rm -rf $MANIFESTS' EXIT
   cp -r manifests/* "$MANIFESTS/"
+else
+  MANIFESTS="manifests"
+fi
 
+if [ "${SINGLE_USER:-}" = "1" ]; then
   # Both services use a single "dbuser" account
   sed -i 's/PGUSER: reporting/PGUSER: dbuser/' "$MANIFESTS/shared-services/01-secrets.yaml"
   sed -i 's/PGPASSWORD: reporting123/PGPASSWORD: dbuser123/' "$MANIFESTS/shared-services/01-secrets.yaml"
@@ -25,8 +29,20 @@ if [ "${SINGLE_USER:-}" = "1" ]; then
     "$MANIFESTS/shared-services/02-postgres.yaml"
 
   echo "=== Single-user mode: all services will use 'dbuser' ==="
-else
-  MANIFESTS="manifests"
+fi
+
+if [ "${SINGLE_NAMESPACE:-}" = "1" ]; then
+  rm -f "$MANIFESTS/shared-services/00-namespace.yaml"
+
+  sed -i 's/namespace: shared-services/namespace: payments/g' "$MANIFESTS/shared-services/"*.yaml
+
+  sed -i 's/namespace="shared-services"/namespace="payments"/g' "$MANIFESTS/shared-services/05-prometheusrules.yaml"
+
+  sed -i "/^  labels:$/a\\    openshift.io/user-monitoring: 'true'" "$MANIFESTS/payments/00-namespace.yaml"
+
+  sed -i 's/postgres\.shared-services\.svc\.cluster\.local/postgres/' "$MANIFESTS/payments/02-payments-api.yaml"
+
+  echo "=== Single-namespace mode: all services deploy to 'payments' ==="
 fi
 
 echo "=== Enabling user workload monitoring ==="
@@ -46,16 +62,27 @@ echo "=== Cleaning up existing namespaces ==="
 oc delete namespace shared-services --ignore-not-found --wait
 oc delete namespace payments --ignore-not-found --wait
 
-echo ""
-echo "=== Deploying shared-services ==="
-oc apply -f "$MANIFESTS/shared-services/"
-oc -n shared-services wait --for=condition=available deployment/postgres --timeout=120s
-oc -n shared-services wait --for=condition=available deployment/reporting-service --timeout=120s
+if [ "${SINGLE_NAMESPACE:-}" = "1" ]; then
+  echo ""
+  echo "=== Deploying to payments namespace ==="
+  oc apply -f "$MANIFESTS/payments/00-namespace.yaml"
+  oc apply -f "$MANIFESTS/shared-services/"
+  oc -n payments wait --for=condition=available deployment/postgres --timeout=120s
+  oc -n payments wait --for=condition=available deployment/reporting-service --timeout=120s
+  oc apply -f "$MANIFESTS/payments/"
+  oc -n payments wait --for=condition=available deployment/payments-api --timeout=120s
+else
+  echo ""
+  echo "=== Deploying shared-services ==="
+  oc apply -f "$MANIFESTS/shared-services/"
+  oc -n shared-services wait --for=condition=available deployment/postgres --timeout=120s
+  oc -n shared-services wait --for=condition=available deployment/reporting-service --timeout=120s
 
-echo ""
-echo "=== Deploying payments ==="
-oc apply -f "$MANIFESTS/payments/"
-oc -n payments wait --for=condition=available deployment/payments-api --timeout=120s
+  echo ""
+  echo "=== Deploying payments ==="
+  oc apply -f "$MANIFESTS/payments/"
+  oc -n payments wait --for=condition=available deployment/payments-api --timeout=120s
+fi
 
 ROUTE=$(oc -n payments get route payments-api -o jsonpath='{.spec.host}')
 echo ""

--- a/generic/01-payments-api-failure/scripts/fix-redherring.sh
+++ b/generic/01-payments-api-failure/scripts/fix-redherring.sh
@@ -3,13 +3,20 @@ set -e
 
 echo "Scenario 01 — Payments API Failure"
 echo ""
+
+if oc get namespace shared-services &>/dev/null; then
+  SERVICES_NS="shared-services"
+else
+  SERVICES_NS="payments"
+fi
+
 echo "=== Fixing probes on reconciliation-service ==="
-oc set probe deployment/reconciliation-service -n shared-services \
+oc set probe deployment/reconciliation-service -n "$SERVICES_NS" \
   --readiness --open-tcp=8080 --initial-delay-seconds=3 --period-seconds=5 --failure-threshold=3
-oc set probe deployment/reconciliation-service -n shared-services \
+oc set probe deployment/reconciliation-service -n "$SERVICES_NS" \
   --liveness --open-tcp=8080 --initial-delay-seconds=3 --period-seconds=5 --failure-threshold=3
 
-oc -n shared-services rollout status deployment/reconciliation-service --timeout=120s
+oc -n "$SERVICES_NS" rollout status deployment/reconciliation-service --timeout=120s
 
 echo ""
 echo "Done. reconciliation-service is running normally."

--- a/generic/01-payments-api-failure/scripts/fix.sh
+++ b/generic/01-payments-api-failure/scripts/fix.sh
@@ -3,9 +3,16 @@ set -e
 
 echo "Scenario 01 — Payments API Failure"
 echo ""
+
+if oc get namespace shared-services &>/dev/null; then
+  SERVICES_NS="shared-services"
+else
+  SERVICES_NS="payments"
+fi
+
 echo "=== Rolling back reporting-service to v1.0.1 ==="
-oc -n shared-services set image deployment/reporting-service reporting-service=quay.io/afalossi/ts01-reporting-service:v1.0.1
-oc -n shared-services rollout status deployment/reporting-service --timeout=120s
+oc -n "$SERVICES_NS" set image deployment/reporting-service reporting-service=quay.io/afalossi/ts01-reporting-service:v1.0.1
+oc -n "$SERVICES_NS" rollout status deployment/reporting-service --timeout=120s
 
 echo ""
 echo "Done. reporting-service is now running v1.0.1."


### PR DESCRIPTION
deploy.sh transforms manifests on the fly when SINGLE_NAMESPACE=1: retargets shared-services resources to payments namespace, rewrites PGHOST to same-namespace service name, fixes PromQL expressions.

Operational scripts auto-detect the deployment mode by checking whether the shared-services namespace exists on the cluster.


Assisted-by: Claude Code:claude-opus-4-6