### PR TITLE
feat: add readiness_probe_diagnosis agentic eval scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -1,6 +1,6 @@
 SCRIPTS_DIR := $(realpath ../scripts)
 
-SUITES := api_failure networkpolicy
+SUITES ?= api_failure networkpolicy readiness_probe_diagnosis
 RUNS ?= 1
 
 .PHONY: setup evals

--- a/agentic/readiness_probe_diagnosis/cleanup.sh
+++ b/agentic/readiness_probe_diagnosis/cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="discovery-hub"
+
+echo "Removing readiness_probe_diagnosis scenario resources from namespace ${NS}…"
+oc delete pod catalog-index-service -n "$NS" --ignore-not-found
+
+oc delete namespace "$NS" --ignore-not-found
+echo "Cleanup complete — all readiness_probe_diagnosis scenario resources removed."

--- a/agentic/readiness_probe_diagnosis/evals.yaml
+++ b/agentic/readiness_probe_diagnosis/evals.yaml
@@ -1,0 +1,143 @@
+- conversation_group_id: readiness_probe_diagnosis_openai
+  tag: agentic_readiness_probe_diagnosis
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The catalog-index-service in the discovery-hub namespace appears to
+          be running but is not becoming Ready. The pod name resembles a
+          Kubernetes Service, but it is actually a Pod.
+
+          Investigate why catalog-index-service is not ready, identify the
+          root cause, and propose a fix.
+        targetNamespaces:
+          - discovery-hub
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the catalog-index-service pod is not ready because its
+        readiness probe is failing. The pod runs a busybox container with a
+        simple echo/sleep loop but has an HTTP readiness probe configured to
+        GET /healthz on port 9200. Since the container does not run an HTTP
+        server, nothing listens on port 9200, and the probe always fails
+        with connection refused. Fix: either add an HTTP server that responds
+        on port 9200, change the probe to an exec-based probe that matches
+        what the container actually runs, or remove the readiness probe.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: readiness_probe_diagnosis_anthropic
+  tag: agentic_readiness_probe_diagnosis
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The catalog-index-service in the discovery-hub namespace appears to
+          be running but is not becoming Ready. The pod name resembles a
+          Kubernetes Service, but it is actually a Pod.
+
+          Investigate why catalog-index-service is not ready, identify the
+          root cause, and propose a fix.
+        targetNamespaces:
+          - discovery-hub
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the catalog-index-service pod is not ready because its
+        readiness probe is failing. The pod runs a busybox container with a
+        simple echo/sleep loop but has an HTTP readiness probe configured to
+        GET /healthz on port 9200. Since the container does not run an HTTP
+        server, nothing listens on port 9200, and the probe always fails
+        with connection refused. Fix: either add an HTTP server that responds
+        on port 9200, change the probe to an exec-based probe that matches
+        what the container actually runs, or remove the readiness probe.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: readiness_probe_diagnosis_gemini
+  tag: agentic_readiness_probe_diagnosis
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The catalog-index-service in the discovery-hub namespace appears to
+          be running but is not becoming Ready. The pod name resembles a
+          Kubernetes Service, but it is actually a Pod.
+
+          Investigate why catalog-index-service is not ready, identify the
+          root cause, and propose a fix.
+        targetNamespaces:
+          - discovery-hub
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the catalog-index-service pod is not ready because its
+        readiness probe is failing. The pod runs a busybox container with a
+        simple echo/sleep loop but has an HTTP readiness probe configured to
+        GET /healthz on port 9200. Since the container does not run an HTTP
+        server, nothing listens on port 9200, and the probe always fails
+        with connection refused. Fix: either add an HTTP server that responds
+        on port 9200, change the probe to an exec-based probe that matches
+        what the container actually runs, or remove the readiness probe.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/readiness_probe_diagnosis/fixtures/manifest.yaml
+++ b/agentic/readiness_probe_diagnosis/fixtures/manifest.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: discovery-hub
+  labels:
+    purpose: eval-test
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: catalog-index-service
+  namespace: discovery-hub
+  labels:
+    app: catalog-index-service
+    tier: indexing
+  annotations:
+    eval/scenario: readiness-probe-diagnosis
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: indexer
+    image: busybox:1.36
+    command: ["sh", "-c", "while true; do echo 'Running...'; sleep 5; done"]
+    ports:
+    - containerPort: 9200
+      name: health
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+    readinessProbe:
+      httpGet:
+        path: /healthz
+        port: 9200
+      initialDelaySeconds: 2
+      periodSeconds: 4
+      failureThreshold: 2
+    resources:
+      requests:
+        cpu: "5m"
+        memory: "32Mi"
+      limits:
+        memory: "64Mi"

--- a/agentic/readiness_probe_diagnosis/setup.sh
+++ b/agentic/readiness_probe_diagnosis/setup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="discovery-hub"
+POD_NAME="catalog-index-service"
+
+echo "Applying readiness_probe_diagnosis scenario manifests in namespace ${NS}…"
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+echo "Waiting for readiness probe failure event (up to 60s)…"
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 60 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  EVENTS=$(oc get events -n "$NS" \
+    --field-selector "involvedObject.name=$POD_NAME,reason=Unhealthy" \
+    -o jsonpath='{.items[*].message}' 2>/dev/null || true)
+  if echo "$EVENTS" | grep -q "Readiness probe failed"; then
+    echo "Scenario readiness_probe_diagnosis ready — readiness probe failure event found (attempt ${ATTEMPT})"
+    exit 0
+  fi
+  [ $((ATTEMPT % 10)) -eq 0 ] && echo "  attempt ${ATTEMPT}/60 — waiting…"
+  sleep 1
+done
+
+echo "ERROR: Readiness probe failure not detected within 60s"
+oc describe pod "$POD_NAME" -n "$NS"
+oc get events -n "$NS" --sort-by='.lastTimestamp' | tail -15
+exit 1

--- a/agentic/readiness_probe_diagnosis/system.yaml
+++ b/agentic/readiness_probe_diagnosis/system.yaml
@@ -1,0 +1,38 @@
+logging:
+  source_level: DEBUG
+
+core:
+  max_threads: 1
+  fail_on_invalid_data: true
+  skip_on_failure: false
+
+llm_pool:
+    models:
+      gpt-4.1:
+        provider: openai
+
+judge_panel:
+    judges:
+      - gpt-4.1
+
+agents:
+  enabled: true
+  default:
+    agent: eval_agent
+    agent_config:
+      timeout: 600
+  eval_agent:
+    type: proposal
+    namespace: openshift-lightspeed
+    auto_approve: true
+    cleanup_proposals: false
+    timeout: 600
+    poll_interval: 5
+
+storage:
+  - type: file
+    output_dir: ./eval_output
+    enabled_outputs: [csv, json]
+
+environment:
+  LITELLM_LOG: ERROR


### PR DESCRIPTION
Migrate the readiness_probe_diagnosis scenario from lightspeed-service into the agentic eval suite. The scenario deploys a pod named catalog-index-service (deliberately resembling a Service name) with a failing HTTP readiness probe — the busybox container has no HTTP server on port 9200.

Also change SUITES assignment to ?= so individual suites can be run via make evals SUITES=readiness_probe_diagnosis.


Assisted-by: Claude Code:claude-opus-4-6