### PR TITLE
feat: add agentic eval suite with multi-run summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/results/
+**/results_*/
 **/_output/
 **/.caches/
 venv/

--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -1,0 +1,21 @@
+SCRIPTS_DIR := $(realpath ../scripts)
+
+SUITES := api-failure
+RUNS ?= 1
+
+.PHONY: setup evals
+
+setup:
+	$(SCRIPTS_DIR)/setup-venv.sh
+
+evals:
+	$(eval RESULTS_DIR := results_$(shell date +%Y%m%d_%H%M%S))
+	@for suite in $(SUITES); do \
+	  echo "==> Suite: $$suite"; \
+	  bash $(SCRIPTS_DIR)/run-agentic-evals.sh \
+	    --system-config $$suite/system.yaml \
+	    --evals $$suite/evals.yaml \
+	    --results-dir $(RESULTS_DIR) \
+	    --runs $(RUNS) \
+	    --tag agentic_$$(echo $$suite | tr '-' '_'); \
+	done

--- a/agentic/api-failure/evals.yaml
+++ b/agentic/api-failure/evals.yaml
@@ -1,0 +1,139 @@
+- conversation_group_id: api_failure_analysis_openai
+  description: gpt-5.2
+  tag: agentic_api_failure
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Alert: PaymentErrorRateHigh (critical)
+          Namespace: payments
+          Description: Payment error rate is 100.00%, which exceeds the 15% threshold.
+          Labels:
+            alertname: PaymentErrorRateHigh
+            namespace: payments
+            severity: critical
+
+          Investigate, follow causality chains to the root cause
+        targetNamespaces:
+          - payments
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: shared-services/reporting-service is repeatedly opening
+        DB connections and leaving them idle in transaction (division by zero
+        without rollback/close), exhausting PostgreSQL connection slots.
+        payments/payments-api cannot obtain a DB connection and returns 503,
+        triggering the alert storm. reconciliation-service CrashLooping is a
+        separate issue (probe port mismatch 8443 vs 8080), not related to
+        the DB connection exhaustion. Fix: restart or scale down
+        reporting-service.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: api_failure_analysis_opus
+  description: Opus 4.6
+  tag: agentic_api_failure
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Alert: PaymentErrorRateHigh (critical)
+          Namespace: payments
+          Description: Payment error rate is 100.00%, which exceeds the 15% threshold.
+          Labels:
+            alertname: PaymentErrorRateHigh
+            namespace: payments
+            severity: critical
+
+          Investigate, follow causality chains to the root cause
+        targetNamespaces:
+          - payments
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: shared-services/reporting-service is repeatedly opening
+        DB connections and leaving them idle in transaction (division by zero
+        without rollback/close), exhausting PostgreSQL connection slots.
+        payments/payments-api cannot obtain a DB connection and returns 503,
+        triggering the alert storm. reconciliation-service CrashLooping is a
+        separate issue (probe port mismatch 8443 vs 8080), not related to
+        the DB connection exhaustion. Fix: restart or scale down
+        reporting-service.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: api_failure_analysis_gemini
+  description: Gemini Flash 2.5
+  tag: agentic_api_failure
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Alert: PaymentErrorRateHigh (critical)
+          Namespace: payments
+          Description: Payment error rate is 100.00%, which exceeds the 15% threshold.
+          Labels:
+            alertname: PaymentErrorRateHigh
+            namespace: payments
+            severity: critical
+
+          Investigate, follow causality chains to the root cause
+        targetNamespaces:
+          - payments
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: shared-services/reporting-service is repeatedly opening
+        DB connections and leaving them idle in transaction (division by zero
+        without rollback/close), exhausting PostgreSQL connection slots.
+        payments/payments-api cannot obtain a DB connection and returns 503,
+        triggering the alert storm. reconciliation-service CrashLooping is a
+        separate issue (probe port mismatch 8443 vs 8080), not related to
+        the DB connection exhaustion. Fix: restart or scale down
+        reporting-service.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/api-failure/system.yaml
+++ b/agentic/api-failure/system.yaml
@@ -1,0 +1,38 @@
+logging:
+  source_level: DEBUG
+
+core:
+  max_threads: 1
+  fail_on_invalid_data: true
+  skip_on_failure: false
+
+llm_pool:
+    models:
+      gpt-4.1:
+        provider: openai
+
+judge_panel:
+    judges:
+      - gpt-4.1
+
+agents:
+  enabled: true
+  default:
+    agent: eval_agent
+    agent_config:
+      timeout: 600
+  eval_agent:
+    type: proposal
+    namespace: lightspeed-evaluation-test
+    auto_approve: true
+    cleanup_proposals: false
+    timeout: 600
+    poll_interval: 5
+
+storage:
+  - type: file
+    output_dir: ./eval_output
+    enabled_outputs: [csv, json]
+
+environment:
+  LITELLM_LOG: ERROR

--- a/scripts/run-agentic-evals.sh
+++ b/scripts/run-agentic-evals.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --system-config FILE --evals FILE --results-dir DIR [--runs N] --tag TAG [--tag TAG ...]"
+  exit 1
+}
+
+SYSTEM_CONFIG=""
+EVALS=""
+RESULTS_DIR=""
+RUNS=1
+TAGS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --system-config) SYSTEM_CONFIG="$2"; shift 2 ;;
+    --evals)         EVALS="$2"; shift 2 ;;
+    --results-dir)   RESULTS_DIR="$2"; shift 2 ;;
+    --runs)          RUNS="$2"; shift 2 ;;
+    --tag)           TAGS+=("$2"); shift 2 ;;
+    *) echo "Unknown arg: $1"; usage ;;
+  esac
+done
+
+[ -n "$SYSTEM_CONFIG" ] && [ -n "$EVALS" ] && [ -n "$RESULTS_DIR" ] && [ ${#TAGS[@]} -gt 0 ] || usage
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VENV_DIR="${SCRIPT_DIR}/../venv"
+
+if [ ! -f "${VENV_DIR}/bin/lightspeed-eval" ]; then
+  echo "ERROR: lightspeed-eval not found at ${VENV_DIR}/bin/lightspeed-eval"
+  echo "Run setup first (make setup)"
+  exit 1
+fi
+
+if [ -z "${OPENAI_API_KEY:-}" ]; then
+  printf '\033[0;31mERROR:\033[0m OPENAI_API_KEY not set (needed for judge LLM)\n'
+  exit 1
+fi
+
+mkdir -p "$RESULTS_DIR"
+
+# Snapshot existing JSON files before runs
+existing_jsons=$(find "$RESULTS_DIR" -maxdepth 1 -name '*_summary.json' 2>/dev/null | sort)
+
+for run in $(seq 1 "$RUNS"); do
+  for tag in "${TAGS[@]}"; do
+    echo ""
+    echo "==> Run ${run}/${RUNS}: ${tag}"
+    "${VENV_DIR}/bin/lightspeed-eval" \
+      --system-config "$SYSTEM_CONFIG" \
+      --output-dir "$RESULTS_DIR" \
+      --eval-data "$EVALS" \
+      --tag "$tag"
+  done
+done
+
+# Find new JSON files produced by this batch
+new_jsons=$(find "$RESULTS_DIR" -maxdepth 1 -name '*_summary.json' 2>/dev/null | sort)
+batch_jsons=$(comm -13 <(echo "$existing_jsons") <(echo "$new_jsons"))
+
+if [ -n "$batch_jsons" ]; then
+  echo ""
+  echo "==> Generating summary..."
+  # shellcheck disable=SC2086
+  "${VENV_DIR}/bin/python" "${SCRIPT_DIR}/summarize-agentic-evals.py" "$RESULTS_DIR" "$EVALS" $batch_jsons
+fi
+
+echo ""
+echo "==> All agentic evals complete. Results in ${RESULTS_DIR}/"

--- a/scripts/summarize-agentic-evals.py
+++ b/scripts/summarize-agentic-evals.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Parse lightspeed-eval summary JSON files and generate a summary table."""
+
+import csv
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+METRIC_LABELS = {
+    "custom:proposal_status": "Status",
+    "custom:proposal_evaluation_correctness": "Correctness",
+}
+
+GREEN = "\033[0;32m"
+RED = "\033[0;31m"
+RESET = "\033[0m"
+
+
+def load_json_data(json_files: list[Path]) -> tuple[list[list[dict]], dict]:
+    """Load results and configuration from JSON summary files."""
+    runs = []
+    config = {}
+    for path in sorted(json_files):
+        with open(path) as f:
+            data = json.load(f)
+        runs.append(data.get("results", []))
+        if not config:
+            config = data.get("configuration", {})
+    return runs, config
+
+
+def load_csv_data(json_files: list[Path]) -> list[list[dict]]:
+    """Load CSV data paired with each JSON file (same timestamp prefix)."""
+    runs = []
+    for json_path in sorted(json_files):
+        csv_path = Path(str(json_path).replace("_summary.json", "_detailed.csv"))
+        if csv_path.exists():
+            with open(csv_path) as f:
+                runs.append(list(csv.DictReader(f)))
+        else:
+            runs.append([])
+    return runs
+
+
+def metric_label(metric_id: str) -> str:
+    return METRIC_LABELS.get(metric_id, metric_id.split(":")[-1])
+
+
+def metric_passed(results: list[dict], conversation_id: str, metric_id: str) -> bool:
+    for r in results:
+        if r["conversation_group_id"] == conversation_id and r["metric_identifier"] == metric_id:
+            return r["result"] == "PASS"
+    return False
+
+
+def all_passed(results: list[dict], conversation_id: str, metrics: list[str]) -> bool:
+    return all(metric_passed(results, conversation_id, m) for m in metrics)
+
+
+def build_summary(
+    runs: list[list[dict]],
+) -> tuple[list[str], list[str], list[dict]]:
+    """Returns (conversations, columns, rows).
+
+    Each row is a dict with pass/total tuples.
+    """
+    conversations = []
+    seen_convs = set()
+    metrics = []
+    seen_metrics = set()
+    for results in runs:
+        for r in results:
+            cid = r["conversation_group_id"]
+            if cid not in seen_convs:
+                seen_convs.add(cid)
+                conversations.append(cid)
+            mid = r["metric_identifier"]
+            if mid not in seen_metrics:
+                seen_metrics.add(mid)
+                metrics.append(mid)
+
+    total = len(runs)
+    rows = []
+    for cid in conversations:
+        row = {}
+        for mid in metrics:
+            passed = sum(1 for r in runs if metric_passed(r, cid, mid))
+            row[metric_label(mid)] = (passed, total)
+        overall = sum(1 for r in runs if all_passed(r, cid, metrics))
+        row["Overall"] = (overall, total)
+        rows.append(row)
+
+    columns = [metric_label(m) for m in metrics] + ["Overall"]
+    return conversations, columns, rows
+
+
+def md_cell(passed: int, total: int) -> str:
+    if passed == total:
+        return f"✅ {passed}/{total}"
+    if passed == 0:
+        return f"❌ {passed}/{total}"
+    return f"{passed}/{total}"
+
+
+def generate_details(
+    conversations: list[str],
+    json_runs: list[list[dict]],
+    csv_runs: list[list[dict]],
+    descriptions: dict[str, str],
+) -> str:
+    """Generate per-conversation detail sections with query, responses, and judge results."""
+    lines = []
+
+    for cid in conversations:
+        lines.append(f"## {cid}")
+        lines.append("")
+
+        desc = descriptions.get(cid)
+        if desc:
+            lines.append(desc)
+            lines.append("")
+
+        # Tags and query from first run
+        tags = None
+        query = None
+        for json_results in json_runs:
+            for r in json_results:
+                if r["conversation_group_id"] == cid and not tags:
+                    tags = r.get("tag", [])
+                    break
+        for csv_rows in csv_runs:
+            for row in csv_rows:
+                if row["conversation_group_id"] == cid and row.get("query"):
+                    query = row["query"]
+                    break
+            if query:
+                break
+
+        if tags:
+            lines.append(f"**Tags**: `{'`, `'.join(tags)}`")
+            lines.append("")
+
+        if query:
+            lines.append("### Query")
+            lines.append("")
+            lines.append("```")
+            lines.append(query.strip())
+            lines.append("```")
+            lines.append("")
+
+        for run_idx, (json_results, csv_rows) in enumerate(zip(json_runs, csv_runs), 1):
+            run_metrics = [r for r in json_results if r["conversation_group_id"] == cid]
+
+            lines.append(f"### Run {run_idx}")
+            lines.append("")
+
+            # Get response from CSV (same for all metrics in a turn)
+            response = None
+            for row in csv_rows:
+                if row["conversation_group_id"] == cid and row.get("response"):
+                    response = row["response"]
+                    break
+
+            if response:
+                lines.append("<details>")
+                lines.append("<summary>Response</summary>")
+                lines.append("")
+                lines.append(response.strip())
+                lines.append("")
+                lines.append("</details>")
+                lines.append("")
+
+            # Metric results from JSON
+            for r in run_metrics:
+                result_icon = "✅" if r["result"] == "PASS" else "❌"
+                score_str = f"{r['score']:.2f}" if r["score"] is not None else "N/A"
+                lines.append(
+                    f"**{metric_label(r['metric_identifier'])}**: "
+                    f"{result_icon} {r['result']} (score: {score_str})"
+                )
+
+                if r.get("judge_scores"):
+                    for js in r["judge_scores"]:
+                        if js.get("reason"):
+                            lines.append("")
+                            lines.append(f"> {js['reason']}")
+
+                lines.append("")
+
+        lines.append("---")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def generate_judge_config(config: dict) -> str:
+    llm = config.get("llm", {})
+    if not llm:
+        return ""
+    lines = [
+        "## Judge LLM",
+        "",
+        f"- **Provider**: {llm.get('provider', 'N/A')}",
+        f"- **Model**: {llm.get('model', 'N/A')}",
+        f"- **Temperature**: {llm.get('temperature', 'N/A')}",
+        f"- **Max tokens**: {llm.get('max_tokens', 'N/A')}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def format_cell(value) -> str:
+    if isinstance(value, tuple):
+        return md_cell(value[0], value[1])
+    return str(value)
+
+
+def generate_markdown(
+    conversations: list[str],
+    columns: list[str],
+    rows: list[dict],
+    total_runs: int,
+    json_runs: list[list[dict]],
+    csv_runs: list[list[dict]],
+    config: dict,
+    descriptions: dict[str, str],
+) -> str:
+    header = "| Conversation | " + " | ".join(columns) + " |"
+    separator = "|---|" + "|".join("---" for _ in columns) + "|"
+    lines = [f"# Evaluation Summary ({total_runs} runs)", "", header, separator]
+    for cid, row in zip(conversations, rows):
+        cells = " | ".join(format_cell(row[c]) for c in columns)
+        lines.append(f"| {cid} | {cells} |")
+    lines.append("")
+
+    judge_config = generate_judge_config(config)
+    if judge_config:
+        lines.append(judge_config)
+
+    details = generate_details(conversations, json_runs, csv_runs, descriptions)
+    lines.append(details)
+
+    return "\n".join(lines)
+
+
+def colorize(passed: int, total: int) -> str:
+    value = f"{passed}/{total}"
+    if passed == total:
+        return f"{GREEN}{value}{RESET}"
+    if passed == 0:
+        return f"{RED}{value}{RESET}"
+    return value
+
+
+def cell_display(value) -> str:
+    if isinstance(value, tuple):
+        return f"{value[0]}/{value[1]}"
+    return str(value)
+
+
+def cell_colored(value) -> str:
+    if isinstance(value, tuple):
+        return colorize(value[0], value[1])
+    return str(value)
+
+
+def print_table(
+    conversations: list[str],
+    columns: list[str],
+    rows: list[dict],
+) -> None:
+    if not rows:
+        return
+
+    col_widths = [max(len("Conversation"), *(len(c) for c in conversations))]
+    for col in columns:
+        values = [cell_display(row[col]) for row in rows]
+        col_widths.append(max(len(col), *(len(v) for v in values)))
+
+    sep = "+-" + "-+-".join("-" * w for w in col_widths) + "-+"
+    header = "| " + " | ".join(
+        f"{h:<{w}}" for h, w in zip(["Conversation"] + columns, col_widths)
+    ) + " |"
+
+    print(sep)
+    print(header)
+    print(sep)
+    for cid, row in zip(conversations, rows):
+        cells = [f"{cid:<{col_widths[0]}}"]
+        for i, col in enumerate(columns):
+            plain = cell_display(row[col])
+            colored = cell_colored(row[col])
+            padding = col_widths[i + 1] - len(plain)
+            cells.append(f"{colored}{' ' * padding}")
+        print("| " + " | ".join(cells) + " |")
+    print(sep)
+
+
+def load_descriptions(evals_file: Path) -> dict[str, str]:
+    """Load conversation descriptions from evals.yaml."""
+    if not evals_file.exists():
+        return {}
+    with open(evals_file) as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, list):
+        return {}
+    return {
+        entry["conversation_group_id"]: entry.get("description", "")
+        for entry in data
+        if "conversation_group_id" in entry
+    }
+
+
+def main():
+    if len(sys.argv) < 4:
+        print(f"Usage: {sys.argv[0]} RESULTS_DIR EVALS_YAML JSON_FILE [JSON_FILE ...]")
+        sys.exit(1)
+
+    results_dir = Path(sys.argv[1])
+    evals_file = Path(sys.argv[2])
+    json_files = [Path(f) for f in sys.argv[3:]]
+
+    descriptions = load_descriptions(evals_file)
+    json_runs, config = load_json_data(json_files)
+    csv_runs = load_csv_data(json_files)
+    conversations, columns, rows = build_summary(json_runs)
+    total_runs = len(json_runs)
+
+    output = results_dir / "summary.md"
+    output.write_text(
+        generate_markdown(
+            conversations, columns, rows, total_runs, json_runs, csv_runs, config,
+            descriptions,
+        )
+    )
+
+    print()
+    print_table(conversations, columns, rows)
+    print()
+    print(f"Summary written to {output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add evaluation infrastructure for agentic OLS scenarios:
- agentic/Makefile with setup (lightspeed-eval venv) and evals targets
- agentic/api-failure/ with evals.yaml and system.yaml for the payments API failure scenario (openai, opus, gemini agents)
- scripts/run-agentic-evals.sh for running evals without OLS port-forwarding, with --runs N for repeated execution
- scripts/summarize-agentic-evals.py to parse results and generate summary.md with per-conversation pass rates, judge config, queries, responses, and judge comments
- .gitignore entry for timestamped results directories


Assisted-by: Claude Code:claude-opus-4-6