### PR TITLE
fix: remove hardcoded runAsUser from missing_envvar scenario

### DIFF
--- a/agentic/missing_envvar/fixtures/deployment.yaml
+++ b/agentic/missing_envvar/fixtures/deployment.yaml
@@ -35,7 +35,6 @@ spec:
           while true; do echo hello; sleep 10; done
         securityContext:
           runAsNonRoot: true
-          runAsUser: 65532
           allowPrivilegeEscalation: false
           capabilities:
             drop:


### PR DESCRIPTION
The hardcoded runAsUser: 65532 falls outside the OpenShift SCC UID range, preventing the pod from being created. Removing it lets OpenShift assign a valid UID so the scenario works as designed: the container starts, fails due to missing DEPLOY_ENV, and enters CrashLoopBackOff.


Assisted-by: Claude Code:claude-opus-4-6