### PR TITLE
feat: add image pull failure troubleshooting scenario

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,22 @@ Monitoring is wired via Prometheus ServiceMonitors and PrometheusRules with aler
 - `generic/02-alert-storm/scripts/` -- shell scripts that implement each Make target
 - `generic/02-alert-storm/images/` -- Dockerfiles and Python source for all five services
 
+## Architecture: generic/03-image-pull-failure (Image Pull Failure with PDB Alert)
+
+Single `inventory` namespace with one application:
+
+- **`inventory-app`**: A simple service using Red Hat UBI (`registry.redhat.io/ubi9/ubi`) with 3 replicas. A PodDisruptionBudget requires at least 2 healthy pods.
+
+The fault: A typo is introduced in the container image reference (`ubi9/ubi9` instead of `ubi9/ubi`), causing all pods to enter `ImagePullBackOff`. With zero healthy pods, the PDB is violated and the platform-level `PodDisruptionBudgetLimit` alert fires.
+
+No custom images or PrometheusRules are needed — this scenario relies on a standard Red Hat image and the built-in OpenShift PDB alert.
+
+### Key Paths
+
+- `generic/03-image-pull-failure/README.md` -- scenario overview and components
+- `generic/03-image-pull-failure/manifests/` -- Kubernetes manifests (namespace, deployment, service, ServiceMonitor, PDB)
+- `generic/03-image-pull-failure/scripts/` -- shell scripts that implement each Make target
+
 ## Tech Stack
 
 - **Eval framework**: [lightspeed-evaluation](https://github.com/lightspeed-core/lightspeed-evaluation), Python 3.11–3.13

--- a/generic/03-image-pull-failure/Makefile
+++ b/generic/03-image-pull-failure/Makefile
@@ -1,0 +1,26 @@
+.PHONY: help deploy break fix cleanup delete-history
+
+help:
+	@echo "Image Pull Failure Scenario"
+	@echo ""
+	@echo "Available targets:"
+	@echo "  deploy            Deploy the initial healthy state"
+	@echo "  break             Introduce image typo and wait for PDB alert"
+	@echo "  fix               Restore correct image"
+	@echo "  delete-history    Reset Prometheus TSDB and restart pods"
+	@echo "  cleanup           Delete all demo resources"
+
+deploy:
+	@./scripts/deploy.sh
+
+break:
+	@./scripts/break.sh
+
+fix:
+	@./scripts/fix.sh
+
+delete-history:
+	@./scripts/delete-history.sh
+
+cleanup:
+	@./scripts/cleanup.sh

--- a/generic/03-image-pull-failure/README.md
+++ b/generic/03-image-pull-failure/README.md
@@ -1,0 +1,50 @@
+# Scenario: Image Pull Failure
+
+## Overview
+
+A Deployment with 3 replicas is running a simple inventory service backed by a Red Hat UBI image. A typo is introduced in the container image reference (`ubi9` instead of `ubi`), causing all pods to enter `ImagePullBackOff`. A PodDisruptionBudget requiring at least 2 healthy pods can no longer be satisfied, triggering the platform-level `PodDisruptionBudgetLimit` alert.
+
+## Usage
+
+```bash
+oc login ...                # required
+
+make deploy                 # deploy healthy state (3 running pods, PDB satisfied)
+make break                  # introduce image typo, wait for PDB alert to fire
+make fix                    # restore correct image
+make cleanup                # delete all resources
+```
+
+## The Root Cause
+
+The Deployment's container image is changed from `registry.redhat.io/ubi9/ubi:latest` to `registry.redhat.io/ubi9/ubi9:latest` — a subtle copy-paste typo (`ubi9` instead of `ubi`). The image does not exist, so all pods fail to pull it and enter `ImagePullBackOff`. With zero healthy pods, the PodDisruptionBudget (`minAvailable: 2`) is violated and the platform alert fires.
+
+## Components
+
+**Namespace:** `inventory`
+
+```mermaid
+graph TB
+    subgraph inventory [inventory namespace]
+        deploy[inventory-app<br/>Deployment<br/>3 replicas]
+        pdb[inventory-app-pdb<br/>PodDisruptionBudget<br/>minAvailable: 2]
+    end
+
+    pdb -.->|selector: app=inventory-app| deploy
+
+    registry[registry.redhat.io/ubi9/ubi9:latest<br/>❌ Does not exist]
+    deploy -->|ImagePullBackOff| registry
+```
+
+| Resource | Name | Details |
+|----------|------|---------|
+| Deployment | `inventory-app` | 3 replicas, image `registry.redhat.io/ubi9/ubi:latest` (healthy) |
+| PodDisruptionBudget | `inventory-app-pdb` | `minAvailable: 2` — triggers platform `PodDisruptionBudgetLimit` alert when violated |
+| PrometheusRule | `inventory-alerts` | `InventoryPodImagePullBackOff` warning alert (fires after 30s of ImagePullBackOff) |
+
+## Alerts
+
+| Alert | Source | Severity | Fires after | Condition |
+|-------|--------|----------|-------------|-----------|
+| `InventoryPodImagePullBackOff` | User workload (PrometheusRule) | warning | ~30s | Pod container stuck in `ImagePullBackOff` |
+| `PodDisruptionBudgetLimit` | Platform (built-in) | critical | ~15m | `currentHealthy < desiredHealthy` on the PDB |

--- a/generic/03-image-pull-failure/manifests/00-namespace.yaml
+++ b/generic/03-image-pull-failure/manifests/00-namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: inventory
+  labels:
+    app.kubernetes.io/name: inventory
+    app.kubernetes.io/part-of: inventory-system

--- a/generic/03-image-pull-failure/manifests/01-inventory-app.yaml
+++ b/generic/03-image-pull-failure/manifests/01-inventory-app.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory-app
+  namespace: inventory
+  labels:
+    app: inventory-app
+    app.kubernetes.io/part-of: inventory-system
+spec:
+  replicas: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: inventory-app
+  template:
+    metadata:
+      labels:
+        app: inventory-app
+        app.kubernetes.io/part-of: inventory-system
+    spec:
+      containers:
+        - name: inventory-app
+          image: registry.redhat.io/ubi9/ubi:latest
+          imagePullPolicy: Always
+          command: ["python3", "-m", "http.server", "8080"]
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5

--- a/generic/03-image-pull-failure/manifests/02-pdb.yaml
+++ b/generic/03-image-pull-failure/manifests/02-pdb.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: inventory-app-pdb
+  namespace: inventory
+  labels:
+    app: inventory-app
+    app.kubernetes.io/part-of: inventory-system
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: inventory-app

--- a/generic/03-image-pull-failure/manifests/03-prometheusrules.yaml
+++ b/generic/03-image-pull-failure/manifests/03-prometheusrules.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: inventory-alerts
+  namespace: inventory
+spec:
+  groups:
+    - name: inventory.kubernetes
+      rules:
+        - alert: InventoryPodImagePullBackOff
+          expr: |
+            max by (namespace, pod, container) (
+              kube_pod_container_status_waiting_reason{namespace="inventory", reason="ImagePullBackOff"} > 0
+            )
+          for: 30s
+          labels:
+            severity: warning
+          annotations:
+            summary: Pod {{ $labels.pod }} has ImagePullBackOff
+            description: >-
+              Container {{ $labels.container }} in pod {{ $labels.pod }}
+              (namespace {{ $labels.namespace }}) has been unable to pull its
+              image for more than 1 minute.

--- a/generic/03-image-pull-failure/scripts/break.sh
+++ b/generic/03-image-pull-failure/scripts/break.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+echo "Scenario 03 — Image Pull Failure"
+echo ""
+
+echo "=== Introducing image typo ==="
+echo "  Setting image to registry.redhat.io/ubi9/ubi9:latest (typo: ubi9 instead of ubi)..."
+oc set image deployment/inventory-app -n inventory \
+  inventory-app=registry.redhat.io/ubi9/ubi9:latest
+
+echo ""
+echo "Waiting for ImagePullBackOff..."
+while true; do
+  STATUS=$(oc get pods -n inventory -l app=inventory-app \
+    -o jsonpath='{.items[*].status.containerStatuses[*].state.waiting.reason}' 2>/dev/null || echo "")
+  if echo "$STATUS" | grep -qE "ImagePullBackOff|ErrImagePull"; then
+    echo "  Pods are in ImagePullBackOff."
+    break
+  fi
+  sleep 5
+done
+
+echo ""
+echo "PDB status:"
+oc get pdb -n inventory
+
+TOKEN=$(oc whoami -t)
+THANOS_HOST=$(oc -n openshift-monitoring get route thanos-querier -o jsonpath='{.spec.host}')
+
+echo ""
+echo "Waiting for InventoryPodImagePullBackOff alert to fire (~30s)..."
+while true; do
+  ALERT_COUNT=$(curl -sk -H "Authorization: Bearer ${TOKEN}" \
+    "https://${THANOS_HOST}/api/v1/alerts" 2>/dev/null |
+    python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(sum(1 for a in data.get('data',{}).get('alerts',[])
+          if a['labels'].get('namespace')=='inventory'
+          and a['state']=='firing'))" 2>/dev/null || echo "0")
+  echo "  Firing alerts in inventory namespace: ${ALERT_COUNT}"
+  if [ "$ALERT_COUNT" -ge 1 ] 2>/dev/null; then
+    break
+  fi
+  sleep 10
+done
+
+echo ""
+echo "Done. InventoryPodImagePullBackOff alert is firing."
+echo "Note: The platform PodDisruptionBudgetLimit (critical) alert will fire after ~15 minutes."
+echo ""
+echo "Pod status:"
+oc get pods -n inventory -l app=inventory-app

--- a/generic/03-image-pull-failure/scripts/cleanup.sh
+++ b/generic/03-image-pull-failure/scripts/cleanup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+echo "Scenario 03 — Image Pull Failure"
+echo ""
+
+echo "=== Cleaning up ==="
+oc delete namespace inventory --ignore-not-found --wait
+
+echo ""
+echo "Done."

--- a/generic/03-image-pull-failure/scripts/delete-history.sh
+++ b/generic/03-image-pull-failure/scripts/delete-history.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Scenario 03 — Image Pull Failure"
+echo ""
+
+echo "=== Deleting Prometheus history ==="
+
+PROM_PODS=(
+  "openshift-monitoring:prometheus-k8s-0"
+  "openshift-monitoring:prometheus-k8s-1"
+  "openshift-user-workload-monitoring:prometheus-user-workload-0"
+  "openshift-user-workload-monitoring:prometheus-user-workload-1"
+)
+
+for entry in "${PROM_PODS[@]}"; do
+  NS="${entry%%:*}"
+  POD="${entry##*:}"
+  echo "  Cleaning ${NS}/${POD}..."
+  oc exec -n "$NS" "$POD" -c prometheus -- \
+    rm -rf /prometheus/wal /prometheus/chunks_head /prometheus/data 2>/dev/null || true
+done
+
+echo ""
+echo "=== Restarting Prometheus pods ==="
+oc delete pod prometheus-k8s-0 prometheus-k8s-1 -n openshift-monitoring --ignore-not-found
+oc delete pod prometheus-user-workload-0 prometheus-user-workload-1 -n openshift-user-workload-monitoring --ignore-not-found
+
+echo ""
+echo "=== Deleting events in inventory namespace ==="
+oc delete events --all -n inventory 2>/dev/null || true
+
+echo ""
+echo "=== Restarting demo pods ==="
+oc delete pods --all -n inventory 2>/dev/null || true
+
+echo ""
+echo "Done."

--- a/generic/03-image-pull-failure/scripts/deploy.sh
+++ b/generic/03-image-pull-failure/scripts/deploy.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+echo "Scenario 03 — Image Pull Failure"
+echo ""
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "=== Enabling user workload monitoring ==="
+oc apply -f - <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+EOF
+
+echo ""
+echo "=== Cleaning up existing namespace ==="
+oc delete namespace inventory --ignore-not-found --wait
+
+echo ""
+echo "=== Creating namespace ==="
+oc apply -f manifests/00-namespace.yaml
+
+echo ""
+echo "=== Deploying inventory-app ==="
+oc apply -f manifests/01-inventory-app.yaml
+oc apply -f manifests/02-pdb.yaml
+oc apply -f manifests/03-prometheusrules.yaml
+
+echo ""
+echo "=== Waiting for deployment to be ready ==="
+echo "  Waiting for inventory-app..."
+oc -n inventory wait --for=condition=available deployment/inventory-app --timeout=120s
+
+echo ""
+echo "Done. All pods running in the 'inventory' namespace."
+echo ""
+echo "PDB status:"
+oc get pdb -n inventory

--- a/generic/03-image-pull-failure/scripts/fix.sh
+++ b/generic/03-image-pull-failure/scripts/fix.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+echo "Scenario 03 — Image Pull Failure"
+echo ""
+
+echo "=== Fixing image typo ==="
+echo "  Setting image to registry.redhat.io/ubi9/ubi:latest (correct image)..."
+oc set image deployment/inventory-app -n inventory \
+  inventory-app=registry.redhat.io/ubi9/ubi:latest
+
+echo ""
+echo "Waiting for rollout to complete..."
+oc rollout status deployment/inventory-app -n inventory
+
+echo ""
+echo "Done. All pods are running with the correct image."
+echo ""
+echo "PDB status:"
+oc get pdb -n inventory


### PR DESCRIPTION
Add generic/03-image-pull-failure scenario that deploys an inventory-app using a Red Hat UBI image. A typo (ubi9/ubi9 instead of ubi9/ubi) causes ImagePullBackOff, violating a PodDisruptionBudget (minAvailable: 2) and triggering both a user-workload InventoryPodImagePullBackOff warning alert (~30s) and the platform PodDisruptionBudgetLimit critical alert (~15m).


Assisted-by: Claude Code:claude-opus-4-6