### PR TITLE
feat: add agentic eval suite for storage-binding scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -1,6 +1,6 @@
 SCRIPTS_DIR := $(realpath ../scripts)
 
-SUITES := api_failure envvar-missing networkpolicy
+SUITES := api_failure envvar-missing networkpolicy storage-binding
 RUNS ?= 1
 
 .PHONY: setup evals

--- a/agentic/storage-binding/cleanup.sh
+++ b/agentic/storage-binding/cleanup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="cache-tier"
+
+oc delete pvc memcached-data-pvc -n "$NS" --ignore-not-found
+oc delete deployment memcached -n "$NS" --ignore-not-found
+oc delete svc memcached -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found
+
+echo "Cleanup complete: removed cache-tier namespace and resources"

--- a/agentic/storage-binding/evals.yaml
+++ b/agentic/storage-binding/evals.yaml
@@ -1,0 +1,140 @@
+- conversation_group_id: storage_binding_analysis_openai
+  tag: agentic_storage_binding
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          PVC: memcached-data-pvc
+          Namespace: cache-tier
+          Status: Pending
+          Description: The memcached-data-pvc PersistentVolumeClaim is stuck in
+          Pending state and the memcached deployment pods cannot start.
+
+          Investigate and identify the root cause
+        targetNamespaces:
+          - cache-tier
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The memcached-data-pvc PersistentVolumeClaim is stuck in
+        Pending state because it references a StorageClass named "standard-v2"
+        that does not exist in the cluster. The PVC cannot be provisioned
+        without a valid StorageClass. Fix: Update the PVC storageClassName to
+        an available StorageClass in the cluster (e.g. gp2, gp3-csi) or
+        create the missing "standard-v2" StorageClass.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: storage_binding_analysis_anthropic
+  tag: agentic_storage_binding
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          PVC: memcached-data-pvc
+          Namespace: cache-tier
+          Status: Pending
+          Description: The memcached-data-pvc PersistentVolumeClaim is stuck in
+          Pending state and the memcached deployment pods cannot start.
+
+          Investigate and identify the root cause
+        targetNamespaces:
+          - cache-tier
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The memcached-data-pvc PersistentVolumeClaim is stuck in
+        Pending state because it references a StorageClass named "standard-v2"
+        that does not exist in the cluster. The PVC cannot be provisioned
+        without a valid StorageClass. Fix: Update the PVC storageClassName to
+        an available StorageClass in the cluster (e.g. gp2, gp3-csi) or
+        create the missing "standard-v2" StorageClass.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: storage_binding_analysis_gemini
+  tag: agentic_storage_binding
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          PVC: memcached-data-pvc
+          Namespace: cache-tier
+          Status: Pending
+          Description: The memcached-data-pvc PersistentVolumeClaim is stuck in
+          Pending state and the memcached deployment pods cannot start.
+
+          Investigate and identify the root cause
+        targetNamespaces:
+          - cache-tier
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The memcached-data-pvc PersistentVolumeClaim is stuck in
+        Pending state because it references a StorageClass named "standard-v2"
+        that does not exist in the cluster. The PVC cannot be provisioned
+        without a valid StorageClass. Fix: Update the PVC storageClassName to
+        an available StorageClass in the cluster (e.g. gp2, gp3-csi) or
+        create the missing "standard-v2" StorageClass.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/storage-binding/fixtures/manifest.yaml
+++ b/agentic/storage-binding/fixtures/manifest.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cache-tier
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: memcached-data-pvc
+  namespace: cache-tier
+  labels:
+    app: memcached
+spec:
+  storageClassName: standard-v2
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: memcached
+  namespace: cache-tier
+spec:
+  type: ClusterIP
+  selector:
+    app: memcached
+  ports:
+  - name: mc
+    port: 11211
+    targetPort: mc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: memcached
+  namespace: cache-tier
+  labels:
+    app: memcached
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: memcached
+  template:
+    metadata:
+      labels:
+        app: memcached
+    spec:
+      initContainers:
+      - name: init-perms
+        image: busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+        command: ["sh", "-c", "chmod 777 /cache"]
+        volumeMounts:
+        - name: cache-vol
+          mountPath: /cache
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+      containers:
+      - name: mc
+        image: memcached:1.6-alpine@sha256:c29847751abb41f4c268c84fb3087fee05d4edcbda44409ccb5086e26148e8a7
+        args: ["-m", "128", "-p", "11211", "-u", "memcache", "-v"]
+        ports:
+        - containerPort: 11211
+          name: mc
+        volumeMounts:
+        - name: cache-vol
+          mountPath: /cache
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "192Mi"
+          limits:
+            cpu: "200m"
+            memory: "384Mi"
+      volumes:
+      - name: cache-vol
+        persistentVolumeClaim:
+          claimName: memcached-data-pvc

--- a/agentic/storage-binding/setup.sh
+++ b/agentic/storage-binding/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="cache-tier"
+PVC="memcached-data-pvc"
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+# Wait for ProvisioningFailed event on the PVC
+echo "Waiting for ProvisioningFailed event on $PVC…"
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 60 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  STATUS=$(oc get events -n "$NS" \
+    --field-selector "involvedObject.name=$PVC,involvedObject.kind=PersistentVolumeClaim" \
+    -o jsonpath='{.items[*].reason}' 2>/dev/null || true)
+  if echo "$STATUS" | grep -q "ProvisioningFailed"; then
+    echo "Setup complete: ProvisioningFailed event detected (attempt $ATTEMPT)"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "ProvisioningFailed event not detected within 60s"
+oc describe pvc "$PVC" -n "$NS"
+exit 1

--- a/agentic/storage-binding/system.yaml
+++ b/agentic/storage-binding/system.yaml
@@ -1,0 +1,38 @@
+logging:
+  source_level: DEBUG
+
+core:
+  max_threads: 1
+  fail_on_invalid_data: true
+  skip_on_failure: false
+
+llm_pool:
+    models:
+      gpt-4.1:
+        provider: openai
+
+judge_panel:
+    judges:
+      - gpt-4.1
+
+agents:
+  enabled: true
+  default:
+    agent: eval_agent
+    agent_config:
+      timeout: 600
+  eval_agent:
+    type: proposal
+    namespace: openshift-lightspeed
+    auto_approve: true
+    cleanup_proposals: false
+    timeout: 600
+    poll_interval: 5
+
+storage:
+  - type: file
+    output_dir: ./eval_output
+    enabled_outputs: [csv, json]
+
+environment:
+  LITELLM_LOG: ERROR


### PR DESCRIPTION
Deploy a memcached pod with a PVC referencing a non-existent "standard-v2" StorageClass in the cache-tier namespace. The PVC stays Pending, blocking the deployment.

Evaluates three LLM agents (OpenAI, Anthropic, Gemini) on their ability to identify the missing StorageClass as root cause.


Assisted-by: Claude Code:claude-opus-4-6