### PR TITLE
feat: add agentic eval suite for envvar missing eval

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -1,6 +1,6 @@
 SCRIPTS_DIR := $(realpath ../scripts)
 
-SUITES := api_failure networkpolicy
+SUITES := api_failure envvar-missing networkpolicy
 RUNS ?= 1
 
 .PHONY: setup evals

--- a/agentic/envvar-missing/cleanup.sh
+++ b/agentic/envvar-missing/cleanup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+
+oc delete -f "$FIXTURE_DIR/deployment.yaml" --ignore-not-found --wait=false
+oc delete namespace warehouse-ops --ignore-not-found
+
+echo "Cleanup complete: removed warehouse-ops namespace and resources"

--- a/agentic/envvar-missing/evals.yaml
+++ b/agentic/envvar-missing/evals.yaml
@@ -1,0 +1,134 @@
+- conversation_group_id: envvar_missing_analysis_openai
+  tag: agentic_envvar_missing
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Pod: order-fulfillment-daemon
+          Namespace: warehouse-ops
+          Status: CrashLoopBackOff
+          Description: The order-fulfillment-daemon pod is repeatedly crashing.
+
+          Investigate and identify the root cause
+        targetNamespaces:
+          - warehouse-ops
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The order-fulfillment-daemon pod is crashing because the
+        required environment variable DEPLOY_ENV is undefined or missing in the
+        deployment configuration. The container checks for this variable at
+        startup and exits with an error when it's not set. Fix: Add the
+        DEPLOY_ENV environment variable to the deployment spec.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: envvar_missing_analysis_anthropic
+  tag: agentic_envvar_missing
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Pod: order-fulfillment-daemon
+          Namespace: warehouse-ops
+          Status: CrashLoopBackOff
+          Description: The order-fulfillment-daemon pod is repeatedly crashing.
+
+          Investigate and identify the root cause
+        targetNamespaces:
+          - warehouse-ops
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The order-fulfillment-daemon pod is crashing because the
+        required environment variable DEPLOY_ENV is undefined or missing in the
+        deployment configuration. The container checks for this variable at
+        startup and exits with an error when it's not set. Fix: Add the
+        DEPLOY_ENV environment variable to the deployment spec.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: envvar_missing_analysis_gemini
+  tag: agentic_envvar_missing
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Pod: order-fulfillment-daemon
+          Namespace: warehouse-ops
+          Status: CrashLoopBackOff
+          Description: The order-fulfillment-daemon pod is repeatedly crashing.
+
+          Investigate and identify the root cause
+        targetNamespaces:
+          - warehouse-ops
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The order-fulfillment-daemon pod is crashing because the
+        required environment variable DEPLOY_ENV is undefined or missing in the
+        deployment configuration. The container checks for this variable at
+        startup and exits with an error when it's not set. Fix: Add the
+        DEPLOY_ENV environment variable to the deployment spec.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/envvar-missing/fixtures/deployment.yaml
+++ b/agentic/envvar-missing/fixtures/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: warehouse-ops
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: order-fulfillment-daemon
+  namespace: warehouse-ops
+  labels:
+    app: order-fulfillment-daemon
+    component: fulfillment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: order-fulfillment-daemon
+  template:
+    metadata:
+      labels:
+        app: order-fulfillment-daemon
+    spec:
+      containers:
+      - name: fulfillment-container
+        image: busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+        command: ["/bin/sh"]
+        args:
+        - -c
+        - |
+          if [ -z "${DEPLOY_ENV}" ]; then
+            echo "Environment variable DEPLOY_ENV is undefined"
+            exit 1
+          fi
+          while true; do echo hello; sleep 10; done
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+        resources:
+          requests:
+            cpu: "5m"
+            memory: "32Mi"

--- a/agentic/envvar-missing/setup.sh
+++ b/agentic/envvar-missing/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="warehouse-ops"
+APP="order-fulfillment-daemon"
+
+oc apply -f "$FIXTURE_DIR/deployment.yaml"
+
+# Wait for the pod to appear
+echo "Waiting for $APP pod to be created…"
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 60 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  POD=$(oc get pods -n "$NS" -l "app=$APP" -o name 2>/dev/null | head -1)
+  [ -n "$POD" ] && break
+  sleep 5
+done
+[ -n "${POD:-}" ] || { echo "$APP pod never appeared"; oc get pods -n "$NS"; exit 1; }
+
+# Wait for CrashLoopBackOff
+echo "Pod exists — waiting for CrashLoopBackOff…"
+oc wait --for=jsonpath='{.status.containerStatuses[0].state.waiting.reason}'=CrashLoopBackOff \
+  pod -l "app=$APP" -n "$NS" --timeout=300s
+
+echo "Setup complete: $APP is in CrashLoopBackOff state"

--- a/agentic/envvar-missing/system.yaml
+++ b/agentic/envvar-missing/system.yaml
@@ -1,0 +1,38 @@
+logging:
+  source_level: DEBUG
+
+core:
+  max_threads: 1
+  fail_on_invalid_data: true
+  skip_on_failure: false
+
+llm_pool:
+    models:
+      gpt-4.1:
+        provider: openai
+
+judge_panel:
+    judges:
+      - gpt-4.1
+
+agents:
+  enabled: true
+  default:
+    agent: eval_agent
+    agent_config:
+      timeout: 600
+  eval_agent:
+    type: proposal
+    namespace: openshift-lightspeed
+    auto_approve: true
+    cleanup_proposals: false
+    timeout: 600
+    poll_interval: 5
+
+storage:
+  - type: file
+    output_dir: ./eval_output
+    enabled_outputs: [csv, json]
+
+environment:
+  LITELLM_LOG: ERROR


### PR DESCRIPTION
Add a new envvar-missing scenario to the agentic evaluation suite that deploys an order-fulfillment-daemon pod with a missing DEPLOY_ENV environment variable, causing CrashLoopBackOff. The eval tests whether the AI agent can correctly diagnose the missing variable as the root cause.

Includes:
- Deployment fixture (warehouse-ops namespace, busybox container)
- Setup script that waits for CrashLoopBackOff state
- Cleanup script for namespace and resource removal
- Evaluation definitions for three LLM variants (OpenAI, Anthropic, Gemini)
- System configuration with proposal-based agent evaluation


Assisted-by: Claude Code:claude-opus-4-6