### PR TITLE
feat: add control-plane alerts troubleshooting scenario

### DIFF
--- a/generic/04-control-plane-alerts/Makefile
+++ b/generic/04-control-plane-alerts/Makefile
@@ -1,0 +1,14 @@
+.PHONY: help break fix
+
+help:
+	@echo "Control Plane Alerts Scenario"
+	@echo ""
+	@echo "Available targets:"
+	@echo "  break    Misconfigure control plane components to trigger alerts"
+	@echo "  fix      Restore default configuration"
+
+break:
+	@./scripts/break.sh
+
+fix:
+	@./scripts/fix.sh

--- a/generic/04-control-plane-alerts/README.md
+++ b/generic/04-control-plane-alerts/README.md
@@ -1,0 +1,43 @@
+# Scenario: Control Plane Alerts
+
+## Overview
+
+Two independent faults are introduced into the OpenShift control plane, each causing a different set of alerts to fire:
+
+1. **Insights Operator** — The `insights-config` ConfigMap is applied with an incorrect upload endpoint, causing the operator to become degraded when it fails to report data.
+2. **NTP (chronyd)** — The `chronyd` service is disabled on a master node, causing clock drift and triggering time-synchronization alerts.
+
+No applications are deployed — this scenario operates entirely on existing cluster components.
+
+## Usage
+
+```bash
+oc login ...                # required
+
+make break                  # introduce both faults
+make fix                    # revert all changes
+```
+
+## The Faults
+
+### Insights Operator
+
+A ConfigMap override is applied to `openshift-insights` that points the upload endpoint to a wrong (but realistic-looking) URL. The Insights Operator picks up the change and fails to upload, becoming degraded.
+
+### NTP
+
+`chronyd` is disabled on the first master node via `oc debug` and the clock is shifted forward by 2 minutes. The immediate offset triggers clock-related alerts within ~10 minutes (the `for:` duration).
+
+## Expected Alerts
+
+| Alert | Severity | Fires after | Triggered by |
+|-------|----------|-------------|--------------|
+| `ClusterOperatorDegraded` | warning | ~30m | `clusteroperator/insights` reports Degraded=True |
+| `NodeClockNotSynchronising` | critical | ~10m | NTP sync lost + clock shifted by 2 minutes pushes max error past 16s immediately |
+
+## Components
+
+| Fault | Namespace / Node | What changes | How it's fixed |
+|-------|-----------------|--------------|----------------|
+| Insights upload endpoint | `openshift-insights` | ConfigMap `insights-config` with wrong `uploadEndpoint` | Delete the ConfigMap |
+| NTP disabled + clock shift | First master node | `systemctl disable --now chronyd` + `date -s '+2 minutes'` | `systemctl enable --now chronyd` (NTP syncs clock back) |

--- a/generic/04-control-plane-alerts/scripts/break.sh
+++ b/generic/04-control-plane-alerts/scripts/break.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+echo "Scenario 04 — Control Plane Alerts"
+echo ""
+
+echo "=== Breaking Insights Operator ==="
+echo "  Applying misconfigured upload endpoint..."
+oc apply -f - <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: insights-config
+  namespace: openshift-insights
+data:
+  config.yaml: |
+    dataReporting:
+      interval: 5m
+      uploadEndpoint: https://console.redhat.com/api/platform/v2/upload
+EOF
+
+echo ""
+echo "=== Breaking NTP on a master node ==="
+MASTER_NODE=$(oc get nodes --selector=node-role.kubernetes.io/master -o jsonpath='{.items[0].metadata.name}')
+echo "  Target node: ${MASTER_NODE}"
+echo "  Disabling chronyd and shifting clock forward by 2 minutes..."
+oc debug "node/${MASTER_NODE}" -- chroot /host bash -c "systemctl disable --now chronyd && date -s '+2 minutes'"
+
+echo ""
+echo "Done. Alerts may take a few minutes to fire."

--- a/generic/04-control-plane-alerts/scripts/fix.sh
+++ b/generic/04-control-plane-alerts/scripts/fix.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+echo "Scenario 04 — Control Plane Alerts"
+echo ""
+
+echo "=== Fixing Insights Operator ==="
+echo "  Removing misconfigured insights-config..."
+oc delete configmap insights-config -n openshift-insights --ignore-not-found
+
+echo ""
+echo "=== Fixing NTP on master node ==="
+MASTER_NODE=$(oc get nodes --selector=node-role.kubernetes.io/master -o jsonpath='{.items[0].metadata.name}')
+echo "  Target node: ${MASTER_NODE}"
+echo "  Re-enabling chronyd..."
+oc debug "node/${MASTER_NODE}" -- chroot /host systemctl enable --now chronyd
+
+echo ""
+echo "Done. All control plane misconfigurations have been reverted."


### PR DESCRIPTION
Introduce scenario 04 with two independent faults that trigger control-plane alerts:
- Misconfigure Insights Operator upload endpoint via ConfigMap
- Disable chronyd and shift clock on a master node

Includes break.sh, fix.sh, Makefile, and README with expected alerts and timing.


Assisted-by: Claude Code:claude-opus-4-6