### PR TITLE
feat: add ingress_rule_mismatch agentic eval

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -1,6 +1,6 @@
 SCRIPTS_DIR := $(realpath ../scripts)
 
-SUITES := api_failure networkpolicy
+SUITES ?= api_failure networkpolicy ingress_rule_mismatch
 RUNS ?= 1
 
 .PHONY: setup evals

--- a/agentic/ingress_rule_mismatch/cleanup.sh
+++ b/agentic/ingress_rule_mismatch/cleanup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="platform-core"
+
+echo "Removing ingress_rule_mismatch scenario resources from namespace ${NS}…"
+oc delete deployment web-portal -n "$NS" --ignore-not-found
+oc delete deployment api-gateway -n "$NS" --ignore-not-found
+oc delete svc api-gateway-svc -n "$NS" --ignore-not-found
+oc delete networkpolicy restrict-api-gateway-ingress -n "$NS" --ignore-not-found
+
+oc delete namespace "$NS" --ignore-not-found
+echo "Cleanup complete — all ingress_rule_mismatch scenario resources removed."

--- a/agentic/ingress_rule_mismatch/evals.yaml
+++ b/agentic/ingress_rule_mismatch/evals.yaml
@@ -1,0 +1,143 @@
+- conversation_group_id: ingress_rule_mismatch_openai
+  tag: agentic_ingress_rule_mismatch
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The web-portal application in the platform-core namespace is
+          getting timeouts when trying to connect to the api-gateway
+          service. The api-gateway pod itself appears to be running and
+          healthy.
+
+          Investigate why web-portal cannot reach api-gateway-svc and
+          identify the root cause.
+        targetNamespaces:
+          - platform-core
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the restrict-api-gateway-ingress NetworkPolicy on
+        api-gateway only allows ingress from pods with label tier=backend,
+        but the web-portal pod has label tier=frontend. This causes all
+        traffic from web-portal to api-gateway-svc on port 8080 to be
+        blocked. Fix: update the NetworkPolicy ingress rule to allow pods
+        with tier=frontend (or app=web-portal), or relabel the web-portal
+        pod to tier=backend.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: ingress_rule_mismatch_anthropic
+  tag: agentic_ingress_rule_mismatch
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The web-portal application in the platform-core namespace is
+          getting timeouts when trying to connect to the api-gateway
+          service. The api-gateway pod itself appears to be running and
+          healthy.
+
+          Investigate why web-portal cannot reach api-gateway-svc and
+          identify the root cause.
+        targetNamespaces:
+          - platform-core
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the restrict-api-gateway-ingress NetworkPolicy on
+        api-gateway only allows ingress from pods with label tier=backend,
+        but the web-portal pod has label tier=frontend. This causes all
+        traffic from web-portal to api-gateway-svc on port 8080 to be
+        blocked. Fix: update the NetworkPolicy ingress rule to allow pods
+        with tier=frontend (or app=web-portal), or relabel the web-portal
+        pod to tier=backend.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: ingress_rule_mismatch_gemini
+  tag: agentic_ingress_rule_mismatch
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The web-portal application in the platform-core namespace is
+          getting timeouts when trying to connect to the api-gateway
+          service. The api-gateway pod itself appears to be running and
+          healthy.
+
+          Investigate why web-portal cannot reach api-gateway-svc and
+          identify the root cause.
+        targetNamespaces:
+          - platform-core
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the restrict-api-gateway-ingress NetworkPolicy on
+        api-gateway only allows ingress from pods with label tier=backend,
+        but the web-portal pod has label tier=frontend. This causes all
+        traffic from web-portal to api-gateway-svc on port 8080 to be
+        blocked. Fix: update the NetworkPolicy ingress rule to allow pods
+        with tier=frontend (or app=web-portal), or relabel the web-portal
+        pod to tier=backend.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/ingress_rule_mismatch/fixtures/api-gateway.yaml
+++ b/agentic/ingress_rule_mismatch/fixtures/api-gateway.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: platform-core
+  labels:
+    purpose: eval-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  namespace: platform-core
+  labels:
+    app: api-gateway
+    tier: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-gateway
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+        tier: backend
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: http-backend
+        image: nginxinc/nginx-unprivileged:alpine
+        ports:
+        - containerPort: 8080
+          name: http
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "15m"
+            memory: "48Mi"
+          limits:
+            cpu: "100m"
+            memory: "96Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway-svc
+  namespace: platform-core
+spec:
+  selector:
+    app: api-gateway
+  ports:
+  - port: 8080
+    targetPort: 8080
+    name: http
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: restrict-api-gateway-ingress
+  namespace: platform-core
+spec:
+  podSelector:
+    matchLabels:
+      app: api-gateway
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          tier: backend
+    ports:
+    - protocol: TCP
+      port: 8080

--- a/agentic/ingress_rule_mismatch/fixtures/web-portal.yaml
+++ b/agentic/ingress_rule_mismatch/fixtures/web-portal.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-portal
+  namespace: platform-core
+  labels:
+    app: web-portal
+    tier: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-portal
+  template:
+    metadata:
+      labels:
+        app: web-portal
+        tier: frontend
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: portal
+        image: alpine:3.19
+        command: ["sh"]
+        args:
+        - -c
+        - |
+          apk add --no-cache curl >/dev/null 2>&1
+          while true; do
+            echo "[portal] probing api-gateway-svc on port 8080…"
+            if curl -sf --connect-timeout 5 http://api-gateway-svc:8080/ >/dev/null 2>&1; then
+              echo "[portal] api-gateway-svc responded OK"
+            else
+              echo "ERROR: Connection timeout to api-gateway-svc!"
+            fi
+            sleep 10
+          done
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "5m"
+            memory: "32Mi"
+          limits:
+            memory: "48Mi"

--- a/agentic/ingress_rule_mismatch/setup.sh
+++ b/agentic/ingress_rule_mismatch/setup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="platform-core"
+
+echo "Applying ingress_rule_mismatch scenario manifests in namespace ${NS}…"
+oc apply -f "$FIXTURE_DIR/api-gateway.yaml"
+
+echo "Waiting for api-gateway deployment to be ready…"
+oc wait --for=condition=available deployment/api-gateway -n "$NS" --timeout=60s
+
+oc apply -f "$FIXTURE_DIR/web-portal.yaml"
+
+echo "Waiting for web-portal to report connection timeout (up to 60s)…"
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 30 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  if oc logs -l app=web-portal -n "$NS" --tail=20 2>/dev/null \
+     | grep -q "ERROR: Connection timeout to api-gateway-svc!"; then
+    echo "Scenario ingress_rule_mismatch ready — timeout error detected (attempt ${ATTEMPT})"
+    exit 0
+  fi
+  [ $((ATTEMPT % 10)) -eq 0 ] && echo "  attempt ${ATTEMPT}/30 — waiting…"
+  sleep 2
+done
+
+echo "ERROR: Connection timeout error not found within 60s"
+oc get pods -n "$NS"
+oc logs -l app=web-portal -n "$NS" --tail=10 2>/dev/null || true
+exit 1

--- a/agentic/ingress_rule_mismatch/system.yaml
+++ b/agentic/ingress_rule_mismatch/system.yaml
@@ -1,0 +1,38 @@
+logging:
+  source_level: DEBUG
+
+core:
+  max_threads: 1
+  fail_on_invalid_data: true
+  skip_on_failure: false
+
+llm_pool:
+    models:
+      gpt-4.1:
+        provider: openai
+
+judge_panel:
+    judges:
+      - gpt-4.1
+
+agents:
+  enabled: true
+  default:
+    agent: eval_agent
+    agent_config:
+      timeout: 600
+  eval_agent:
+    type: proposal
+    namespace: openshift-lightspeed
+    auto_approve: true
+    cleanup_proposals: false
+    timeout: 600
+    poll_interval: 5
+
+storage:
+  - type: file
+    output_dir: ./eval_output
+    enabled_outputs: [csv, json]
+
+environment:
+  LITELLM_LOG: ERROR


### PR DESCRIPTION
Migrate the ingress_rule_mismatch scenario from
lightspeed-service. A NetworkPolicy on api-gateway only allows ingress from tier=backend, blocking web-portal (tier=frontend).


Assisted-by: Claude Code:claude-opus-4-6