### PR TITLE
feat: shared setup/cleanup and results for agentic evals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 **/results/
+!agentic/results/
+agentic/results/logs/
 **/_output/
 **/.caches/
 venv/

--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -1,6 +1,6 @@
 SCRIPTS_DIR := $(realpath ../scripts)
 
-SUITES ?= blocking_networkpolicy failing_api misconfigured_readiness_probe mismatched_ingress_rule missing_envvar scheduled_outage pending_pvc
+SUITES ?= failing_api blocking_networkpolicy misconfigured_readiness_probe mismatched_ingress_rule missing_envvar scheduled_outage pending_pvc
 RUNS ?= 1
 
 .PHONY: setup evals cleanup help
@@ -15,6 +15,8 @@ setup:
 evals:
 	$(eval RESULTS_DIR := results/$(shell date +%Y%m%d_%H%M%S))
 	@for suite in $(SUITES); do \
+	  echo "==> Setup: $$suite"; \
+	  if [ -x $$suite/setup.sh ]; then bash $$suite/setup.sh; fi; \
 	  echo "==> Suite: $$suite"; \
 	  bash $(SCRIPTS_DIR)/run-agentic-evals.sh \
 	    --system-config system.yaml \
@@ -22,7 +24,15 @@ evals:
 	    --results-dir $(RESULTS_DIR) \
 	    --runs $(RUNS) \
 	    --tag agentic_$$(echo $$suite | tr '-' '_'); \
+	  echo "==> Cleanup: $$suite"; \
+	  if [ -x $$suite/cleanup.sh ]; then bash $$suite/cleanup.sh; fi; \
 	done
+	@echo ""
+	@echo "==> Generating summary..."
+	@../venv/bin/python $(SCRIPTS_DIR)/summarize-agentic-evals.py \
+	  $(RESULTS_DIR) \
+	  $(foreach s,$(SUITES),$s/evals.yaml) \
+	  $$(find $(RESULTS_DIR) -name '*_summary.json' | sort)
 
 cleanup:
 	@for suite in $(SUITES); do \

--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -13,7 +13,9 @@ setup:
 	@echo "This will be automated in the future."
 
 evals:
-	$(eval RESULTS_DIR := results/$(shell date +%Y%m%d_%H%M%S))
+	$(eval DATETIME := $(shell date +%Y%m%d_%H%M%S))
+	$(eval LOGS_DIR := results/logs/$(DATETIME))
+	$(eval SUMMARY := results/results_$(DATETIME).md)
 	@for suite in $(SUITES); do \
 	  echo "==> Setup: $$suite"; \
 	  if [ -x $$suite/setup.sh ]; then bash $$suite/setup.sh; fi; \
@@ -21,7 +23,7 @@ evals:
 	  bash $(SCRIPTS_DIR)/run-agentic-evals.sh \
 	    --system-config system.yaml \
 	    --evals $$suite/evals.yaml \
-	    --results-dir $(RESULTS_DIR) \
+	    --results-dir $(LOGS_DIR) \
 	    --runs $(RUNS) \
 	    --tag agentic_$$(echo $$suite | tr '-' '_'); \
 	  echo "==> Cleanup: $$suite"; \
@@ -30,9 +32,10 @@ evals:
 	@echo ""
 	@echo "==> Generating summary..."
 	@../venv/bin/python $(SCRIPTS_DIR)/summarize-agentic-evals.py \
-	  $(RESULTS_DIR) \
+	  $(LOGS_DIR) \
+	  --output $(SUMMARY) \
 	  $(foreach s,$(SUITES),$s/evals.yaml) \
-	  $$(find $(RESULTS_DIR) -name '*_summary.json' | sort)
+	  $$(find $(LOGS_DIR) -name '*_summary.json' | sort)
 
 cleanup:
 	@for suite in $(SUITES); do \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -1,18 +1,18 @@
 # Agentic Evals
 
-Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspeed](https://github.com/openshift/lightspeed-agentic-operator). Each suite deploys a fault on a live cluster, submits a configurable number of `AgenticRun`s and scores the analysis.
+Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspeed](https://github.com/openshift/lightspeed-agentic-operator). Each scenario deploys a fault on a live cluster, submits a configurable number of `AgenticRun`s and scores the analysis.
 
-## Suites
+## Scenarios
 
-| Suite | Symptom | Root Cause |
-|-------|---------|------------|
-| `blocking_networkpolicy` | Frontend gets connection timeouts to backend | NetworkPolicy only allows ingress from `tier=backend`, blocking `tier=frontend` pods |
-| `failing_api` | Payment API returning 503s (100% error rate) | Reporting service leaks DB connections, exhausting the shared PostgreSQL pool |
-| `misconfigured_readiness_probe` | Pod running but not becoming Ready | HTTP readiness probe targets port 9200 but container has no HTTP server |
-| `mismatched_ingress_rule` | Web-portal gets connection timeouts to API gateway | NetworkPolicy ingress rule label selector does not match the caller's labels |
-| `missing_envvar` | Pod in CrashLoopBackOff | Required environment variable `DEPLOY_ENV` is missing from the deployment spec |
-| `pending_pvc` | PVC stuck in Pending, pods cannot start | PVC references a StorageClass (`standard-v2`) that does not exist |
-| `scheduled_outage` | Upstream timeouts during 03:00-03:05 window | Upstream API has a scheduled maintenance window, not a bug in the application |
+| Scenario | Symptom | Root Cause | Difficulty |
+|-------|---------|------------|------------|
+| `failing_api` | Payment API returning 503s (100% error rate) | Reporting service leaks DB connections, exhausting the shared PostgreSQL pool | Hard |
+| `pending_pvc` | PVC stuck in Pending, pods cannot start | PVC references a StorageClass (`standard-v2`) that does not exist | Medium |
+| `scheduled_outage` | Upstream timeouts during 03:00-03:05 window | Upstream API has a scheduled maintenance window, not a bug in the application | Medium |
+| `blocking_networkpolicy` | Frontend gets connection timeouts to backend | NetworkPolicy only allows ingress from `tier=backend`, blocking `tier=frontend` pods | Normal |
+| `misconfigured_readiness_probe` | Pod running but not becoming Ready | HTTP readiness probe targets port 9200 but container has no HTTP server | Normal |
+| `missing_envvar` | Pod in CrashLoopBackOff | Required environment variable `DEPLOY_ENV` is missing from the deployment spec | Normal |
+| `mismatched_ingress_rule` | Web-portal gets connection timeouts to API gateway | NetworkPolicy ingress rule label selector does not match the caller's labels | Normal |
 
 ## Prerequisites
 
@@ -26,9 +26,9 @@ All commands run from this directory.
 
 ```bash
 make setup                  # Install Python venv
-make evals                  # Run all suites
-make evals SUITES="failing_api pending_pvc"  # Run specific suites
-make evals RUNS=3           # Run each suite 3 times
-make cleanup                # Remove suite resources and venv
+make evals                  # Run all scenarios
+make evals SUITES="failing_api pending_pvc"  # Run specific scenarios
+make evals RUNS=3           # Run each scenario 3 times
+make cleanup                # Remove scenario resources and venv
 make help                   # Show all targets and options
 ```

--- a/agentic/blocking_networkpolicy/evals.yaml
+++ b/agentic/blocking_networkpolicy/evals.yaml
@@ -1,7 +1,6 @@
 - conversation_group_id: blocking_networkpolicy_openai
   tag: agentic_blocking_networkpolicy
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+
   
   turns:
     - turn_id: turn_1
@@ -46,8 +45,7 @@
 
 - conversation_group_id: blocking_networkpolicy_anthropic
   tag: agentic_blocking_networkpolicy
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+
 
   turns:
     - turn_id: turn_1
@@ -92,8 +90,7 @@
 
 - conversation_group_id: blocking_networkpolicy_gemini
   tag: agentic_blocking_networkpolicy
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+
 
   turns:
     - turn_id: turn_1

--- a/agentic/failing_api/cleanup.sh
+++ b/agentic/failing_api/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCENARIO_DIR="$(cd "$(dirname "$0")/../../generic/01-payments-api-failure" && pwd)"
+
+make -C "$SCENARIO_DIR" cleanup

--- a/agentic/failing_api/evals.yaml
+++ b/agentic/failing_api/evals.yaml
@@ -1,4 +1,4 @@
-- conversation_group_id: failing_api_analysis_openai
+- conversation_group_id: failing_api_openai
   tag: agentic_failing_api
 
   turns:
@@ -47,7 +47,7 @@
         "custom:proposal_evaluation_correctness":
           threshold: 0.75
 
-- conversation_group_id: failing_api_analysis_anthropic
+- conversation_group_id: failing_api_anthropic
   tag: agentic_failing_api
 
   turns:
@@ -96,7 +96,7 @@
         "custom:proposal_evaluation_correctness":
           threshold: 0.75
 
-- conversation_group_id: failing_api_analysis_gemini
+- conversation_group_id: failing_api_gemini
   tag: agentic_failing_api
 
   turns:

--- a/agentic/failing_api/setup.sh
+++ b/agentic/failing_api/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCENARIO_DIR="$(cd "$(dirname "$0")/../../generic/01-payments-api-failure" && pwd)"
+
+make -C "$SCENARIO_DIR" deploy SINGLE_NAMESPACE=1
+make -C "$SCENARIO_DIR" break

--- a/agentic/misconfigured_readiness_probe/evals.yaml
+++ b/agentic/misconfigured_readiness_probe/evals.yaml
@@ -1,7 +1,6 @@
 - conversation_group_id: misconfigured_readiness_probe_openai
   tag: agentic_misconfigured_readiness_probe
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+
 
   turns:
     - turn_id: turn_1
@@ -48,8 +47,7 @@
 
 - conversation_group_id: misconfigured_readiness_probe_anthropic
   tag: agentic_misconfigured_readiness_probe
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+
 
   turns:
     - turn_id: turn_1
@@ -96,8 +94,7 @@
 
 - conversation_group_id: misconfigured_readiness_probe_gemini
   tag: agentic_misconfigured_readiness_probe
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+
 
   turns:
     - turn_id: turn_1

--- a/agentic/mismatched_ingress_rule/evals.yaml
+++ b/agentic/mismatched_ingress_rule/evals.yaml
@@ -1,7 +1,6 @@
 - conversation_group_id: mismatched_ingress_rule_openai
   tag: agentic_mismatched_ingress_rule
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+
 
   turns:
     - turn_id: turn_1
@@ -48,8 +47,7 @@
 
 - conversation_group_id: mismatched_ingress_rule_anthropic
   tag: agentic_mismatched_ingress_rule
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+
 
   turns:
     - turn_id: turn_1
@@ -96,8 +94,7 @@
 
 - conversation_group_id: mismatched_ingress_rule_gemini
   tag: agentic_mismatched_ingress_rule
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+
 
   turns:
     - turn_id: turn_1

--- a/agentic/missing_envvar/evals.yaml
+++ b/agentic/missing_envvar/evals.yaml
@@ -1,7 +1,6 @@
-- conversation_group_id: envvar_missing_analysis_openai
-  tag: agentic_envvar_missing
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+- conversation_group_id: missing_envvar_openai
+  tag: agentic_missing_envvar
+
 
   turns:
     - turn_id: turn_1
@@ -43,10 +42,9 @@
         "custom:proposal_evaluation_correctness":
           threshold: 0.75
 
-- conversation_group_id: envvar_missing_analysis_anthropic
-  tag: agentic_envvar_missing
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+- conversation_group_id: missing_envvar_anthropic
+  tag: agentic_missing_envvar
+
 
   turns:
     - turn_id: turn_1
@@ -88,10 +86,9 @@
         "custom:proposal_evaluation_correctness":
           threshold: 0.75
 
-- conversation_group_id: envvar_missing_analysis_gemini
-  tag: agentic_envvar_missing
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+- conversation_group_id: missing_envvar_gemini
+  tag: agentic_missing_envvar
+
 
   turns:
     - turn_id: turn_1

--- a/agentic/pending_pvc/evals.yaml
+++ b/agentic/pending_pvc/evals.yaml
@@ -1,7 +1,6 @@
-- conversation_group_id: pending_pvc_analysis_openai
+- conversation_group_id: pending_pvc_openai
   tag: agentic_pending_pvc
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+
 
   turns:
     - turn_id: turn_1
@@ -45,10 +44,9 @@
         "custom:proposal_evaluation_correctness":
           threshold: 0.75
 
-- conversation_group_id: pending_pvc_analysis_anthropic
+- conversation_group_id: pending_pvc_anthropic
   tag: agentic_pending_pvc
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+
 
   turns:
     - turn_id: turn_1
@@ -92,10 +90,9 @@
         "custom:proposal_evaluation_correctness":
           threshold: 0.75
 
-- conversation_group_id: pending_pvc_analysis_gemini
+- conversation_group_id: pending_pvc_gemini
   tag: agentic_pending_pvc
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+
 
   turns:
     - turn_id: turn_1

--- a/agentic/results/results_20260715_073553.md
+++ b/agentic/results/results_20260715_073553.md
@@ -1,0 +1,1451 @@
+# Evaluation Summary
+2026-07-15 05:44:10 UTC
+
+| Model | failing_api_analysis | blocking_networkpolicy | misconfigured_readiness_probe | mismatched_ingress_rule | scheduled_outage | pending_pvc_analysis |
+|---|---|---|---|---|---|---|
+| gemini | ❌ 0/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ❌ 0/1 | ✅ 1/1 |
+| openai | ❌ 0/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 |
+| anthropic | ❌ 0/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ❌ 0/1 |
+
+## Details
+
+| Scenario | Completed | Correctness | Overall |
+|---|---|---|---|
+| [failing_api_analysis_gemini](#failing_api_analysis_gemini) | ✅ 1/1 | ❌ 0/1 | ❌ 0/1 |
+| [failing_api_analysis_openai](#failing_api_analysis_openai) | ✅ 1/1 | ❌ 0/1 | ❌ 0/1 |
+| [failing_api_analysis_anthropic](#failing_api_analysis_anthropic) | ✅ 1/1 | ❌ 0/1 | ❌ 0/1 |
+| [blocking_networkpolicy_openai](#blocking_networkpolicy_openai) | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 |
+| [blocking_networkpolicy_gemini](#blocking_networkpolicy_gemini) | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 |
+| [blocking_networkpolicy_anthropic](#blocking_networkpolicy_anthropic) | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 |
+| [misconfigured_readiness_probe_openai](#misconfigured_readiness_probe_openai) | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 |
+| [misconfigured_readiness_probe_gemini](#misconfigured_readiness_probe_gemini) | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 |
+| [misconfigured_readiness_probe_anthropic](#misconfigured_readiness_probe_anthropic) | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 |
+| [mismatched_ingress_rule_openai](#mismatched_ingress_rule_openai) | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 |
+| [mismatched_ingress_rule_gemini](#mismatched_ingress_rule_gemini) | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 |
+| [mismatched_ingress_rule_anthropic](#mismatched_ingress_rule_anthropic) | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 |
+| [scheduled_outage_openai](#scheduled_outage_openai) | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 |
+| [scheduled_outage_gemini](#scheduled_outage_gemini) | ✅ 1/1 | ❌ 0/1 | ❌ 0/1 |
+| [scheduled_outage_anthropic](#scheduled_outage_anthropic) | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 |
+| [pending_pvc_analysis_openai](#pending_pvc_analysis_openai) | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 |
+| [pending_pvc_analysis_gemini](#pending_pvc_analysis_gemini) | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 |
+| [pending_pvc_analysis_anthropic](#pending_pvc_analysis_anthropic) | ✅ 1/1 | ❌ 0/1 | ❌ 0/1 |
+
+## Judge LLM
+
+- **Provider**: openai
+- **Model**: gpt-5.4-mini
+
+## failing_api_analysis_gemini
+
+**Tags**: `agentic_failing_api`
+
+### Query
+
+```
+Alert: PaymentErrorRateHigh (critical)
+Namespace: payments
+Description: Payment error rate is 100.00%, which exceeds the 15% threshold.
+Labels:
+  alertname: PaymentErrorRateHigh
+  namespace: payments
+  severity: critical
+
+Investigate, follow causality chains to the root cause
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ❌ FAIL (score: 0.10)
+
+> Proposal evaluation correctness: diagnosis=0.10, execution=N/A, verification=N/A, avg=0.10 — The workflow diagnosed an unrelated issue: it focused on reconciliation-service CrashLoopBackOff caused by probe scheme mismatch, while the expected root cause is PostgreSQL connection exhaustion caused by shared-services/reporting-service leaving transactions open. This is a significant misattribution and misses the causality chain to payments/payments-api returning 503s, so the diagnosis is poor. No execution or verification phases ran, so both are N/A.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+Alert: PaymentErrorRateHigh (critical)
+Namespace: payments
+Description: Payment error rate is 100.00%, which exceeds the 15% threshold.
+Labels:
+  alertname: PaymentErrorRateHigh
+  namespace: payments
+  severity: critical
+
+Investigate, follow causality chains to the root cause
+
+
+## Analysis
+
+1 option(s) proposed
+
+### Option 0 (Approved): Fix misconfigured probes for reconciliation-service
+**Diagnosis:** The `reconciliation-service` pod is in a `CrashLoopBackOff` state. Analysis of the pod's logs and the deployment's configuration reveals that the liveness and readiness probes are incorrectly configured. The probes are attempting to connect to the pod's port `8443` using `HTTP`, but the service is expecting an `HTTPS` connection. This mismatch causes the probes to fail, leading Kubernetes to repeatedly terminate and restart the pod. The high error rate reported by the alert is a direct consequence of this service being unavailable. (Confidence: High)
+**Root Cause:** The liveness and readiness probes for the `reconciliation-service` are misconfigured. They are using HTTP to connect to an HTTPS endpoint, causing the probes to fail and the pod to be continuously restarted.
+**Proposed Actions:**
+1. [pre-check] Get the current deployment to confirm the probe configuration.
+2. [mutation] Patch the deployment to change the liveness and readiness probe schemes from HTTP to HTTPS.
+3. [wait] Wait for the deployment to complete and the new pod to be rolled out.
+4. [post-check] Verify that the `reconciliation-service` pod is in the `Running` state and not restarting.
+**Risk:** Low | **Reversible:** Reversible
+
+## Outcome
+
+Analysis complete with 1 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## failing_api_analysis_openai
+
+**Tags**: `agentic_failing_api`
+
+### Query
+
+```
+Alert: PaymentErrorRateHigh (critical)
+Namespace: payments
+Description: Payment error rate is 100.00%, which exceeds the 15% threshold.
+Labels:
+  alertname: PaymentErrorRateHigh
+  namespace: payments
+  severity: critical
+
+Investigate, follow causality chains to the root cause
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ❌ FAIL (score: 0.30)
+
+> Proposal evaluation correctness: diagnosis=0.30, execution=N/A, verification=N/A, avg=0.30 — Diagnosis is materially off: it attributes the connection exhaustion to leaked sessions from payments-api / dbuser and even suggests restarting postgres, but the expected root cause is shared-services/reporting-service repeatedly leaving transactions idle, with reconciliation-service being a separate probe issue. No execution phase ran, so execution is N/A. Verification was not configured, and the proposed checks mostly validate generic DB recovery rather than confirming the specific offending service was identified or remediated.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+Alert: PaymentErrorRateHigh (critical)
+Namespace: payments
+Description: Payment error rate is 100.00%, which exceeds the 15% threshold.
+Labels:
+  alertname: PaymentErrorRateHigh
+  namespace: payments
+  severity: critical
+
+Investigate, follow causality chains to the root cause
+
+
+## Analysis
+
+2 option(s) proposed
+
+### Option 0 (Approved): Restart `payments-api` to clear leaked DB sessions
+**Diagnosis:** `PaymentErrorRateHigh` is caused by a database connection exhaustion chain in `payments`, not by ingress or pod availability.
+
+Findings:
+- The alert is actively firing at `2026-07-15T05:39:21Z` with value `100` for namespace `payments`.
+- `payments-api` is healthy at the pod level, but its logs show every `/api/v1/process-payment` request failing with `503` because connections to `postgres` are rejected: `FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute`.
+- PostgreSQL logs show the same `FATAL` error continuously starting at `2026-07-15 05:38:45 UTC`, matching the payment failures.
+- Prometheus metric `pg_stat_activity_count{namespace="payments"}` shows `16` sessions in state `idle in transaction` for user `dbuser` on database `demo`, plus only `1` active and `1` idle session. This is consistent with leaked/unclosed transactions consuming nearly all available non-superuser connections.
+- Additional symptom: `reconciliation-service` is in `CrashLoopBackOff`, with no endpoints, because its deployment runs image `registry.redhat.io/rhel9/httpd-24:latest` and probes `HTTP` on port `8443`, producing probe `400` responses. This is a separate misconfiguration, but the payment alert’s direct root cause is still the exhausted PostgreSQL connections.
+
+Causality chain:
+`idle in transaction` leak by `dbuser` -> PostgreSQL non-superuser slots exhausted -> `payments-api` cannot open DB connections -> every payment request returns `503` -> payment error rate reaches `100%`. (Confidence: High)
+**Root Cause:** `payments-api` returns 503 because PostgreSQL connection slots are exhausted by 16 `idle in transaction` sessions from role `dbuser`, causing every payment request to fail
+**Proposed Actions:**
+1. [pre-check] Pre-check the current application deployment state before mutation
+2. [pre-check] Pre-check current payments-api pod identity and readiness
+3. [pre-check] Confirm the current failure is DB connection exhaustion before restarting
+4. [pre-check] Confirm PostgreSQL is rejecting connections due to slot exhaustion
+5. [mutation] Restart the likely offending workload to drop leaked DB sessions and recreate a clean connection pool
+6. [wait] Wait for the restarted payments-api deployment to become available
+7. [post-check] Verify a new payments-api pod is running after restart
+8. [post-check] Check that PostgreSQL is no longer emitting connection-slot exhaustion errors after the restart
+9. [post-check] Verify payments-api stops returning 503 errors caused by DB connection failures
+10. [post-check] Fetch the route hostname for end-to-end verification
+11. [post-check] Perform an external verification request and expect the endpoint to stop returning 503
+**Risk:** Medium | **Reversible:** Reversible
+
+### Option 1 : Restart `postgres` to apply connection-capacity settings and clear sessions
+**Diagnosis:** `PaymentErrorRateHigh` is driven by PostgreSQL connection starvation.
+
+Evidence:
+- `payments-api` logs show every payment request failing with `503` because PostgreSQL rejects connections with `FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute`.
+- PostgreSQL logs confirm the rejection is ongoing from `2026-07-15 05:38:45 UTC` onward.
+- During init, PostgreSQL logged: `parameter "max_connections" cannot be changed without restarting the server` and `configuration file ... contains errors; unaffected changes were applied`. That means a desired connection-capacity change was attempted dynamically but did not take effect at runtime.
+- Current metrics show `16` `idle in transaction` sessions for `dbuser`; with a low active connection ceiling, that is sufficient to block new application traffic.
+
+Causality chain:
+failed runtime application of `max_connections` change -> database remains on lower connection ceiling -> leaked `idle in transaction` sessions exhaust non-superuser slots -> `payments-api` gets DB connection failures -> all payments fail with `503`. (Confidence: High)
+**Root Cause:** PostgreSQL is running with an effectively too-low active connection ceiling after `ALTER SYSTEM` attempted to change `max_connections` without a restart, while 16 leaked `idle in transaction` sessions consume available slots
+**Proposed Actions:**
+1. [pre-check] Pre-check the current PostgreSQL deployment state
+2. [pre-check] Pre-check the current database pod and node placement
+3. [pre-check] Confirm the current slot-exhaustion errors and the earlier max_connections reload failure
+4. [mutation] Restart PostgreSQL so startup-only settings such as max_connections are re-read and leaked sessions are cleared
+5. [wait] Wait for PostgreSQL to come back and become available
+6. [post-check] Verify a new PostgreSQL pod is running
+7. [post-check] Verify PostgreSQL starts cleanly and no immediate slot exhaustion occurs
+8. [post-check] Verify the application stops seeing DB connection slot exhaustion errors after database restart
+9. [post-check] Confirm payment requests recover after the database restart
+**Risk:** High | **Reversible:** Partial
+
+## Outcome
+
+Analysis complete with 2 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## failing_api_analysis_anthropic
+
+**Tags**: `agentic_failing_api`
+
+### Query
+
+```
+Alert: PaymentErrorRateHigh (critical)
+Namespace: payments
+Description: Payment error rate is 100.00%, which exceeds the 15% threshold.
+Labels:
+  alertname: PaymentErrorRateHigh
+  namespace: payments
+  severity: critical
+
+Investigate, follow causality chains to the root cause
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ❌ FAIL (score: 0.60)
+
+> Proposal evaluation correctness: diagnosis=0.60, execution=N/A, verification=N/A, avg=0.60 — The workflow correctly identifies a PostgreSQL connection exhaustion problem and ties it to reporting-service v1.0.2 leaking connections, but it overstates and partially misattributes the root cause by centering PostgreSQL max_connections=20 as the primary issue and proposing a broad DB configuration change. The expected root cause is specifically the reporting-service repeatedly opening DB connections and leaving them idle in transaction; the workflow’s secondary reconciliation-service diagnosis is unrelated noise. No execution or verification phases ran, so those dimensions are not applicable.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+Alert: PaymentErrorRateHigh (critical)
+Namespace: payments
+Description: Payment error rate is 100.00%, which exceeds the 15% threshold.
+Labels:
+  alertname: PaymentErrorRateHigh
+  namespace: payments
+  severity: critical
+
+Investigate, follow causality chains to the root cause
+
+
+## Analysis
+
+1 option(s) proposed
+
+### Option 0 (Approved): Increase PostgreSQL max_connections and rollback reporting-service to fix connection leak
+**Diagnosis:** ## Root Cause Analysis
+
+### Causality Chain
+
+1. **PostgreSQL `max_connections` set to 20** — The `postgres-init` ConfigMap contains `ALTER SYSTEM SET max_connections = 20` in `init.sql`. This wrote the setting to `postgresql.auto.conf`, which took effect when docker-entrypoint.sh restarted PostgreSQL after initialization. The default is 100; 20 is extremely low.
+
+2. **reporting-service v1.0.2 has a connection leak** — The reporting-service was recently updated from v1.0.1 to v1.0.2 (deployment revision 2, old ReplicaSet `reporting-service-76d5ddbcf6` ran v1.0.1). The v1.0.2 code opens a new database connection every 10 seconds (`Open db connection`) and encounters a `division by zero` error each time, but never properly closes the connection. This is evident from the logs: 16 consecutive 'Open db connection' entries from 05:36:20 to 05:39:00 with no corresponding close.
+
+3. **Connection slots exhausted in ~3 minutes** — With `max_connections=20` and `superuser_reserved_connections=3` (PostgreSQL default), only 17 non-superuser slots are available. The reporting-service leaked ~16-17 connections in ~160 seconds (one every 10s), consuming all available slots by 05:39:00 UTC.
+
+4. **100% payment failure** — After connection exhaustion, every `payments-api` request to PostgreSQL fails with `FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute`, causing the API to return HTTP 503 on all `/api/v1/process-payment` calls.
+
+### Secondary Issue (not directly causing alert)
+
+The `reconciliation-service` deployment uses the wrong container image (`registry.redhat.io/rhel9/httpd-24:latest` — a generic Apache HTTPD image). Its liveness/readiness probes target port 8443 and receive HTTP 400 responses, causing CrashLoopBackOff. This service has no endpoints registered.
+
+### Evidence
+- **postgres logs**: Continuous `FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute` since 05:39:00
+- **payments-api logs**: Every payment fails with the same PostgreSQL connection error, returning 503
+- **reporting-service logs**: `Open db connection` every 10s from 05:36:20, `division by zero` error each iteration, transitions to connection-exhaustion errors at 05:39:00
+- **postgres-init ConfigMap**: Contains `ALTER SYSTEM SET max_connections = 20`
+- **postgres startup logs**: `parameter "max_connections" cannot be changed without restarting the server` — confirms the ALTER SYSTEM was persisted to postgresql.auto.conf and took effect on the production restart (Confidence: High)
+**Root Cause:** PostgreSQL max_connections=20 (set by init.sql) exhausted by reporting-service v1.0.2 connection leak (new connection every 10s, never closed), blocking all payments-api database access
+**Proposed Actions:**
+1. [pre-check] Verify current max_connections value (expected: 20)
+2. [pre-check] Check current number of active connections to confirm exhaustion
+3. [pre-check] Confirm reporting-service is running v1.0.2 (the leaky version)
+4. [mutation] Increase max_connections to 200 in postgresql.auto.conf (requires restart to take effect)
+5. [mutation] Roll back reporting-service from v1.0.2 to v1.0.1 to fix the connection leak and division-by-zero bug
+6. [wait] Wait for reporting-service rollback to complete — this ensures the leaky v1.0.2 pod is terminated and leaked connections are released
+7. [mutation] Restart PostgreSQL to apply the new max_connections=200 setting
+8. [wait] Wait for PostgreSQL to restart and become ready
+9. [post-check] Verify max_connections is now 200
+10. [mutation] Update postgres-init ConfigMap to remove the ALTER SYSTEM SET max_connections = 20 line, preventing recurrence on future re-initialization
+11. [post-check] Verify payments-api is no longer getting connection errors and payments are succeeding
+12. [post-check] Verify payments-api endpoints are healthy
+**Risk:** Medium | **Reversible:** Reversible
+
+## Outcome
+
+Analysis complete with 1 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## blocking_networkpolicy_openai
+
+**Tags**: `agentic_blocking_networkpolicy`
+
+### Query
+
+```
+The frontend application in the service-mesh namespace is logging
+repeated "ERROR: Connection timeout to backend-service!" messages.
+The backend pod appears to be running and healthy.
+
+Investigate the connectivity issue between frontend and backend,
+follow causality chains to the root cause.
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ✅ PASS (score: 0.98)
+
+> Proposal evaluation correctness: diagnosis=0.98, execution=N/A, verification=N/A, avg=0.98 — The diagnosis matches the expected root cause closely: it identifies the specific NetworkPolicy (`backend-network-policy`) and correctly explains that its ingress selector only allows `tier=backend`, blocking the `tier=frontend` frontend pod from reaching `backend-service:8080`. No execution phase ran, so execution is N/A, and there was no verification phase configured, so verification is also N/A.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+The frontend application in the service-mesh namespace is logging
+repeated "ERROR: Connection timeout to backend-service!" messages.
+The backend pod appears to be running and healthy.
+
+Investigate the connectivity issue between frontend and backend,
+follow causality chains to the root cause.
+
+
+## Analysis
+
+1 option(s) proposed
+
+### Option 0 (Approved): Patch the backend NetworkPolicy to allow frontend ingress
+**Diagnosis:** The timeout is caused by a **namespace-local NetworkPolicy**, not by backend health. Evidence:
+
+- `frontend` logs repeatedly show `wget: download timed out` while connecting to `http://backend-service:8080`.
+- `backend-service` is correctly configured as `ClusterIP 172.30.186.6` on `8080/TCP` with a live endpoint `10.131.0.157:8080`.
+- The backend pod `backend-54d6d7b87c-thcwx` is `Running` and `Ready`, and the deployment reports `1 available`.
+- The only NetworkPolicy in `service-mesh`, `backend-network-policy`, selects `app=backend` and allows ingress on port `8080` **only from pods with label `tier=backend`**.
+- The frontend pod is labeled `tier=frontend`, so its traffic does not match the allowed `from` clause and is dropped, which explains the connection timeout despite healthy backend endpoints.
+
+Causality chain: `frontend` timeout → service has endpoints → backend pod is healthy → ingress isolation applies to backend pods → policy source selector excludes frontend → connection denied. (Confidence: High)
+**Root Cause:** `backend-network-policy` only allows ingress to backend pods from pods labeled `tier=backend`, so frontend pods labeled `tier=frontend` are denied reaching `backend-service:8080`
+**Proposed Actions:**
+1. [pre-check] Pre-check the current NetworkPolicy source selector and preserve the exact existing state
+2. [pre-check] Pre-check that both workloads are still present and healthy before changing policy
+3. [pre-check] Pre-check the backend Service definition and target port
+4. [pre-check] Pre-check that the Service still has a backend endpoint
+5. [pre-check] Pre-check and capture the current timeout symptom from frontend logs
+6. [mutation] Allow frontend pods to connect to backend pods on TCP/8080 by expanding the allowed source selectors
+7. [post-check] Confirm the NetworkPolicy now allows both `tier=backend` and `tier=frontend` sources
+8. [wait] Wait for backend deployment to remain available after the policy update
+9. [wait] Wait for frontend deployment to remain available while traffic retries
+10. [post-check] Verify the backend Service still resolves to a live endpoint after the change
+11. [post-check] Verify frontend logs no longer show connection timeouts and begin showing successful responses
+**Risk:** Low | **Reversible:** Reversible
+
+## Outcome
+
+Analysis complete with 1 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## blocking_networkpolicy_gemini
+
+**Tags**: `agentic_blocking_networkpolicy`
+
+### Query
+
+```
+The frontend application in the service-mesh namespace is logging
+repeated "ERROR: Connection timeout to backend-service!" messages.
+The backend pod appears to be running and healthy.
+
+Investigate the connectivity issue between frontend and backend,
+follow causality chains to the root cause.
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ✅ PASS (score: 0.98)
+
+> Proposal evaluation correctness: diagnosis=0.98, execution=N/A, verification=N/A, avg=0.98 — The diagnosis is correct and specific: it identifies the backend-network-policy in the service-mesh namespace as the blocker, with ingress only allowed from tier=backend while the frontend is tier=frontend. The workflow did not execute any remediation or verification steps, so those dimensions are N/A rather than scored.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+The frontend application in the service-mesh namespace is logging
+repeated "ERROR: Connection timeout to backend-service!" messages.
+The backend pod appears to be running and healthy.
+
+Investigate the connectivity issue between frontend and backend,
+follow causality chains to the root cause.
+
+
+## Analysis
+
+1 option(s) proposed
+
+### Option 0 (Approved): Update NetworkPolicy to Allow Frontend Traffic
+**Diagnosis:** The `backend-network-policy` in the `service-mesh` namespace is configured to only allow ingress traffic from pods with the label `tier: backend`. The frontend pod, however, has the label `tier: frontend`. This mismatch causes the network policy to block requests from the frontend to the backend, resulting in connection timeouts. (Confidence: High)
+**Root Cause:** A NetworkPolicy is blocking ingress traffic from the frontend to the backend service.
+**Proposed Actions:**
+1. [pre-check] Inspect the current network policy before making changes.
+2. [mutation] Patch the network policy to add a rule that allows ingress from pods with the 'tier: frontend' label.
+3. [post-check] Verify that the network policy has been updated correctly.
+**Risk:** Low | **Reversible:** Reversible
+
+## Outcome
+
+Analysis complete with 1 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## blocking_networkpolicy_anthropic
+
+**Tags**: `agentic_blocking_networkpolicy`
+
+### Query
+
+```
+The frontend application in the service-mesh namespace is logging
+repeated "ERROR: Connection timeout to backend-service!" messages.
+The backend pod appears to be running and healthy.
+
+Investigate the connectivity issue between frontend and backend,
+follow causality chains to the root cause.
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ✅ PASS (score: 1.00)
+
+> Proposal evaluation correctness: diagnosis=1.00, execution=N/A, verification=N/A, avg=1.00 — The diagnosis matches the expected root cause: the backend NetworkPolicy only allows ingress from pods labeled tier=backend, which blocks the frontend pod labeled tier=frontend and explains the timeout behavior. No execution phase ran, so there were no remediation actions to assess, and no verification phase was configured, so there are no post-fix checks to score.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+The frontend application in the service-mesh namespace is logging
+repeated "ERROR: Connection timeout to backend-service!" messages.
+The backend pod appears to be running and healthy.
+
+Investigate the connectivity issue between frontend and backend,
+follow causality chains to the root cause.
+
+
+## Analysis
+
+1 option(s) proposed
+
+### Option 0 (Approved): Fix NetworkPolicy ingress selector to allow frontend traffic
+**Diagnosis:** ## Root Cause Analysis
+
+The frontend pod repeatedly logs `ERROR: Connection timeout to backend-service!` when attempting `wget -O- http://backend-service:8080`. The backend pod (nginx) is healthy, listening on port 8080, and the Service `backend-service` has a valid endpoint (`10.131.0.157:8080`). DNS resolution works correctly — the frontend resolves `backend-service` to ClusterIP `172.30.186.6`.
+
+### Findings
+
+1. **NetworkPolicy `backend-network-policy`** applies to pods with `app: backend` and restricts ingress to only allow traffic from pods matching `tier: backend` on port 8080/TCP.
+2. **Frontend pod labels**: `app: frontend`, `tier: frontend`
+3. **Backend pod labels**: `app: backend`, `tier: backend`
+
+The ingress rule's `from.podSelector.matchLabels` is `tier: backend` — this only permits traffic from other *backend* pods. The frontend pod has `tier: frontend`, which does **not** match the selector. Consequently, **all traffic from frontend → backend is dropped** by the NetworkPolicy.
+
+### Why a timeout (not connection refused)?
+
+NetworkPolicies silently drop non-matching packets at the network layer. The frontend's TCP SYN packets are dropped without any RST response, causing the 5-second `wget` timeout rather than an immediate "connection refused" error. This is the hallmark signature of a NetworkPolicy block.
+
+### Verified non-issues
+- ✅ Both pods are `Running` and `Ready` (1/1), no restarts
+- ✅ Service selector (`app=backend`) correctly matches the backend pod
+- ✅ Endpoints populated: `10.131.0.157:8080`
+- ✅ Backend nginx started successfully on port 8080
+- ✅ Both pods are co-located on the same node (no inter-node networking issues)
+- ✅ DNS is functional (frontend resolves the service name to the correct ClusterIP) (Confidence: High)
+**Root Cause:** NetworkPolicy backend-network-policy ingress selector requires tier=backend, but frontend pod has tier=frontend — all frontend→backend traffic is silently dropped
+**Proposed Actions:**
+1. [pre-check] Verify the current ingress from-selector is tier=backend (the misconfigured value)
+2. [pre-check] Confirm frontend pods exist with the tier=frontend label that the updated policy will match
+3. [mutation] Patch the NetworkPolicy ingress rule to allow traffic from pods with tier=frontend instead of tier=backend
+4. [post-check] Verify the NetworkPolicy now has tier=frontend in the ingress from-selector
+5. [post-check] Wait a few seconds for the next connection attempt and check frontend logs for successful connection (should see 'Success!' instead of timeout errors)
+**Risk:** Low | **Reversible:** Reversible
+
+## Outcome
+
+Analysis complete with 1 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## misconfigured_readiness_probe_openai
+
+**Tags**: `agentic_misconfigured_readiness_probe`
+
+### Query
+
+```
+The catalog-index-service in the discovery-hub namespace appears to
+be running but is not becoming Ready. The pod name resembles a
+Kubernetes Service, but it is actually a Pod.
+
+Investigate why catalog-index-service is not ready, identify the
+root cause, and propose a fix.
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ✅ PASS (score: 0.90)
+
+> Proposal evaluation correctness: diagnosis=0.90, execution=N/A, verification=N/A, avg=0.90 — Diagnosis is largely correct: it identifies the specific pod, the failing HTTP readiness probe on port 9200, and the absence of an HTTP server as the cause of the repeated connection-refused failures. However, the proposed fixes are somewhat over-specific and include recreating the pod rather than the simpler expected options of adding an HTTP server, changing to an exec probe, or removing the probe. Execution and verification were not run, so they are N/A.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+The catalog-index-service in the discovery-hub namespace appears to
+be running but is not becoming Ready. The pod name resembles a
+Kubernetes Service, but it is actually a Pod.
+
+Investigate why catalog-index-service is not ready, identify the
+root cause, and propose a fix.
+
+
+## Analysis
+
+2 option(s) proposed
+
+### Option 0 (Approved): Recreate the Pod with a matching health endpoint
+**Diagnosis:** `catalog-index-service` in namespace `discovery-hub` is a standalone Pod, not a Service-backed workload. The Pod is `Running` but `0/1 Ready` because the only container, `indexer`, runs `sh -c 'while true; do echo '"'"'Running...'"'"'; sleep 5; done'` and does not start any HTTP server. At the same time, the Pod declares a readiness probe `http-get http://:9200/healthz` with `initialDelaySeconds=2`, `periodSeconds=4`, and `timeoutSeconds=1`. `oc describe pod` shows repeated kubelet events: `Readiness probe failed: Get "http://10.131.0.162:9200/healthz": dial tcp 10.131.0.162:9200: connect: connection refused`. Container logs only show repeated `Running...` messages, confirming the process is alive but not serving the probe endpoint. There is no owner reference on the Pod, so the fix must be applied directly to this Pod manifest or by recreating the Pod with corrected settings. (Confidence: High)
+**Root Cause:** The `catalog-index-service` Pod never listens on port 9200, so its HTTP readiness probe to `/healthz` fails with `connection refused`.
+**Proposed Actions:**
+1. [pre-check] Pre-check the current standalone Pod spec, including its command and readiness probe
+2. [pre-check] Pre-check the failing readiness probe events before making changes
+3. [mutation] Remove the broken standalone Pod so it can be recreated with a corrected spec
+4. [mutation] Recreate the Pod so the container actually listens on port 9200 and returns HTTP 200 for the readiness probe
+5. [wait] Wait for the recreated Pod to satisfy readiness
+6. [post-check] Post-check that the Pod is now `1/1 Ready`
+7. [post-check] Post-check that readiness probe failures have stopped
+**Risk:** Medium | **Reversible:** Partial
+
+### Option 1 : Recreate the Pod with a process-based readiness probe
+**Diagnosis:** The Pod is healthy enough to stay `Running`, but it can never transition to `Ready` with the current probe definition. Evidence: the container command is only a sleep/log loop, container logs show repeated `Running...`, and kubelet reports repeated readiness failures with `dial tcp 10.131.0.162:9200: connect: connection refused`. Because this is a standalone Pod with no owner reference, an alternative fix is to keep the current command and change the readiness probe to match what the container can actually satisfy, for example a simple exec probe. (Confidence: High)
+**Root Cause:** The readiness probe is misconfigured for the current container behavior; the container runs an infinite shell loop and exposes no HTTP server on `:9200/healthz`.
+**Proposed Actions:**
+1. [pre-check] Pre-check the current Pod definition before replacement
+2. [pre-check] Pre-check the current readiness probe failure mode
+3. [mutation] Delete the standalone Pod so it can be recreated with a probe that matches the running process
+4. [mutation] Recreate the Pod with an exec readiness probe that validates the actual running process instead of a nonexistent HTTP endpoint
+5. [wait] Wait for the Pod to become Ready with the corrected probe
+6. [post-check] Post-check that the Pod now reports `1/1 Ready`
+7. [post-check] Post-check that readiness failures no longer show `connection refused`
+**Risk:** Medium | **Reversible:** Partial
+
+## Outcome
+
+Analysis complete with 2 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## misconfigured_readiness_probe_gemini
+
+**Tags**: `agentic_misconfigured_readiness_probe`
+
+### Query
+
+```
+The catalog-index-service in the discovery-hub namespace appears to
+be running but is not becoming Ready. The pod name resembles a
+Kubernetes Service, but it is actually a Pod.
+
+Investigate why catalog-index-service is not ready, identify the
+root cause, and propose a fix.
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ✅ PASS (score: 0.80)
+
+> Proposal evaluation correctness: diagnosis=0.80, execution=N/A, verification=N/A, avg=0.80 — The diagnosis is largely correct: it identifies the readiness probe on the indexer container as the reason the pod never becomes Ready, and it correctly notes that nothing is listening on port 9200. However, the proposed fix is somewhat off-target and risky because it suggests patching the pod command to run a temporary web server with nc rather than recommending the more appropriate probe/container alignment or a proper application-side health endpoint. No execution or verification phases ran, so those dimensions are not applicable.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+The catalog-index-service in the discovery-hub namespace appears to
+be running but is not becoming Ready. The pod name resembles a
+Kubernetes Service, but it is actually a Pod.
+
+Investigate why catalog-index-service is not ready, identify the
+root cause, and propose a fix.
+
+
+## Analysis
+
+1 option(s) proposed
+
+### Option 0 (Approved): Fix Readiness Probe by Running a Web Server
+**Diagnosis:** The `catalog-index-service` pod in the `discovery-hub` namespace has a readiness probe configured for the `indexer` container. This probe sends an HTTP GET request to `/healthz` on port 9200. 
+
+The container's command is a simple shell loop (`while true; do echo 'Running...'; sleep 5; done`) that does not start any process to listen on port 9200. 
+
+Consequently, when the `kubelet` performs the readiness check, the connection is refused, the probe fails, and the pod is never marked as `Ready`. This is confirmed by the pod events, which show the warning: `Readiness probe failed: Get "http://<pod-ip>:9200/healthz": connect: connection refused`. (Confidence: High)
+**Root Cause:** Readiness probe failing due to no process listening on the target port.
+**Proposed Actions:**
+1. [pre-check] Pre-check: Confirm the current command of the 'indexer' container. This will show the command that does not start a web server.
+2. [mutation] Mutation: Patch the pod to replace the container's command with one that starts a simple web server using `nc`. This server will listen on port 9200 and respond with '200 OK' to the readiness probe.
+3. [wait] Wait: Wait for the pod to become Ready. This confirms that the new command has fixed the readiness probe issue.
+4. [post-check] Post-check: Verify that the pod is in the 'Ready' state and running.
+**Risk:** Low | **Reversible:** Reversible
+
+## Outcome
+
+Analysis complete with 1 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## misconfigured_readiness_probe_anthropic
+
+**Tags**: `agentic_misconfigured_readiness_probe`
+
+### Query
+
+```
+The catalog-index-service in the discovery-hub namespace appears to
+be running but is not becoming Ready. The pod name resembles a
+Kubernetes Service, but it is actually a Pod.
+
+Investigate why catalog-index-service is not ready, identify the
+root cause, and propose a fix.
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ✅ PASS (score: 0.95)
+
+> Proposal evaluation correctness: diagnosis=0.95, execution=N/A, verification=N/A, avg=0.95 — The diagnosis is largely correct: it identifies the specific pod, the failing HTTP readiness probe on /healthz:9200, and the fact that the busybox container only runs a shell loop and never starts an HTTP server, which matches the expected root cause. However, the workflow includes two remediation options and one is somewhat over-scoped relative to the expected fix; still, both options are directionally valid and safe. No execution or verification phases ran, so those dimensions are N/A.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+The catalog-index-service in the discovery-hub namespace appears to
+be running but is not becoming Ready. The pod name resembles a
+Kubernetes Service, but it is actually a Pod.
+
+Investigate why catalog-index-service is not ready, identify the
+root cause, and propose a fix.
+
+
+## Analysis
+
+2 option(s) proposed
+
+### Option 0 (Approved): Replace HTTP readiness probe with an exec probe
+**Diagnosis:** ## Root Cause Analysis
+
+The pod `catalog-index-service` in `discovery-hub` has a **mismatch between its readiness probe and its container command**.
+
+### Symptoms
+- Pod is `Running` but `Ready: False` (0/1 containers ready)
+- Repeated `Warning Unhealthy` events: `Readiness probe failed: Get "http://10.131.0.162:9200/healthz": dial tcp 10.131.0.162:9200: connect: connection refused`
+- The container has never been ready since creation and has 0 restarts
+
+### Findings
+1. **Container command**: `sh -c 'while true; do echo Running...; sleep 5; done'` — a simple infinite loop that prints "Running..." every 5 seconds. **It does not start any HTTP server.**
+2. **Readiness probe**: `httpGet` on path `/healthz`, port `9200`, with `periodSeconds: 4`, `failureThreshold: 2`. This probe tries to make an HTTP connection to port 9200 every 4 seconds.
+3. **Port 9200 declaration**: The pod declares `containerPort: 9200` named `health`, but this is only metadata — it does not cause anything to actually listen on that port.
+4. **Image**: `busybox:1.36` — a minimal image that does include a basic `httpd`, but the container command never starts it.
+5. **No Services** exist in the namespace selecting this pod, so the NotReady state only affects the pod's own `Ready` condition.
+
+### Conclusion
+The readiness probe will **never succeed** because port 9200 has no listener. The probe type must be changed to match what the container actually runs, or the container must be modified to serve health on port 9200. (Confidence: High)
+**Root Cause:** Readiness probe performs httpGet on port 9200 but the container command is a shell loop that never starts an HTTP server — nothing listens on port 9200
+**Proposed Actions:**
+1. [pre-check] Confirm the pod is currently NotReady before making changes
+2. [pre-check] Inspect the current readiness probe configuration to confirm it uses httpGet on port 9200
+3. [mutation] Export the current pod spec, strip runtime fields, and replace the httpGet readiness probe with an exec probe running 'true'
+4. [mutation] Delete the existing pod (spec is immutable, so delete-recreate is required)
+5. [mutation] Recreate the pod with the corrected exec-based readiness probe
+6. [wait] Wait for the pod to become Ready with the new probe
+7. [post-check] Verify the pod is Running and Ready (1/1)
+8. [post-check] Confirm the readiness probe is now exec-based, not httpGet
+**Risk:** Medium | **Reversible:** Reversible
+
+### Option 1 : Add busybox httpd to serve /healthz on port 9200
+**Diagnosis:** ## Root Cause Analysis
+
+Same root cause as Option 1: the container command is a simple shell loop that never starts an HTTP server, while the readiness probe expects `httpGet` responses on port 9200. The difference in this option is the remediation approach — rather than changing the probe, we fix the container to actually serve HTTP.
+
+### Key Evidence
+- Container command: `while true; do echo 'Running...'; sleep 5; done` — no HTTP server
+- Readiness probe: `httpGet /healthz` on port 9200 — expects HTTP
+- Events show continuous `connection refused` on `10.131.0.162:9200`
+- `busybox:1.36` includes a built-in `httpd` that can serve static files (Confidence: High)
+**Root Cause:** Readiness probe performs httpGet on port 9200 but the container command is a shell loop that never starts an HTTP server — nothing listens on port 9200
+**Proposed Actions:**
+1. [pre-check] Confirm the pod is currently NotReady before making changes
+2. [mutation] Export pod spec and replace the command to start busybox httpd on port 9200 with a /healthz file before running the main loop
+3. [mutation] Delete the existing pod
+4. [mutation] Recreate the pod with the httpd-enabled command
+5. [wait] Wait for the pod to become Ready with httpd serving the health endpoint
+6. [post-check] Verify the pod is Running and Ready (1/1)
+7. [post-check] Verify the /healthz endpoint returns 'ok' from inside the container
+**Risk:** Medium | **Reversible:** Reversible
+
+## Outcome
+
+Analysis complete with 2 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## mismatched_ingress_rule_openai
+
+**Tags**: `agentic_mismatched_ingress_rule`
+
+### Query
+
+```
+The web-portal application in the platform-core namespace is
+getting timeouts when trying to connect to the api-gateway
+service. The api-gateway pod itself appears to be running and
+healthy.
+
+Investigate why web-portal cannot reach api-gateway-svc and
+identify the root cause.
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ✅ PASS (score: 0.97)
+
+> Proposal evaluation correctness: diagnosis=0.97, execution=N/A, verification=N/A, avg=0.97 — The diagnosis matches the expected root cause closely: it identifies the specific NetworkPolicy `restrict-api-gateway-ingress` as blocking traffic from `web-portal` because the policy only allows sources with `tier=backend`, while `web-portal` is labeled `tier=frontend`. The proposed remediation is also appropriate and safe, though slightly broader than necessary because it suggests allowing `web-portal` or relabeling rather than strictly choosing one minimal fix. No execution phase ran, and no verification phase was configured, so those dimensions are N/A.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+The web-portal application in the platform-core namespace is
+getting timeouts when trying to connect to the api-gateway
+service. The api-gateway pod itself appears to be running and
+healthy.
+
+Investigate why web-portal cannot reach api-gateway-svc and
+identify the root cause.
+
+
+## Analysis
+
+1 option(s) proposed
+
+### Option 0 (Approved): Patch the api-gateway NetworkPolicy to allow web-portal
+**Diagnosis:** `web-portal` cannot reach `api-gateway-svc` because namespace-local service discovery and endpoints are healthy, but ingress to the backend pod is explicitly denied by network policy.
+
+Findings:
+- `api-gateway-svc` exists in `platform-core` with ClusterIP `172.30.66.118` and a live endpoint `10.131.0.166:8080`.
+- `api-gateway` pod `api-gateway-7f4c5f99f9-t666p` is `Running` and logs show normal nginx startup, with no application failure.
+- `web-portal` pod `web-portal-6f9d97fbc9-76fbk` is `Running`, but its logs repeatedly show `ERROR: Connection timeout to api-gateway-svc!`.
+- `NetworkPolicy/restrict-api-gateway-ingress` selects pods with `app=api-gateway` and allows TCP/8080 ingress only from pods matching `tier=backend`.
+- The `web-portal` pod labels are `app=web-portal`, `tier=frontend`, so it does not match the allowed source selector.
+
+This explains the symptom exactly: the service resolves and has endpoints, the backend pod is healthy, but OVN/Kubernetes policy blocks packets from `web-portal` to `api-gateway`. (Confidence: High)
+**Root Cause:** `NetworkPolicy/restrict-api-gateway-ingress` only allows ingress to `api-gateway` from pods labeled `tier=backend`, but `web-portal` pods are labeled `tier=frontend`, so traffic to `api-gateway-svc:8080` is dropped.
+**Proposed Actions:**
+1. [pre-check] Pre-check the current NetworkPolicy definition before making changes
+2. [pre-check] Confirm the current web-portal pod labels that must be allowed by policy
+3. [pre-check] Confirm the service and its endpoint are present before changing policy
+4. [mutation] Allow ingress to api-gateway on TCP/8080 from web-portal pods while preserving the existing backend allowance
+5. [wait] Verify the NetworkPolicy now includes a source selector for web-portal
+6. [post-check] Check web-portal logs for successful connections after the policy change
+7. [post-check] Confirm the web-portal pod remains healthy after the change
+8. [post-check] Confirm the api-gateway pod remains healthy after the change
+**Risk:** Medium | **Reversible:** Reversible
+
+## Outcome
+
+Analysis complete with 1 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## mismatched_ingress_rule_gemini
+
+**Tags**: `agentic_mismatched_ingress_rule`
+
+### Query
+
+```
+The web-portal application in the platform-core namespace is
+getting timeouts when trying to connect to the api-gateway
+service. The api-gateway pod itself appears to be running and
+healthy.
+
+Investigate why web-portal cannot reach api-gateway-svc and
+identify the root cause.
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ✅ PASS (score: 1.00)
+
+> Proposal evaluation correctness: diagnosis=1.00, execution=N/A, verification=N/A, avg=1.00 — The diagnosis matches the expected root cause: a restrictive NetworkPolicy named restrict-api-gateway-ingress is blocking web-portal traffic because it only allows ingress from tier=backend pods while web-portal is tier=frontend. However, only the analysis phase ran, so no remediation was actually executed and no verification was performed; those dimensions are therefore N/A.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+The web-portal application in the platform-core namespace is
+getting timeouts when trying to connect to the api-gateway
+service. The api-gateway pod itself appears to be running and
+healthy.
+
+Investigate why web-portal cannot reach api-gateway-svc and
+identify the root cause.
+
+
+## Analysis
+
+1 option(s) proposed
+
+### Option 0 (Approved): Update Network Policy to Allow Web-Portal Access
+**Diagnosis:** The `web-portal` application is experiencing timeouts when attempting to connect to the `api-gateway` service. This is due to an existing `NetworkPolicy` named `restrict-api-gateway-ingress` which only permits ingress traffic to `api-gateway` pods from pods with the label `tier=backend`. The `web-portal` pods have the label `tier=frontend`, and as a result, their connection attempts are being blocked. The fix is to update the network policy to also allow traffic from pods with the `tier=frontend` label. (Confidence: High)
+**Root Cause:** A restrictive network policy is blocking traffic from the web-portal to the api-gateway.
+**Proposed Actions:**
+1. [pre-check] This command retrieves the current network policy to show its state before any modifications.
+2. [mutation] This command patches the network policy to add a new rule that allows ingress from pods with the 'tier=frontend' label. This will allow the web-portal to connect to the api-gateway.
+3. [post-check] This command retrieves the network policy again to verify that the patch was applied correctly and the new rule is in place.
+**Risk:** Low | **Reversible:** Reversible
+
+## Outcome
+
+Analysis complete with 1 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## mismatched_ingress_rule_anthropic
+
+**Tags**: `agentic_mismatched_ingress_rule`
+
+### Query
+
+```
+The web-portal application in the platform-core namespace is
+getting timeouts when trying to connect to the api-gateway
+service. The api-gateway pod itself appears to be running and
+healthy.
+
+Investigate why web-portal cannot reach api-gateway-svc and
+identify the root cause.
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ✅ PASS (score: 0.98)
+
+> Proposal evaluation correctness: diagnosis=0.98, execution=N/A, verification=N/A, avg=0.98 — The diagnosis matches the expected root cause: a NetworkPolicy on api-gateway is denying ingress from web-portal because web-portal has tier=frontend while the policy only allows tier=backend. The proposed remediation is also aligned and appropriately scoped, though it includes some extra pre/post checks that are not necessary for root-cause identification. No execution phase ran, and no verification phase was configured, so both are N/A.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+The web-portal application in the platform-core namespace is
+getting timeouts when trying to connect to the api-gateway
+service. The api-gateway pod itself appears to be running and
+healthy.
+
+Investigate why web-portal cannot reach api-gateway-svc and
+identify the root cause.
+
+
+## Analysis
+
+1 option(s) proposed
+
+### Option 0 (Approved): Update NetworkPolicy to allow frontend tier ingress
+**Diagnosis:** ## Root Cause Analysis
+
+**Problem:** The `web-portal` pod cannot reach `api-gateway-svc` on port 8080, resulting in connection timeouts.
+
+**Findings:**
+
+1. **Both pods are Running and Ready** — `api-gateway-7f4c5f99f9-t666p` (1/1 Running) and `web-portal-6f9d97fbc9-76fbk` (1/1 Running). Both are on the same node (`ip-10-0-30-162`), ruling out cross-node networking issues.
+
+2. **Service and Endpoints are correct** — `api-gateway-svc` (ClusterIP `172.30.66.118:8080`) has a healthy endpoint (`10.131.0.166:8080`) matching the api-gateway pod IP. Service selector `app=api-gateway` correctly matches the pod.
+
+3. **NetworkPolicy is the blocker** — The `restrict-api-gateway-ingress` NetworkPolicy:
+   - **Applies to:** pods with `app=api-gateway`
+   - **Allows ingress from:** pods with `tier=backend` only, on port 8080/TCP
+   - **Effect:** All other ingress is **denied by default** (Kubernetes NetworkPolicy deny-by-default behavior when a policy selects a pod)
+
+4. **Label mismatch:**
+   - `api-gateway` pod labels: `app=api-gateway`, **`tier=backend`**
+   - `web-portal` pod labels: `app=web-portal`, **`tier=frontend`**
+   - The web-portal has `tier=frontend`, which does **not** match the NetworkPolicy's `from` selector of `tier=backend`. Traffic is silently dropped.
+
+5. **Web-portal logs confirm** continuous `ERROR: Connection timeout to api-gateway-svc!` messages, consistent with packets being dropped by the NetworkPolicy (connections hang until the 5-second curl timeout). (Confidence: High)
+**Root Cause:** NetworkPolicy restrict-api-gateway-ingress blocks ingress from tier=frontend pods (web-portal) — only tier=backend is allowed
+**Proposed Actions:**
+1. [pre-check] Inspect the current NetworkPolicy definition to confirm the existing ingress rules before modification
+2. [pre-check] Identify all pods with tier=frontend that will be granted access by this change
+3. [mutation] Add a second 'from' entry to the existing ingress rule allowing pods with tier=frontend to reach api-gateway on port 8080
+4. [post-check] Verify the NetworkPolicy now includes both tier=backend and tier=frontend in its ingress from selectors
+5. [wait] Wait a few seconds for OVN-Kubernetes to propagate the updated network policy rules to the dataplane
+6. [post-check] Check web-portal logs to confirm it can now successfully reach api-gateway-svc (should show 'api-gateway-svc responded OK')
+**Risk:** Low | **Reversible:** Reversible
+
+## Outcome
+
+Analysis complete with 1 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## scheduled_outage_openai
+
+**Tags**: `agentic_scheduled_outage`
+
+### Query
+
+```
+The report-generator in the analytics-platform namespace is
+processing historical records. Analyze the pod logs to identify
+any issues that occurred between 03:00 and 04:00.
+
+Investigate the root cause and determine whether this is a
+recurring pattern or an isolated incident.
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ✅ PASS (score: 0.80)
+
+> Proposal evaluation correctness: diagnosis=0.80, execution=N/A, verification=N/A, avg=0.80 — The diagnosis is largely correct: it identifies repeated upstream timeouts to https://reports-upstream.internal/v2/ingest during the 03:00-03:05 window and correctly treats the issue as time-bounded and likely tied to upstream maintenance rather than a report-generator bug. However, it includes some unsupported specifics (e.g., exact log counts, timestamps, and a warning about scheduled maintenance) that appear hallucinated relative to the expected outcome, and the proposed StatefulSet mutation is over-scoped for an incident that appears isolated. No execution phase ran, and no verification phase ran, so both are N/A.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+The report-generator in the analytics-platform namespace is
+processing historical records. Analyze the pod logs to identify
+any issues that occurred between 03:00 and 04:00.
+
+Investigate the root cause and determine whether this is a
+recurring pattern or an isolated incident.
+
+
+## Analysis
+
+1 option(s) proposed
+
+### Option 0 (Approved): Harden `report-generator` against brief upstream outages
+**Diagnosis:** `report-generator-0` in namespace `analytics-platform` stayed healthy at the pod level, but its application logs show a burst of request failures between **03:00 and 04:00**. Evidence from `kubectl logs -n analytics-platform report-generator-0 --timestamps` shows **36 consecutive `level=ERROR` entries** from `ts=2026-07-13T03:00:00.732Z` through `ts=2026-07-13T03:05:58.732Z`, all with the same message: `reason=upstream unreachable url=https://reports-upstream.internal/v2/ingest err=timeout after 5000ms`. The app also emitted a warning at `2026-07-13T03:00:00.732Z`: `Detected repeated failures during 03:00-03:05 window hint=possible scheduled maintenance upstream`.
+
+The failure stopped without any pod restart or workload change. Immediately afterward, normal processing resumed at `03:06:08.732Z` with `Report batch completed...`, and periodic `System health check passed latency_ms=...` messages continued throughout the rest of the 03:00–04:00 hour. Kubernetes events only show normal pod startup activity for the current pod instance and no runtime failures relevant to the incident. This points to an **external dependency timeout**, not a container, node, or Kubernetes scheduling problem.
+
+On recurrence: within the retained log sample, the same 03:00–03:05 failure pattern appears on **2026-07-13** only. A check for `level=ERROR` during the prior day's `03:00` hour returned no matches, so this looks **isolated in the available logs**, though the application's own warning suggests it may align with a scheduled upstream maintenance window. (Confidence: High)
+**Root Cause:** `report-generator` hit a transient upstream outage: `reports-upstream.internal/v2/ingest` timed out repeatedly from 03:00:00Z to 03:05:58Z on 2026-07-13
+**Proposed Actions:**
+1. [pre-check] Pre-check the current StatefulSet spec before making any changes
+2. [pre-check] Pre-check the currently running report-generator pod and placement
+3. [pre-check] Reconfirm the exact failure pattern before changing the workload
+4. [mutation] Patch the StatefulSet to increase tolerance to short upstream outages by adding timeout/retry and optional maintenance-window controls
+5. [wait] Wait for the StatefulSet rollout to complete
+6. [post-check] Confirm the replacement pod is running after rollout
+7. [wait] Wait until the report-generator pod reports Ready
+8. [post-check] Verify the new environment settings are present in the StatefulSet template
+9. [post-check] Verify recent logs show normal batch completion and no repeated upstream timeout storm
+**Risk:** Medium | **Reversible:** Partial
+
+## Outcome
+
+Analysis complete with 1 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## scheduled_outage_gemini
+
+**Tags**: `agentic_scheduled_outage`
+
+### Query
+
+```
+The report-generator in the analytics-platform namespace is
+processing historical records. Analyze the pod logs to identify
+any issues that occurred between 03:00 and 04:00.
+
+Investigate the root cause and determine whether this is a
+recurring pattern or an isolated incident.
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ❌ FAIL (score: 0.10)
+
+> Proposal evaluation correctness: diagnosis=0.10, execution=N/A, verification=N/A, avg=0.10 — The diagnosis is incorrect: it attributes the issue to a missing Secret and a FailedMount restart loop, but the expected root cause is repeated upstream API timeouts during the 03:00-03:05 window. The proposed action to create a placeholder script Secret is not aligned with the actual failure and would not address the reported upstream connectivity problem. No execution or verification phases ran, so both are N/A.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+The report-generator in the analytics-platform namespace is
+processing historical records. Analyze the pod logs to identify
+any issues that occurred between 03:00 and 04:00.
+
+Investigate the root cause and determine whether this is a
+recurring pattern or an isolated incident.
+
+
+## Analysis
+
+1 option(s) proposed
+
+### Option 0 (Approved): Create Missing Log Generator Script
+**Diagnosis:** The `report-generator-0` pod in the `analytics-platform` namespace is in a restart loop due to a `FailedMount` error. The pod's definition specifies a volume mount `/opt/scripts` that expects to be populated from a Secret named `report-generator-logs-script`. This Secret does not exist in the namespace, causing the pod to fail to initialize.
+
+The container's command is set to execute `/opt/scripts/generate_logs.py`, so the missing Secret is expected to contain this Python script. The recent creation time of the pod and the absence of older pods suggest this is a recurring problem preventing the application from running. (Confidence: High)
+**Root Cause:** The 'report-generator-0' pod is failing to start because it is unable to mount a volume named 'log-scripts', which is backed by a missing Secret 'report-generator-logs-script'.
+**Proposed Actions:**
+1. [pre-check] Check if the secret exists before creating it. This command is expected to fail.
+2. [mutation] Creates the missing 'report-generator-logs-script' Secret with a 'generate_logs.py' key. The script is a placeholder that logs a message every 10 seconds.
+3. [post-check] Verify that the secret was created successfully.
+4. [wait] Wait for the StatefulSet to become healthy after the secret is created.
+5. [post-check] Verify the pod is running and ready.
+**Risk:** Low | **Reversible:** Reversible
+
+## Outcome
+
+Analysis complete with 1 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## scheduled_outage_anthropic
+
+**Tags**: `agentic_scheduled_outage`
+
+### Query
+
+```
+The report-generator in the analytics-platform namespace is
+processing historical records. Analyze the pod logs to identify
+any issues that occurred between 03:00 and 04:00.
+
+Investigate the root cause and determine whether this is a
+recurring pattern or an isolated incident.
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ✅ PASS (score: 0.80)
+
+> Proposal evaluation correctness: diagnosis=0.80, execution=N/A, verification=N/A, avg=0.80 — The diagnosis is mostly aligned with the expected outcome: it correctly identifies repeated timeout failures to the upstream URL during the 03:00–03:05 window and ties them to a likely scheduled maintenance period, with normal operation outside that window. However, it adds unsupported claims about a missing Kubernetes Service/Endpoints and a specific maintenance-aware remediation plan that was not part of the observed evidence, so the root-cause attribution is somewhat overreached. No execution or verification phases ran, so those dimensions are not applicable.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+The report-generator in the analytics-platform namespace is
+processing historical records. Analyze the pod logs to identify
+any issues that occurred between 03:00 and 04:00.
+
+Investigate the root cause and determine whether this is a
+recurring pattern or an isolated incident.
+
+
+## Analysis
+
+1 option(s) proposed
+
+### Option 0 (Approved): Upstream maintenance window — add retry logic and maintenance-aware scheduling
+**Diagnosis:** ## Root Cause Analysis
+
+### Symptoms
+- **36 consecutive ERROR entries** between `2026-07-13T03:00:00Z` and `2026-07-13T03:05:58Z`
+- All errors are identical: `Report generation failed reason=upstream unreachable url=https://reports-upstream.internal/v2/ingest err=timeout after 5000ms`
+- The application itself emitted a WARN: `Detected repeated failures during 03:00-03:05 window hint=possible scheduled maintenance upstream`
+- Normal batch processing (10-second intervals, 84–412ms latency, 300–8900 rows/batch) continued without interruption before and after the window
+- No pod restarts, OOM kills, or resource exhaustion observed
+
+### Findings
+1. **External upstream dependency unreachable:** The target `https://reports-upstream.internal/v2/ingest` is not a Kubernetes Service within the cluster (no matching Service or Endpoints found in any namespace). This is an external/DNS-based dependency.
+2. **Precisely timed outage:** The failure window began at exactly `03:00:00.732Z` — a time consistent with scheduled maintenance windows.
+3. **Clean recovery:** Processing resumed automatically at `03:06:08Z` with normal latency and row counts. No restart was required.
+4. **No recurrence data from other days:** Logs span only ~24 hours (July 12 05:58 → July 13 05:59). The July 12 03:00 window is not present in the logs (pod started at 05:58). Therefore, we cannot confirm whether this is a nightly recurrence from pod logs alone.
+5. **Data loss risk:** During the 6-minute outage, 36 batch attempts failed. If the application does not have retry/replay logic for failed batches, approximately 36 batches of historical records (typically 300–8900 rows each) may have been skipped.
+6. **Overall reliability:** 8,427 successful batches vs. 36 failures = 99.6% success rate across the available log window.
+
+### Conclusion
+The root cause is that the external upstream service at `reports-upstream.internal` was unavailable during a suspected scheduled maintenance window (03:00–03:06 UTC). The report-generator has no retry/backoff mechanism and no maintenance-window awareness, so it logged 36 consecutive timeout errors before the upstream recovered on its own. (Confidence: High)
+**Root Cause:** External upstream service (reports-upstream.internal) unreachable during 03:00–03:06 UTC scheduled maintenance window, causing 36 consecutive 5-second timeout errors with no retry/backoff
+**Proposed Actions:**
+1. [pre-check] Check current StatefulSet status to confirm all replicas are healthy before any changes
+2. [pre-check] Verify the pod is currently processing successfully and the upstream is reachable now
+3. [pre-check] Confirm total error count has not increased since the original 03:00 incident (should be 36)
+4. [mutation] Create a ConfigMap defining the known upstream maintenance window and retry parameters so the application can be configured to pause or use exponential backoff during this period
+5. [mutation] Inject the maintenance window ConfigMap as environment variables into the report-generator container so the application can read and respect the maintenance schedule
+6. [wait] Wait for the StatefulSet rollout to complete after the environment variable change
+7. [post-check] Verify the new pod is running and ready after the rollout
+8. [post-check] Verify the restarted pod is processing batches normally with the new configuration
+**Risk:** Low | **Reversible:** Reversible
+
+## Outcome
+
+Analysis complete with 1 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## pending_pvc_analysis_openai
+
+**Tags**: `agentic_pending_pvc`
+
+### Query
+
+```
+PVC: memcached-data-pvc
+Namespace: cache-tier
+Status: Pending
+Description: The memcached-data-pvc PersistentVolumeClaim is stuck in
+Pending state and the memcached deployment pods cannot start.
+
+Investigate and identify the root cause
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ✅ PASS (score: 0.97)
+
+> Proposal evaluation correctness: diagnosis=0.97, execution=N/A, verification=N/A, avg=0.97 — The diagnosis correctly identifies the specific root cause: the PVC is Pending because it references a non-existent StorageClass, `standard-v2`, and the cited evidence matches the expected outcome. The proposed remediation is directionally correct, though it chooses delete-and-recreate rather than the simpler option of updating to an existing StorageClass; that is still valid because `storageClassName` is immutable. No execution or verification phases ran, so those dimensions are not applicable.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+PVC: memcached-data-pvc
+Namespace: cache-tier
+Status: Pending
+Description: The memcached-data-pvc PersistentVolumeClaim is stuck in
+Pending state and the memcached deployment pods cannot start.
+
+Investigate and identify the root cause
+
+
+## Analysis
+
+1 option(s) proposed
+
+### Option 0 (Approved): Recreate the PVC with an existing StorageClass
+**Diagnosis:** `memcached-data-pvc` in namespace `cache-tier` is stuck in `Pending` because its `spec.storageClassName` is `standard-v2`, but the cluster does not have that StorageClass. Evidence:
+
+- `kubectl describe pvc memcached-data-pvc -n cache-tier` shows repeated event `ProvisioningFailed` from `persistentvolume-controller` with exact message: `storageclass.storage.k8s.io "standard-v2" not found`.
+- `kubectl get storageclass` shows only `gp2-csi` and `gp3-csi (default)`; `standard-v2` is absent.
+- The PVC itself confirms `storageClassName: standard-v2` and remains `status.phase: Pending`.
+
+This is the direct root cause of the PVC issue. There is also a separate deployment SCC admission error on the memcached init container (`runAsUser: 65532`), but that is unrelated to why the PVC is `Pending` and is therefore not part of this remediation option. (Confidence: High)
+**Root Cause:** PVC `memcached-data-pvc` requests non-existent StorageClass `standard-v2`, so dynamic provisioning never starts and the claim remains Pending
+**Proposed Actions:**
+1. [pre-check] Pre-check the current PVC status and confirm it is still Pending
+2. [pre-check] Pre-check the PVC events and confirm the provisioning failure cites missing StorageClass `standard-v2`
+3. [pre-check] Pre-check which StorageClasses exist and identify the intended replacement class
+4. [mutation] Delete the Pending PVC because `spec.storageClassName` is immutable and cannot be patched in place
+5. [mutation] Recreate the PVC with the same size/access mode but with an existing StorageClass
+6. [wait] Wait for the new PVC to bind to a dynamically provisioned volume
+7. [post-check] Post-check that the recreated PVC is Bound and has a PV assigned
+8. [post-check] Post-check that provisioning succeeded and no missing-StorageClass events remain
+**Risk:** Medium | **Reversible:** Partial
+
+## Outcome
+
+Analysis complete with 1 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## pending_pvc_analysis_gemini
+
+**Tags**: `agentic_pending_pvc`
+
+### Query
+
+```
+PVC: memcached-data-pvc
+Namespace: cache-tier
+Status: Pending
+Description: The memcached-data-pvc PersistentVolumeClaim is stuck in
+Pending state and the memcached deployment pods cannot start.
+
+Investigate and identify the root cause
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ✅ PASS (score: 0.95)
+
+> Proposal evaluation correctness: diagnosis=0.95, execution=N/A, verification=N/A, avg=0.95 — The diagnosis matches the expected root cause: the PVC is Pending because it references a non-existent StorageClass, 'standard-v2'. However, the workflow only performed analysis; no remediation was executed and no verification phase ran, so those dimensions are not applicable. The proposed fix to switch to an existing StorageClass is directionally correct, though it assumes 'gp3-csi' is available without confirming it in the summary.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+PVC: memcached-data-pvc
+Namespace: cache-tier
+Status: Pending
+Description: The memcached-data-pvc PersistentVolumeClaim is stuck in
+Pending state and the memcached deployment pods cannot start.
+
+Investigate and identify the root cause
+
+
+## Analysis
+
+1 option(s) proposed
+
+### Option 0 (Approved): Update PVC to Use Existing StorageClass
+**Diagnosis:** The `memcached-data-pvc` PersistentVolumeClaim (PVC) is in a `Pending` state. An inspection of the PVC's events reveals the error message: `storageclass.storage.k8s.io "standard-v2" not found`. This indicates that the Kubernetes cluster does not have a StorageClass named `standard-v2` configured. Dynamic volume provisioning cannot proceed without a valid StorageClass, so the PVC remains unbound. (Confidence: High)
+**Root Cause:** PersistentVolumeClaim 'memcached-data-pvc' references a non-existent StorageClass 'standard-v2'
+**Proposed Actions:**
+1. [pre-check] Confirm the current StorageClass of the PVC.
+2. [mutation] Patch the PVC to use the existing 'gp3-csi' StorageClass, which is the default for this cluster.
+3. [wait] Wait for the PVC to become Bound, which indicates that a PersistentVolume has been successfully provisioned and attached.
+4. [post-check] Verify the final status of the PVC is 'Bound'.
+**Risk:** Low | **Reversible:** Reversible
+
+## Outcome
+
+Analysis complete with 1 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)
+
+## pending_pvc_analysis_anthropic
+
+**Tags**: `agentic_pending_pvc`
+
+### Query
+
+```
+PVC: memcached-data-pvc
+Namespace: cache-tier
+Status: Pending
+Description: The memcached-data-pvc PersistentVolumeClaim is stuck in
+Pending state and the memcached deployment pods cannot start.
+
+Investigate and identify the root cause
+```
+
+### AgenticRun #1
+
+**Completed**: ✅ PASS (score: 1.00)
+
+> Phase matches: Completed; All condition assertions passed
+
+**Correctness**: ❌ FAIL (score: 0.70)
+
+> Proposal evaluation correctness: diagnosis=0.70, execution=N/A, verification=N/A, avg=0.70 — The analysis correctly identifies the PVC root cause: it references a non-existent StorageClass, which matches the expected outcome. However, it introduces an additional SCC/init-container failure as a co-root-cause without evidence in the expected outcome, and the proposed remediation is over-scoped and unsafe for a simple Pending PVC investigation because it suggests deleting/recreating the PVC and modifying the deployment unnecessarily. No execution or verification phases ran, so those dimensions are not applicable.
+
+<details>
+<summary>See response</summary>
+
+````markdown
+## Request
+
+PVC: memcached-data-pvc
+Namespace: cache-tier
+Status: Pending
+Description: The memcached-data-pvc PersistentVolumeClaim is stuck in
+Pending state and the memcached deployment pods cannot start.
+
+Investigate and identify the root cause
+
+
+## Analysis
+
+1 option(s) proposed
+
+### Option 0 (Approved): Fix StorageClass and remove non-compliant init container
+**Diagnosis:** **Two cascading failures prevent the memcached deployment from running:**
+
+### Issue 1: PVC Pending — StorageClass not found
+- The PVC `memcached-data-pvc` specifies `storageClassName: standard-v2`
+- This StorageClass does **not exist** on the cluster
+- Available StorageClasses are: `gp2-csi` and `gp3-csi` (default)
+- The PVC event confirms: `storageclass.storage.k8s.io "standard-v2" not found`
+
+### Issue 2: Pod creation blocked — SCC UID violation
+- The init container `init-perms` explicitly sets `runAsUser: 65532`
+- The namespace `cache-tier` has UID range `1000800000/10000` (UIDs 1000800000–1000809999)
+- The `restricted-v2` SCC (the only one available to the default SA) rejects UID 65532 because it falls outside the allowed range
+- ReplicaSet `memcached-74ff9bb8dc` has 0 pods created (DESIRED=1, CURRENT=0)
+- The init container's purpose (`chmod 777 /cache`) is both **unnecessary** on OpenShift (fsGroup handles volume permissions) and **would fail** anyway since a non-root user cannot `chmod` a root-owned mount point
+
+### Root cause chain
+The PVC cannot provision → no volume available, AND pods cannot be created due to SCC violation → deployment is completely stuck with zero running pods. (Confidence: High)
+**Root Cause:** PVC references non-existent StorageClass 'standard-v2' and init container specifies runAsUser: 65532 outside the namespace UID range (1000800000-1000809999)
+**Proposed Actions:**
+1. [pre-check] Confirm the PVC is still in Pending state (no data to lose)
+2. [pre-check] Confirm the target StorageClass gp3-csi exists on the cluster
+3. [pre-check] Confirm the init container init-perms exists before attempting removal
+4. [mutation] Delete the PVC with the incorrect StorageClass (safe — it is Pending with no bound volume and no data)
+5. [mutation] Recreate the PVC with the correct StorageClass gp3-csi (cluster default, AWS EBS gp3)
+6. [mutation] Remove the init container that violates the namespace SCC UID range. OpenShift's restricted-v2 SCC automatically applies fsGroup from namespace supplemental groups, making the volume group-writable without manual chmod
+7. [wait] Wait for the deployment rollout to complete (up to 120 seconds)
+8. [post-check] Verify PVC is now Bound (it will bind once a pod is scheduled due to WaitForFirstConsumer)
+9. [post-check] Verify the memcached pod is Running and Ready
+10. [post-check] Verify deployment conditions show Available=True and no ReplicaFailure
+**Risk:** Low | **Reversible:** Reversible
+
+## Outcome
+
+Analysis complete with 1 option(s); Execution step not configured; Verification step not configured in workflow
+````
+
+</details>
+
+[Back to top](#evaluation-summary)

--- a/agentic/scheduled_outage/evals.yaml
+++ b/agentic/scheduled_outage/evals.yaml
@@ -1,7 +1,6 @@
 - conversation_group_id: scheduled_outage_openai
   tag: agentic_scheduled_outage
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+
 
   turns:
     - turn_id: turn_1
@@ -47,8 +46,7 @@
 
 - conversation_group_id: scheduled_outage_anthropic
   tag: agentic_scheduled_outage
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+
 
   turns:
     - turn_id: turn_1
@@ -94,8 +92,7 @@
 
 - conversation_group_id: scheduled_outage_gemini
   tag: agentic_scheduled_outage
-  setup_script: ./setup.sh
-  cleanup_script: ./cleanup.sh
+
 
   turns:
     - turn_id: turn_1

--- a/agentic/system.yaml
+++ b/agentic/system.yaml
@@ -2,7 +2,7 @@ logging:
   source_level: DEBUG
 
 core:
-  max_threads: 1
+  max_threads: 3
   fail_on_invalid_data: true
   skip_on_failure: false
 

--- a/scripts/run-agentic-evals.sh
+++ b/scripts/run-agentic-evals.sh
@@ -41,9 +41,6 @@ fi
 
 mkdir -p "$RESULTS_DIR"
 
-# Snapshot existing JSON files before runs
-existing_jsons=$(find "$RESULTS_DIR" -maxdepth 1 -name '*_summary.json' 2>/dev/null | sort)
-
 for run in $(seq 1 "$RUNS"); do
   for tag in "${TAGS[@]}"; do
     echo ""
@@ -55,17 +52,3 @@ for run in $(seq 1 "$RUNS"); do
       --tag "$tag"
   done
 done
-
-# Find new JSON files produced by this batch
-new_jsons=$(find "$RESULTS_DIR" -maxdepth 1 -name '*_summary.json' 2>/dev/null | sort)
-batch_jsons=$(comm -13 <(echo "$existing_jsons") <(echo "$new_jsons"))
-
-if [ -n "$batch_jsons" ]; then
-  echo ""
-  echo "==> Generating summary..."
-  # shellcheck disable=SC2086
-  "${VENV_DIR}/bin/python" "${SCRIPT_DIR}/summarize-agentic-evals.py" "$RESULTS_DIR" "$EVALS" $batch_jsons
-fi
-
-echo ""
-echo "==> All agentic evals complete. Results in ${RESULTS_DIR}/"

--- a/scripts/summarize-agentic-evals.py
+++ b/scripts/summarize-agentic-evals.py
@@ -84,14 +84,15 @@ def build_summary(
                 seen_metrics.add(mid)
                 metrics.append(mid)
 
-    total = len(runs)
     rows = []
     for cid in conversations:
+        relevant = [r for r in runs if any(x["conversation_group_id"] == cid for x in r)]
+        total = len(relevant)
         row = {}
         for mid in metrics:
-            passed = sum(1 for r in runs if metric_passed(r, cid, mid))
+            passed = sum(1 for r in relevant if metric_passed(r, cid, mid))
             row[metric_label(mid)] = (passed, total)
-        overall = sum(1 for r in runs if all_passed(r, cid, metrics))
+        overall = sum(1 for r in relevant if all_passed(r, cid, metrics))
         row["Overall"] = (overall, total)
         rows.append(row)
 
@@ -105,6 +106,51 @@ def md_cell(passed: int, total: int) -> str:
     if passed == 0:
         return f"❌ {passed}/{total}"
     return f"{passed}/{total}"
+
+
+def split_model_scenario(cid: str) -> tuple[str, str]:
+    """Split 'scenario_model' into (scenario, model) using the last _ segment."""
+    parts = cid.rsplit("_", 1)
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    return cid, ""
+
+
+def generate_pivot_table(
+    conversations: list[str],
+    rows: list[dict],
+) -> str:
+    """Build a model-vs-scenario pivot table with Overall results."""
+    scenarios = []
+    seen_scenarios = set()
+    models = []
+    seen_models = set()
+    pivot = {}
+
+    for cid, row in zip(conversations, rows):
+        scenario, model = split_model_scenario(cid)
+        if scenario not in seen_scenarios:
+            seen_scenarios.add(scenario)
+            scenarios.append(scenario)
+        if model not in seen_models:
+            seen_models.add(model)
+            models.append(model)
+        pivot[(model, scenario)] = row["Overall"]
+
+    if not models or not scenarios:
+        return ""
+
+    header = "| Model | " + " | ".join(scenarios) + " |"
+    separator = "|---|" + "|".join("---" for _ in scenarios) + "|"
+    lines = [header, separator]
+    for model in models:
+        cells = []
+        for scenario in scenarios:
+            value = pivot.get((model, scenario))
+            cells.append(format_cell(value) if value else "")
+        lines.append(f"| {model} | " + " | ".join(cells) + " |")
+    lines.append("")
+    return "\n".join(lines)
 
 
 def generate_details(
@@ -153,7 +199,12 @@ def generate_details(
             lines.append("```")
             lines.append("")
 
-        for run_idx, (json_results, csv_rows) in enumerate(zip(json_runs, csv_runs), 1):
+        relevant = [
+            (json_results, csv_rows)
+            for json_results, csv_rows in zip(json_runs, csv_runs)
+            if any(r["conversation_group_id"] == cid for r in json_results)
+        ]
+        for run_idx, (json_results, csv_rows) in enumerate(relevant, 1):
             run_metrics = [r for r in json_results if r["conversation_group_id"] == cid]
 
             lines.append(f"### AgenticRun #{run_idx}")
@@ -194,6 +245,7 @@ def generate_details(
                 lines.append("</details>")
                 lines.append("")
 
+        lines.append("[Back to top](#evaluation-summary)")
         lines.append("")
 
     return "\n".join(lines)
@@ -244,10 +296,16 @@ def generate_markdown(
     formatted = format_timestamp(timestamp)
     if formatted:
         lines.append(formatted)
-    lines.extend(["", header, separator])
+
+    pivot = generate_pivot_table(conversations, rows)
+    if pivot:
+        lines.extend(["", pivot])
+
+    lines.extend(["## Details", "", header, separator])
     for cid, row in zip(conversations, rows):
+        anchor = cid.lower().replace(" ", "-")
         cells = " | ".join(format_cell(row[c]) for c in columns)
-        lines.append(f"| {cid} | {cells} |")
+        lines.append(f"| [{cid}](#{anchor}) | {cells} |")
     lines.append("")
 
     judge_config = generate_judge_config(config)
@@ -313,31 +371,34 @@ def print_table(
     print(sep)
 
 
-def load_descriptions(evals_file: Path) -> dict[str, str]:
-    """Load conversation descriptions from evals.yaml."""
-    if not evals_file.exists():
-        return {}
-    with open(evals_file) as f:
-        data = yaml.safe_load(f)
-    if not isinstance(data, list):
-        return {}
-    return {
-        entry["conversation_group_id"]: entry.get("description", "")
-        for entry in data
-        if "conversation_group_id" in entry
-    }
+def load_descriptions(evals_files: list[Path]) -> dict[str, str]:
+    """Load conversation descriptions from one or more evals YAML files."""
+    descriptions = {}
+    for evals_file in evals_files:
+        if not evals_file.exists():
+            continue
+        with open(evals_file) as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, list):
+            continue
+        for entry in data:
+            if "conversation_group_id" in entry:
+                descriptions[entry["conversation_group_id"]] = entry.get("description", "")
+    return descriptions
 
 
 def main():
-    if len(sys.argv) < 4:
-        print(f"Usage: {sys.argv[0]} RESULTS_DIR EVALS_YAML JSON_FILE [JSON_FILE ...]")
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} RESULTS_DIR FILE [FILE ...]")
+        print("  Files ending in .yaml are treated as evals configs,")
+        print("  files ending in .json as summary results.")
         sys.exit(1)
 
     results_dir = Path(sys.argv[1])
-    evals_file = Path(sys.argv[2])
-    json_files = [Path(f) for f in sys.argv[3:]]
+    evals_files = [Path(f) for f in sys.argv[2:] if f.endswith(".yaml")]
+    json_files = [Path(f) for f in sys.argv[2:] if f.endswith(".json")]
 
-    descriptions = load_descriptions(evals_file)
+    descriptions = load_descriptions(evals_files)
     json_runs, config, timestamp = load_json_data(json_files)
     csv_runs = load_csv_data(json_files)
     conversations, columns, rows = build_summary(json_runs)

--- a/scripts/summarize-agentic-evals.py
+++ b/scripts/summarize-agentic-evals.py
@@ -290,7 +290,7 @@ def generate_markdown(
     descriptions: dict[str, str],
     timestamp: str = "",
 ) -> str:
-    header = "| Test | " + " | ".join(columns) + " |"
+    header = "| Scenario | " + " | ".join(columns) + " |"
     separator = "|---|" + "|".join("---" for _ in columns) + "|"
     lines = ["# Evaluation Summary"]
     formatted = format_timestamp(timestamp)
@@ -389,14 +389,22 @@ def load_descriptions(evals_files: list[Path]) -> dict[str, str]:
 
 def main():
     if len(sys.argv) < 3:
-        print(f"Usage: {sys.argv[0]} RESULTS_DIR FILE [FILE ...]")
+        print(f"Usage: {sys.argv[0]} RESULTS_DIR [--output FILE] FILE [FILE ...]")
         print("  Files ending in .yaml are treated as evals configs,")
         print("  files ending in .json as summary results.")
+        print("  --output FILE  Write summary to FILE instead of RESULTS_DIR/summary.md")
         sys.exit(1)
 
-    results_dir = Path(sys.argv[1])
-    evals_files = [Path(f) for f in sys.argv[2:] if f.endswith(".yaml")]
-    json_files = [Path(f) for f in sys.argv[2:] if f.endswith(".json")]
+    args = sys.argv[1:]
+    results_dir = Path(args.pop(0))
+
+    output_path = None
+    if args and args[0] == "--output":
+        args.pop(0)
+        output_path = Path(args.pop(0))
+
+    evals_files = [Path(f) for f in args if f.endswith(".yaml")]
+    json_files = [Path(f) for f in args if f.endswith(".json")]
 
     descriptions = load_descriptions(evals_files)
     json_runs, config, timestamp = load_json_data(json_files)
@@ -404,7 +412,7 @@ def main():
     conversations, columns, rows = build_summary(json_runs)
     total_runs = len(json_runs)
 
-    output = results_dir / "summary.md"
+    output = output_path or results_dir / "summary.md"
     output.write_text(
         generate_markdown(
             conversations, columns, rows, total_runs, json_runs, csv_runs, config,


### PR DESCRIPTION
  - Run setup/cleanup once per eval run instead of per-suite, and fix the summarizer to use "Scenario" instead of "Test"
  - Restructure results directory: summaries go to results/results_DATETIME.md (tracked in git), logs go to results/logs/DATETIME/
  (gitignored)
  - Add --output flag to summarize-agentic-evals.py for custom summary path