### PR TITLE
feat: add PrometheusRule alerts to agentic scenarios

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -15,7 +15,7 @@ SUITES ?= \
 	unscheduled_pod
 RUNS ?= 1
 
-.PHONY: setup evals cleanup help
+.PHONY: setup evals cleanup deploy-alerts cleanup-alerts help
 
 setup:
 	$(SCRIPTS_DIR)/setup-venv.sh
@@ -25,6 +25,7 @@ setup:
 	@echo "This will be automated in the future."
 
 evals:
+	@$(SCRIPTS_DIR)/enable-uwm.sh
 	@for suite in $(SUITES); do \
 	  if [ ! -d "$$suite" ]; then \
 	    echo "Error: suite '$$suite' not found. Available suites:"; \
@@ -67,6 +68,25 @@ cleanup:
 	done
 	rm -rf ../venv
 	@echo "venv removed."
+
+ALERT_SUITES := crashlooping_pod oomkilled_pod pending_pvc unready_pod
+
+deploy-alerts:
+	@$(SCRIPTS_DIR)/enable-uwm.sh
+	@for suite in $(ALERT_SUITES); do \
+	  echo "==> Deploying with alerts: $$suite"; \
+	  bash $$suite/setup.sh; \
+	done
+	@echo ""
+	@echo "All alert scenarios deployed."
+
+cleanup-alerts:
+	@for suite in $(ALERT_SUITES); do \
+	  echo "==> Cleaning up: $$suite"; \
+	  bash $$suite/cleanup.sh; \
+	done
+	@echo ""
+	@echo "All alert scenarios removed."
 
 help:
 	@echo "Usage: make <target> [RUNS=N]"

--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -15,9 +15,18 @@ SUITES ?= \
 	unscheduled_pod
 RUNS ?= 1
 
-.PHONY: setup evals cleanup deploy-alerts cleanup-alerts help
+.PHONY: setup evals cleanup help
+
+ALERT_SUITES := crashlooping_pod oomkilled_pod pending_pvc unready_pod
 
 setup:
+	@$(SCRIPTS_DIR)/enable-uwm.sh
+	@for suite in $(ALERT_SUITES); do \
+	  echo "==> Deploying alert scenario: $$suite"; \
+	  bash $$suite/setup.sh; \
+	done
+	@echo ""
+	@echo "All alert scenarios deployed."
 	$(SCRIPTS_DIR)/setup-venv.sh
 	@echo ""
 	@echo "NOTE: Install lightspeed-agentic-operator manually by following:"
@@ -25,7 +34,6 @@ setup:
 	@echo "This will be automated in the future."
 
 evals:
-	@$(SCRIPTS_DIR)/enable-uwm.sh
 	@for suite in $(SUITES); do \
 	  if [ ! -d "$$suite" ]; then \
 	    echo "Error: suite '$$suite' not found. Available suites:"; \
@@ -68,25 +76,6 @@ cleanup:
 	done
 	rm -rf ../venv
 	@echo "venv removed."
-
-ALERT_SUITES := crashlooping_pod oomkilled_pod pending_pvc unready_pod
-
-deploy-alerts:
-	@$(SCRIPTS_DIR)/enable-uwm.sh
-	@for suite in $(ALERT_SUITES); do \
-	  echo "==> Deploying with alerts: $$suite"; \
-	  bash $$suite/setup.sh; \
-	done
-	@echo ""
-	@echo "All alert scenarios deployed."
-
-cleanup-alerts:
-	@for suite in $(ALERT_SUITES); do \
-	  echo "==> Cleaning up: $$suite"; \
-	  bash $$suite/cleanup.sh; \
-	done
-	@echo ""
-	@echo "All alert scenarios removed."
 
 help:
 	@echo "Usage: make <target> [RUNS=N]"

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -4,20 +4,20 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 
 ## Scenarios
 
-| Suite | Symptom | Root Cause | Difficulty |
-|-------|---------|------------|------------|
-| `failing_api` | Payment API returning 503s (100% error rate) | Reporting service leaks DB connections, exhausting the shared PostgreSQL pool | Hard |
-| `pending_pvc` | PVC stuck in Pending, pods cannot start | PVC references a StorageClass (`standard-v2`) that does not exist | Medium |
-| `recurring_batch_failure` | Batch processor errors during 03:00-03:05 UTC | Upstream service has a scheduled maintenance window causing connection timeouts | Medium |
-| `sporadic_api_timeout` | Report generator timeouts during 03:00-03:05 window | Upstream API has a scheduled maintenance window, not a bug in the application | Medium |
-| `refused_connections` | Gateway-proxy returning connection refused errors | Config hot-reload loaded staging database/cache hosts into production; staging hosts unreachable from production VPC | Medium |
-| `crashlooping_pod` | Pod in CrashLoopBackOff | Required environment variable `DEPLOY_ENV` is missing from the deployment spec | Normal |
-| `failed_job` | inventory-sync-validator Job fails | Job cannot connect to database at prod-db:3333 (connection refused) | Normal |
-| `oomkilled_pod` | Pods repeatedly OOMKilled / CrashLoopBackOff | Python app has a memory leak (~1MB/s) that exceeds the 60Mi container limit | Normal |
-| `timeout_connections` | Frontend gets connection timeouts to backend | NetworkPolicy only allows ingress from `tier=backend`, blocking `tier=frontend` pods | Normal |
-| `unbalanced_replicas` | Namespaces have different pod counts | fleet-alpha has 6 pods vs fleet-alpha1 with 9, due to different deployment sets | Normal |
-| `unready_pod` | Pod running but not becoming Ready | HTTP readiness probe targets port 9200 but container has no HTTP server | Normal |
-| `unscheduled_pod` | Pod stuck in Pending, not scheduled to any node | nodeSelector requires `disk-type=ssd-high-iops` but no nodes have this label | Normal |
+| Suite | Symptom | Root Cause | Difficulty | Alert (fires in) |
+|-------|---------|------------|------------|------------------|
+| `failing_api` | Payment API returning 503s (100% error rate) | Reporting service leaks DB connections, exhausting the shared PostgreSQL pool | Hard | |
+| `pending_pvc` | PVC stuck in Pending, pods cannot start | PVC references a StorageClass (`standard-v2`) that does not exist | Medium | ~30s |
+| `recurring_batch_failure` | Batch processor errors during 03:00-03:05 UTC | Upstream service has a scheduled maintenance window causing connection timeouts | Medium | |
+| `sporadic_api_timeout` | Report generator timeouts during 03:00-03:05 window | Upstream API has a scheduled maintenance window, not a bug in the application | Medium | |
+| `refused_connections` | Gateway-proxy returning connection refused errors | Config hot-reload loaded staging database/cache hosts into production; staging hosts unreachable from production VPC | Medium | |
+| `crashlooping_pod` | Pod in CrashLoopBackOff | Required environment variable `DEPLOY_ENV` is missing from the deployment spec | Normal | ~3min |
+| `failed_job` | inventory-sync-validator Job fails | Job cannot connect to database at prod-db:3333 (connection refused) | Normal | |
+| `oomkilled_pod` | Pods repeatedly OOMKilled / CrashLoopBackOff | Python app has a memory leak (~1MB/s) that exceeds the 60Mi container limit | Normal | ~2min |
+| `timeout_connections` | Frontend gets connection timeouts to backend | NetworkPolicy only allows ingress from `tier=backend`, blocking `tier=frontend` pods | Normal | |
+| `unbalanced_replicas` | Namespaces have different pod counts | fleet-alpha has 6 pods vs fleet-alpha1 with 9, due to different deployment sets | Normal | |
+| `unready_pod` | Pod running but not becoming Ready | HTTP readiness probe targets port 9200 but container has no HTTP server | Normal | ~1.5min |
+| `unscheduled_pod` | Pod stuck in Pending, not scheduled to any node | nodeSelector requires `disk-type=ssd-high-iops` but no nodes have this label | Normal | |
 
 ## Prerequisites
 

--- a/agentic/crashlooping_pod/cleanup.sh
+++ b/agentic/crashlooping_pod/cleanup.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
 
+oc delete -f "$FIXTURE_DIR/prometheusrule.yaml" --ignore-not-found
 oc delete -f "$FIXTURE_DIR/deployment.yaml" --ignore-not-found --wait=false
 oc delete namespace warehouse-ops --ignore-not-found
 

--- a/agentic/crashlooping_pod/fixtures/prometheusrule.yaml
+++ b/agentic/crashlooping_pod/fixtures/prometheusrule.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: warehouse-ops-alerts
+  namespace: warehouse-ops
+spec:
+  groups:
+    - name: warehouse-ops.workloads
+      rules:
+        - alert: WarehouseOpsPodRestarting
+          expr: |
+            increase(kube_pod_container_status_restarts_total{namespace="warehouse-ops"}[10m]) > 2
+          for: 15s
+          labels:
+            severity: warning
+          annotations:
+            summary: Pod {{ $labels.pod }} is restarting frequently
+            description: Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} has restarted multiple times. Check application logs and resource configuration.

--- a/agentic/crashlooping_pod/fixtures/prometheusrule.yaml
+++ b/agentic/crashlooping_pod/fixtures/prometheusrule.yaml
@@ -9,7 +9,7 @@ spec:
       rules:
         - alert: WarehouseOpsPodRestarting
           expr: |
-            increase(kube_pod_container_status_restarts_total{namespace="warehouse-ops"}[10m]) > 2
+            kube_pod_container_status_restarts_total{namespace="warehouse-ops"} > 2
           for: 15s
           labels:
             severity: warning

--- a/agentic/crashlooping_pod/setup.sh
+++ b/agentic/crashlooping_pod/setup.sh
@@ -6,6 +6,7 @@ NS="warehouse-ops"
 APP="order-fulfillment-daemon"
 
 oc apply -f "$FIXTURE_DIR/deployment.yaml"
+oc apply -f "$FIXTURE_DIR/prometheusrule.yaml"
 
 # Wait for the pod to appear
 echo "Waiting for $APP pod to be created…"

--- a/agentic/oomkilled_pod/cleanup.sh
+++ b/agentic/oomkilled_pod/cleanup.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
 
+oc delete -f "$FIXTURE_DIR/prometheusrule.yaml" --ignore-not-found
 oc delete -f "$FIXTURE_DIR/manifest.yaml" --ignore-not-found --wait=false
-oc delete namespace oom-scenario --ignore-not-found
+oc delete namespace data-processing --ignore-not-found
 
-echo "Cleanup complete: removed oom-scenario namespace and resources"
+echo "Cleanup complete: removed data-processing namespace and resources"

--- a/agentic/oomkilled_pod/evals.yaml
+++ b/agentic/oomkilled_pod/evals.yaml
@@ -6,14 +6,14 @@
     - turn_id: turn_1
       proposal_spec:
         request: |
-          Pod: awesome-application
-          Namespace: oom-scenario
+          Pod: report-generator
+          Namespace: data-processing
           Status: CrashLoopBackOff
-          Description: The awesome-application pods are repeatedly crashing.
+          Description: The report-generator pods are repeatedly crashing.
 
           Investigate and identify the root cause
         targetNamespaces:
-          - oom-scenario
+          - data-processing
         tools:
           skills:
             - image: quay.io/afalossi/agentic-skills:latest
@@ -29,7 +29,7 @@
             status: "True"
 
       expected_outcome: >-
-        Root cause: The awesome-application pods are being OOMKilled because
+        Root cause: The report-generator pods are being OOMKilled because
         the container runs a Python script that continuously allocates ~1MB
         per second, exceeding the 60Mi memory limit. The container has a
         deliberate memory leak that causes unbounded memory growth until the
@@ -51,14 +51,14 @@
     - turn_id: turn_1
       proposal_spec:
         request: |
-          Pod: awesome-application
-          Namespace: oom-scenario
+          Pod: report-generator
+          Namespace: data-processing
           Status: CrashLoopBackOff
-          Description: The awesome-application pods are repeatedly crashing.
+          Description: The report-generator pods are repeatedly crashing.
 
           Investigate and identify the root cause
         targetNamespaces:
-          - oom-scenario
+          - data-processing
         tools:
           skills:
             - image: quay.io/afalossi/agentic-skills:latest
@@ -74,7 +74,7 @@
             status: "True"
 
       expected_outcome: >-
-        Root cause: The awesome-application pods are being OOMKilled because
+        Root cause: The report-generator pods are being OOMKilled because
         the container runs a Python script that continuously allocates ~1MB
         per second, exceeding the 60Mi memory limit. The container has a
         deliberate memory leak that causes unbounded memory growth until the
@@ -96,14 +96,14 @@
     - turn_id: turn_1
       proposal_spec:
         request: |
-          Pod: awesome-application
-          Namespace: oom-scenario
+          Pod: report-generator
+          Namespace: data-processing
           Status: CrashLoopBackOff
-          Description: The awesome-application pods are repeatedly crashing.
+          Description: The report-generator pods are repeatedly crashing.
 
           Investigate and identify the root cause
         targetNamespaces:
-          - oom-scenario
+          - data-processing
         tools:
           skills:
             - image: quay.io/afalossi/agentic-skills:latest
@@ -119,7 +119,7 @@
             status: "True"
 
       expected_outcome: >-
-        Root cause: The awesome-application pods are being OOMKilled because
+        Root cause: The report-generator pods are being OOMKilled because
         the container runs a Python script that continuously allocates ~1MB
         per second, exceeding the 60Mi memory limit. The container has a
         deliberate memory leak that causes unbounded memory growth until the

--- a/agentic/oomkilled_pod/fixtures/manifest.yaml
+++ b/agentic/oomkilled_pod/fixtures/manifest.yaml
@@ -1,26 +1,26 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: oom-scenario
+  name: data-processing
   labels:
     purpose: eval-test
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: awesome-application
-  namespace: oom-scenario
+  name: report-generator
+  namespace: data-processing
   labels:
-    app: awesome-application
+    app: report-generator
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: awesome-application
+      app: report-generator
   template:
     metadata:
       labels:
-        app: awesome-application
+        app: report-generator
     spec:
       containers:
       - name: app

--- a/agentic/oomkilled_pod/fixtures/prometheusrule.yaml
+++ b/agentic/oomkilled_pod/fixtures/prometheusrule.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: data-processing-alerts
+  namespace: data-processing
+spec:
+  groups:
+    - name: data-processing.workloads
+      rules:
+        - alert: DataProcessingPodRestarting
+          expr: |
+            increase(kube_pod_container_status_restarts_total{namespace="data-processing"}[10m]) > 2
+          for: 15s
+          labels:
+            severity: warning
+          annotations:
+            summary: Pod {{ $labels.pod }} is restarting unexpectedly
+            description: Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} has restarted multiple times. Check resource limits and application logs.

--- a/agentic/oomkilled_pod/fixtures/prometheusrule.yaml
+++ b/agentic/oomkilled_pod/fixtures/prometheusrule.yaml
@@ -9,7 +9,7 @@ spec:
       rules:
         - alert: DataProcessingPodRestarting
           expr: |
-            increase(kube_pod_container_status_restarts_total{namespace="data-processing"}[10m]) > 2
+            kube_pod_container_status_restarts_total{namespace="data-processing"} > 2
           for: 15s
           labels:
             severity: warning

--- a/agentic/oomkilled_pod/setup.sh
+++ b/agentic/oomkilled_pod/setup.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
-NS="oom-scenario"
-APP="awesome-application"
+NS="data-processing"
+APP="report-generator"
 
 oc apply -f "$FIXTURE_DIR/manifest.yaml"
+oc apply -f "$FIXTURE_DIR/prometheusrule.yaml"
 
 echo "Waiting for $APP to be OOMKilled…"
 ATTEMPT=0

--- a/agentic/pending_pvc/cleanup.sh
+++ b/agentic/pending_pvc/cleanup.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 NS="cache-tier"
 
+oc delete -f "$(cd "$(dirname "$0")/fixtures" && pwd)/prometheusrule.yaml" --ignore-not-found
 oc delete pvc memcached-data-pvc -n "$NS" --ignore-not-found
 oc delete deployment memcached -n "$NS" --ignore-not-found
 oc delete svc memcached -n "$NS" --ignore-not-found

--- a/agentic/pending_pvc/fixtures/manifest.yaml
+++ b/agentic/pending_pvc/fixtures/manifest.yaml
@@ -60,6 +60,8 @@ spec:
           runAsNonRoot: true
           runAsUser: 65532
           allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
           capabilities:
             drop:
               - ALL
@@ -76,6 +78,8 @@ spec:
         securityContext:
           runAsNonRoot: true
           allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
           capabilities:
             drop:
               - ALL

--- a/agentic/pending_pvc/fixtures/prometheusrule.yaml
+++ b/agentic/pending_pvc/fixtures/prometheusrule.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cache-tier-alerts
+  namespace: cache-tier
+spec:
+  groups:
+    - name: cache-tier.storage
+      rules:
+        - alert: CacheTierPersistentVolumeClaimPending
+          expr: |
+            kube_persistentvolumeclaim_status_phase{namespace="cache-tier", phase="Pending"} == 1
+          for: 15s
+          labels:
+            severity: warning
+          annotations:
+            summary: PVC {{ $labels.persistentvolumeclaim }} is stuck in Pending
+            description: PersistentVolumeClaim {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} has been in Pending state for more than 15 seconds.

--- a/agentic/pending_pvc/setup.sh
+++ b/agentic/pending_pvc/setup.sh
@@ -6,6 +6,7 @@ NS="cache-tier"
 PVC="memcached-data-pvc"
 
 oc apply -f "$FIXTURE_DIR/manifest.yaml"
+oc apply -f "$FIXTURE_DIR/prometheusrule.yaml"
 
 # Wait for ProvisioningFailed event on the PVC
 echo "Waiting for ProvisioningFailed event on $PVC…"

--- a/agentic/unready_pod/cleanup.sh
+++ b/agentic/unready_pod/cleanup.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 NS="discovery-hub"
 
 echo "Removing unready_pod scenario resources from namespace ${NS}…"
+oc delete -f "$(cd "$(dirname "$0")/fixtures" && pwd)/prometheusrule.yaml" --ignore-not-found
 oc delete pod catalog-index-service -n "$NS" --ignore-not-found
 
 oc delete namespace "$NS" --ignore-not-found

--- a/agentic/unready_pod/fixtures/prometheusrule.yaml
+++ b/agentic/unready_pod/fixtures/prometheusrule.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: discovery-hub-alerts
+  namespace: discovery-hub
+spec:
+  groups:
+    - name: discovery-hub.workloads
+      rules:
+        - alert: DiscoveryHubPodNotReady
+          expr: |
+            min_over_time(kube_pod_status_ready{namespace="discovery-hub", condition="true"}[1m]) == 0
+          for: 15s
+          labels:
+            severity: warning
+          annotations:
+            summary: Pod {{ $labels.pod }} is not ready
+            description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a not-ready state for more than 15 seconds.

--- a/agentic/unready_pod/setup.sh
+++ b/agentic/unready_pod/setup.sh
@@ -7,6 +7,7 @@ POD_NAME="catalog-index-service"
 
 echo "Applying unready_pod scenario manifests in namespace ${NS}…"
 oc apply -f "$FIXTURE_DIR/manifest.yaml"
+oc apply -f "$FIXTURE_DIR/prometheusrule.yaml"
 
 echo "Waiting for readiness probe failure event (up to 60s)…"
 ATTEMPT=0

--- a/scripts/enable-uwm.sh
+++ b/scripts/enable-uwm.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Ensuring user workload monitoring is enabled..."
+oc apply -f - <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+EOF


### PR DESCRIPTION
Add PrometheusRule fixtures to crashlooping_pod, oomkilled_pod, pending_pvc, and unready_pod scenarios. Alert expressions use realistic metrics (restart count, PVC phase, pod readiness) that don't reveal the root cause.

Rename oomkilled_pod namespace from oom-scenario to data-processing and app from awesome-application to report-generator for realism.

Update setup/cleanup scripts to apply and remove PrometheusRules. Add deploy-alerts and cleanup-alerts Makefile targets.


Assisted-by: Claude Code:claude-opus-4-6