### PR TITLE
feat: add agentic eval suite for namespace_pod_count scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -1,6 +1,6 @@
 SCRIPTS_DIR := $(realpath ../scripts)
 
-SUITES ?= failing_api blocking_networkpolicy misconfigured_readiness_probe missing_envvar scheduled_outage pending_pvc
+SUITES ?= failing_api blocking_networkpolicy misconfigured_readiness_probe missing_envvar scheduled_outage pending_pvc namespace_pod_count
 RUNS ?= 1
 
 .PHONY: setup evals cleanup help

--- a/agentic/namespace_pod_count/cleanup.sh
+++ b/agentic/namespace_pod_count/cleanup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+
+oc delete -f "$FIXTURE_DIR/manifests.yaml" --ignore-not-found --wait=false
+oc delete namespace fleet-alpha fleet-alpha1 --ignore-not-found
+
+echo "Cleanup complete: removed fleet-alpha and fleet-alpha1 namespaces and resources"

--- a/agentic/namespace_pod_count/evals.yaml
+++ b/agentic/namespace_pod_count/evals.yaml
@@ -1,0 +1,143 @@
+- conversation_group_id: namespace_pod_count_openai
+  tag: agentic_namespace_pod_count
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Namespaces: fleet-alpha, fleet-alpha1
+          Description: We expect both namespaces to have the same number of
+          running pods, but they appear to have different counts. Investigate
+          and report the pod counts in each namespace and identify any
+          discrepancy.
+
+          Investigate and identify the root cause
+        targetNamespaces:
+          - fleet-alpha
+          - fleet-alpha1
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The fleet-alpha namespace has 6 running pods while
+        fleet-alpha1 has 9 running pods. The namespaces have a pod count
+        discrepancy — fleet-alpha1 has 3 more pods than fleet-alpha.
+        The additional workloads in fleet-alpha1 are store-primary,
+        store-replica, cache-handler, proxy-router, validator-east, and
+        validator-west (9 deployments) compared to fleet-alpha which has
+        2 deployments and 4 standalone pods (6 total).
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: namespace_pod_count_anthropic
+  tag: agentic_namespace_pod_count
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Namespaces: fleet-alpha, fleet-alpha1
+          Description: We expect both namespaces to have the same number of
+          running pods, but they appear to have different counts. Investigate
+          and report the pod counts in each namespace and identify any
+          discrepancy.
+
+          Investigate and identify the root cause
+        targetNamespaces:
+          - fleet-alpha
+          - fleet-alpha1
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The fleet-alpha namespace has 6 running pods while
+        fleet-alpha1 has 9 running pods. The namespaces have a pod count
+        discrepancy — fleet-alpha1 has 3 more pods than fleet-alpha.
+        The additional workloads in fleet-alpha1 are store-primary,
+        store-replica, cache-handler, proxy-router, validator-east, and
+        validator-west (9 deployments) compared to fleet-alpha which has
+        2 deployments and 4 standalone pods (6 total).
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: namespace_pod_count_gemini
+  tag: agentic_namespace_pod_count
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Namespaces: fleet-alpha, fleet-alpha1
+          Description: We expect both namespaces to have the same number of
+          running pods, but they appear to have different counts. Investigate
+          and report the pod counts in each namespace and identify any
+          discrepancy.
+
+          Investigate and identify the root cause
+        targetNamespaces:
+          - fleet-alpha
+          - fleet-alpha1
+        tools:
+          skills:
+            - image: quay.io/afalossi/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The fleet-alpha namespace has 6 running pods while
+        fleet-alpha1 has 9 running pods. The namespaces have a pod count
+        discrepancy — fleet-alpha1 has 3 more pods than fleet-alpha.
+        The additional workloads in fleet-alpha1 are store-primary,
+        store-replica, cache-handler, proxy-router, validator-east, and
+        validator-west (9 deployments) compared to fleet-alpha which has
+        2 deployments and 4 standalone pods (6 total).
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/namespace_pod_count/fixtures/manifests.yaml
+++ b/agentic/namespace_pod_count/fixtures/manifests.yaml
@@ -1,0 +1,422 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fleet-alpha
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fleet-alpha1
+---
+# --- fleet-alpha: 6 workloads (mix of Pods and Deployments) ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dispatcher-north
+  namespace: fleet-alpha
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: dispatcher-north
+  template:
+    metadata:
+      labels:
+        unit: dispatcher-north
+    spec:
+      containers:
+        - name: runner
+          image: nginxinc/nginx-unprivileged:alpine@sha256:6320020c7da8714feab524e02c08c5a1958675c4e68700e93a2fd8970b065786
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: "5m"
+              memory: "16Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dispatcher-south
+  namespace: fleet-alpha
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: dispatcher-south
+  template:
+    metadata:
+      labels:
+        unit: dispatcher-south
+    spec:
+      containers:
+        - name: runner
+          image: nginxinc/nginx-unprivileged:alpine@sha256:6320020c7da8714feab524e02c08c5a1958675c4e68700e93a2fd8970b065786
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: "5m"
+              memory: "16Mi"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tracker-primary
+  namespace: fleet-alpha
+spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: nginx
+      image: nginxinc/nginx-unprivileged:alpine@sha256:6320020c7da8714feab524e02c08c5a1958675c4e68700e93a2fd8970b065786
+      securityContext:
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+      resources:
+        requests:
+          cpu: "5m"
+          memory: "16Mi"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tracker-secondary
+  namespace: fleet-alpha
+spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: nginx
+      image: nginxinc/nginx-unprivileged:alpine@sha256:6320020c7da8714feab524e02c08c5a1958675c4e68700e93a2fd8970b065786
+      securityContext:
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+      resources:
+        requests:
+          cpu: "5m"
+          memory: "16Mi"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: scheduler-main
+  namespace: fleet-alpha
+spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: nginx
+      image: nginxinc/nginx-unprivileged:alpine@sha256:6320020c7da8714feab524e02c08c5a1958675c4e68700e93a2fd8970b065786
+      securityContext:
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+      resources:
+        requests:
+          cpu: "5m"
+          memory: "16Mi"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: logger-central
+  namespace: fleet-alpha
+spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: nginx
+      image: nginxinc/nginx-unprivileged:alpine@sha256:6320020c7da8714feab524e02c08c5a1958675c4e68700e93a2fd8970b065786
+      securityContext:
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+      resources:
+        requests:
+          cpu: "5m"
+          memory: "16Mi"
+---
+# --- fleet-alpha1: 9 workloads (Deployments only) ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingestion-node
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: ingestion-node
+  template:
+    metadata:
+      labels:
+        unit: ingestion-node
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine@sha256:6320020c7da8714feab524e02c08c5a1958675c4e68700e93a2fd8970b065786
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: "5m"
+              memory: "16Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: transform-node
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: transform-node
+  template:
+    metadata:
+      labels:
+        unit: transform-node
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine@sha256:6320020c7da8714feab524e02c08c5a1958675c4e68700e93a2fd8970b065786
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: "5m"
+              memory: "16Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: output-node
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: output-node
+  template:
+    metadata:
+      labels:
+        unit: output-node
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine@sha256:6320020c7da8714feab524e02c08c5a1958675c4e68700e93a2fd8970b065786
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: "5m"
+              memory: "16Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: validator-east
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: validator-east
+  template:
+    metadata:
+      labels:
+        unit: validator-east
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine@sha256:6320020c7da8714feab524e02c08c5a1958675c4e68700e93a2fd8970b065786
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: "5m"
+              memory: "16Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: validator-west
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: validator-west
+  template:
+    metadata:
+      labels:
+        unit: validator-west
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine@sha256:6320020c7da8714feab524e02c08c5a1958675c4e68700e93a2fd8970b065786
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: "5m"
+              memory: "16Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: store-primary
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: store-primary
+  template:
+    metadata:
+      labels:
+        unit: store-primary
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine@sha256:6320020c7da8714feab524e02c08c5a1958675c4e68700e93a2fd8970b065786
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: "5m"
+              memory: "16Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: store-replica
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: store-replica
+  template:
+    metadata:
+      labels:
+        unit: store-replica
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine@sha256:6320020c7da8714feab524e02c08c5a1958675c4e68700e93a2fd8970b065786
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: "5m"
+              memory: "16Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cache-handler
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: cache-handler
+  template:
+    metadata:
+      labels:
+        unit: cache-handler
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine@sha256:6320020c7da8714feab524e02c08c5a1958675c4e68700e93a2fd8970b065786
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: "5m"
+              memory: "16Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy-router
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: proxy-router
+  template:
+    metadata:
+      labels:
+        unit: proxy-router
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine@sha256:6320020c7da8714feab524e02c08c5a1958675c4e68700e93a2fd8970b065786
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: "5m"
+              memory: "16Mi"

--- a/agentic/namespace_pod_count/setup.sh
+++ b/agentic/namespace_pod_count/setup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS_A="fleet-alpha"
+NS_B="fleet-alpha1"
+EXPECTED_A=6
+EXPECTED_B=9
+
+oc apply -f "$FIXTURE_DIR/manifests.yaml"
+
+# Wait for all pods to reach Running in both namespaces
+echo "Waiting for pods to reach Running state…"
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 20 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  COUNT_A=$(oc get pods -n "$NS_A" --no-headers --field-selector=status.phase=Running 2>/dev/null | wc -l | tr -d ' ')
+  COUNT_B=$(oc get pods -n "$NS_B" --no-headers --field-selector=status.phase=Running 2>/dev/null | wc -l | tr -d ' ')
+
+  if [ "$COUNT_A" -eq "$EXPECTED_A" ] && [ "$COUNT_B" -eq "$EXPECTED_B" ]; then
+    echo "Setup complete: $NS_A:$COUNT_A pods  $NS_B:$COUNT_B pods"
+    exit 0
+  fi
+  echo "attempt $ATTEMPT/20 — $NS_A:$COUNT_A/$EXPECTED_A  $NS_B:$COUNT_B/$EXPECTED_B — waiting 3s…"
+  sleep 3
+done
+
+echo "Expected pod counts not reached"
+oc get pods -n "$NS_A"
+oc get pods -n "$NS_B"
+exit 1


### PR DESCRIPTION
Deploy two namespaces (fleet-alpha with 6 pods, fleet-alpha1 with 9 pods) and evaluate whether LLM agents can identify the pod count discrepancy. Includes setup/cleanup scripts, Kubernetes fixtures, and eval definitions for OpenAI, Anthropic, and Gemini agents.


Assisted-by: Claude Code:claude-opus-4-6