### PR TITLE
feat: add scheduled_outage_detection agentic eval

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -1,6 +1,6 @@
 SCRIPTS_DIR := $(realpath ../scripts)
 
-SUITES := api_failure networkpolicy
+SUITES ?= api_failure networkpolicy scheduled_outage_detection
 RUNS ?= 1
 
 .PHONY: setup evals

--- a/agentic/scheduled_outage_detection/cleanup.sh
+++ b/agentic/scheduled_outage_detection/cleanup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="analytics-platform"
+
+echo "Removing scheduled_outage_detection scenario resources from namespace ${NS}…"
+oc delete statefulset report-generator -n "$NS" --ignore-not-found --wait=false
+oc delete secret report-generator-logs-script -n "$NS" --ignore-not-found
+
+oc delete namespace "$NS" --ignore-not-found
+echo "Cleanup complete — all scheduled_outage_detection scenario resources removed."

--- a/agentic/scheduled_outage_detection/evals.yaml
+++ b/agentic/scheduled_outage_detection/evals.yaml
@@ -1,0 +1,140 @@
+- conversation_group_id: scheduled_outage_detection_openai
+  tag: agentic_scheduled_outage_detection
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The report-generator in the analytics-platform namespace is
+          processing historical records. Analyze the pod logs to identify
+          any issues that occurred between 03:00 and 04:00.
+
+          Investigate the root cause and determine whether this is a
+          recurring pattern or an isolated incident.
+        targetNamespaces:
+          - analytics-platform
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the report-generator pod experienced repeated failures
+        during the 03:00-03:05 window. The errors show "upstream unreachable"
+        with timeout connecting to https://reports-upstream.internal/v2/ingest.
+        This is consistent with a scheduled maintenance window on the upstream
+        API. Outside this window the report-generator operates normally,
+        completing report batches successfully. The failures are time-bounded
+        and not caused by a bug in the report-generator itself.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: scheduled_outage_detection_anthropic
+  tag: agentic_scheduled_outage_detection
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The report-generator in the analytics-platform namespace is
+          processing historical records. Analyze the pod logs to identify
+          any issues that occurred between 03:00 and 04:00.
+
+          Investigate the root cause and determine whether this is a
+          recurring pattern or an isolated incident.
+        targetNamespaces:
+          - analytics-platform
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the report-generator pod experienced repeated failures
+        during the 03:00-03:05 window. The errors show "upstream unreachable"
+        with timeout connecting to https://reports-upstream.internal/v2/ingest.
+        This is consistent with a scheduled maintenance window on the upstream
+        API. Outside this window the report-generator operates normally,
+        completing report batches successfully. The failures are time-bounded
+        and not caused by a bug in the report-generator itself.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: scheduled_outage_detection_gemini
+  tag: agentic_scheduled_outage_detection
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The report-generator in the analytics-platform namespace is
+          processing historical records. Analyze the pod logs to identify
+          any issues that occurred between 03:00 and 04:00.
+
+          Investigate the root cause and determine whether this is a
+          recurring pattern or an isolated incident.
+        targetNamespaces:
+          - analytics-platform
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the report-generator pod experienced repeated failures
+        during the 03:00-03:05 window. The errors show "upstream unreachable"
+        with timeout connecting to https://reports-upstream.internal/v2/ingest.
+        This is consistent with a scheduled maintenance window on the upstream
+        API. Outside this window the report-generator operates normally,
+        completing report batches successfully. The failures are time-bounded
+        and not caused by a bug in the report-generator itself.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/scheduled_outage_detection/fixtures/generate_logs.py
+++ b/agentic/scheduled_outage_detection/fixtures/generate_logs.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Generate report-generator logs with a failure window between 03:00-03:05."""
+
+import random
+import sys
+import time
+from datetime import datetime, timedelta
+
+TICK = timedelta(seconds=10)
+FAILURE_START_HOUR = 3
+FAILURE_START_MIN = 0
+FAILURE_END_MIN = 5
+API_URL = "https://reports-upstream.internal/v2/ingest"
+
+
+def ts(dt):
+    """Format a datetime as an ISO 8601 timestamp with millisecond precision."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def in_failure_window(dt):
+    """Return True if dt falls within the 03:00-03:05 failure window."""
+    return (
+        dt.hour == FAILURE_START_HOUR
+        and FAILURE_START_MIN <= dt.minute <= FAILURE_END_MIN
+    )
+
+
+def emit(dt, level, msg, **extra):
+    """Print a structured log line for the report-generator component."""
+    parts = [
+        f"ts={ts(dt)}",
+        f"level={level}",
+        "component=report-generator",
+        f"msg={msg}",
+    ]
+    for k, v in extra.items():
+        parts.append(f"{k}={v}")
+    print(" ".join(parts))
+
+
+def run():
+    """Generate report-generator logs spanning 24 hours with a failure window."""
+    now = datetime.utcnow()
+    two_days_ago = now - timedelta(days=2)
+    cursor = two_days_ago - timedelta(hours=24)
+    iteration = 0
+    warning_emitted = False
+
+    while cursor < two_days_ago:
+        if in_failure_window(cursor):
+            emit(
+                cursor,
+                "ERROR",
+                "Report generation failed",
+                reason="upstream unreachable",
+                url=API_URL,
+                err="timeout after 5000ms",
+            )
+
+            if not warning_emitted:
+                warning_emitted = True
+                print(
+                    f"ts={ts(cursor)} level=WARN component=report-generator "
+                    f"msg=Detected repeated failures during 03:00-03:05 window "
+                    f"hint=possible scheduled maintenance upstream"
+                )
+        else:
+            duration = random.randint(80, 420)  # noqa: S311
+            emit(
+                cursor,
+                "INFO",
+                f"Report batch completed in {duration}ms",
+                rows=random.randint(50, 9000),  # noqa: S311
+            )
+
+        if iteration % 90 == 0:
+            emit(
+                cursor,
+                "INFO",
+                "System health check passed",
+                latency_ms=random.randint(1, 12),  # noqa: S311
+            )
+
+        cursor += TICK
+        if random.random() < 0.08:  # noqa: S311
+            cursor += timedelta(seconds=random.randint(1, 4))  # noqa: S311
+        iteration += 1
+
+    # sentinel so setup.sh knows logs are fully written
+    cursor += timedelta(seconds=random.randint(1, 5))  # noqa: S311
+    emit(cursor, "INFO", "Job executed successfully in 167ms.", final="true")
+    sys.stdout.flush()
+
+    while True:
+        time.sleep(3600)
+
+
+if __name__ == "__main__":
+    run()

--- a/agentic/scheduled_outage_detection/fixtures/manifest.yaml
+++ b/agentic/scheduled_outage_detection/fixtures/manifest.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: analytics-platform
+  labels:
+    purpose: eval-test
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: report-generator
+  namespace: analytics-platform
+  labels:
+    app: report-generator
+    tier: analytics
+spec:
+  serviceName: report-generator
+  replicas: 1
+  selector:
+    matchLabels:
+      app: report-generator
+  template:
+    metadata:
+      labels:
+        app: report-generator
+        tier: analytics
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: generator
+        image: python:3.11-alpine
+        command: ["python3", "-u", "/opt/scripts/generate_logs.py"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+        - name: log-scripts
+          mountPath: /opt/scripts
+          readOnly: true
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "48Mi"
+          limits:
+            memory: "128Mi"
+      volumes:
+      - name: log-scripts
+        secret:
+          secretName: report-generator-logs-script
+          defaultMode: 0555

--- a/agentic/scheduled_outage_detection/setup.sh
+++ b/agentic/scheduled_outage_detection/setup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="analytics-platform"
+APP="report-generator"
+
+echo "Applying scheduled_outage_detection scenario manifests in namespace ${NS}…"
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+oc create secret generic report-generator-logs-script \
+  --from-file=generate_logs.py="$FIXTURE_DIR/generate_logs.py" \
+  -n "$NS" --dry-run=client -o yaml | oc apply -f -
+
+logs_ready() {
+  local logs
+  logs=$(oc logs -l "app=$APP" -n "$NS" --tail=10000 2>/dev/null || true)
+  echo "$logs" | grep "Detected repeated failures during 03:00-03:05 window" >/dev/null || return 1
+  echo "$logs" | grep "System health check passed" >/dev/null || return 1
+  echo "$logs" | grep "Job executed successfully in 167ms\." >/dev/null || return 1
+}
+
+echo "Waiting for log sentinels (up to 120s)…"
+ATTEMPT=0
+until logs_ready; do
+  ATTEMPT=$((ATTEMPT + 1))
+  if [ "$ATTEMPT" -ge 40 ]; then
+    echo "ERROR: Sentinels not found after 40 checks"
+    oc get pods -n "$NS"
+    exit 1
+  fi
+  [ $((ATTEMPT % 10)) -eq 0 ] && echo "  attempt ${ATTEMPT}/40 — waiting…"
+  sleep 3
+done
+echo "Scenario scheduled_outage_detection ready — all log sentinels present (attempt ${ATTEMPT})"

--- a/agentic/scheduled_outage_detection/system.yaml
+++ b/agentic/scheduled_outage_detection/system.yaml
@@ -1,0 +1,38 @@
+logging:
+  source_level: DEBUG
+
+core:
+  max_threads: 1
+  fail_on_invalid_data: true
+  skip_on_failure: false
+
+llm_pool:
+    models:
+      gpt-4.1:
+        provider: openai
+
+judge_panel:
+    judges:
+      - gpt-4.1
+
+agents:
+  enabled: true
+  default:
+    agent: eval_agent
+    agent_config:
+      timeout: 600
+  eval_agent:
+    type: proposal
+    namespace: openshift-lightspeed
+    auto_approve: true
+    cleanup_proposals: false
+    timeout: 600
+    poll_interval: 5
+
+storage:
+  - type: file
+    output_dir: ./eval_output
+    enabled_outputs: [csv, json]
+
+environment:
+  LITELLM_LOG: ERROR


### PR DESCRIPTION
Migrate the scheduled_outage_detection scenario from lightspeed-service. A StatefulSet runs a Python log generator producing 24h of structured logs with ERROR failures in a 03:00-03:05 window, simulating upstream scheduled maintenance.


Assisted-by: Claude Code:claude-opus-4-6