### PR TITLE
feat: add deploy-easy mode with reduced difficulty for failing-api scenario

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,16 +76,14 @@ make cleanup        # Remove OLS operator + local venv
 
 ## Architecture: generic/01-payments-api-failure (Database Connection Exhaustion)
 
-Two OpenShift namespaces share a PostgreSQL database with `max_connections=20`:
+Services share a PostgreSQL database with `max_connections=20`. The fault: `reporting-service` v1.0.2 accumulates database connections without closing them, exhausting the shared pool and causing payments-api to return 503s.
 
-- **`payments`** namespace: `payments-api` (Python/FastAPI) serves `GET /api/v1/process-payment` and runs a background traffic simulator. Connects cross-namespace to `postgres.shared-services.svc.cluster.local`.
-- **`shared-services`** namespace: `postgres` (with postgres-exporter sidecar on port 9187), `reporting-service` (two versions), and `reconciliation-service` (intentional red herring, always in CrashLoopBackOff).
+Two deployment modes control difficulty:
 
-The fault: `reporting-service` v1.0.2 accumulates database connections without closing them, exhausting the shared pool and causing payments-api to return 503s from a different namespace.
+- **`make deploy-easy`**: single `payments` namespace, per-service DB users (`payments`, `reporting`), only 1 critical alert (payment error rate) and 1 warning (DB connections), no red herring.
+- **`make deploy`** (hard): two namespaces (`payments`, `shared-services`), shared `dbuser` DB account, graduated alerts (warning + critical for both payment and DB), `reconciliation-service` red herring (always in CrashLoopBackOff). Accepts `SINGLE_NAMESPACE=1` to collapse into one namespace while keeping other hard-mode traits.
 
-Monitoring is wired via Prometheus ServiceMonitors and PrometheusRules with alerts on error rate (`PaymentErrorRateHigh`) and connection count (`PostgresqlConnectionsHigh`, `PostgresqlTooManyConnections`).
-
-**Single-namespace mode**: `make deploy SINGLE_NAMESPACE=1` deploys everything into the `payments` namespace. The deploy script transforms manifests on the fly (retargets namespace, rewrites PGHOST to same-namespace service name, fixes PromQL expressions). Operational scripts (break, fix, cleanup, etc.) auto-detect the deployment mode by checking whether the `shared-services` namespace exists.
+The deploy script always works on a temp copy of manifests, applying sed transformations per mode. Operational scripts (break, fix, cleanup, etc.) auto-detect the deployment mode by checking whether the `shared-services` namespace exists.
 
 ### Key Paths
 

--- a/generic/01-payments-api-failure/Makefile
+++ b/generic/01-payments-api-failure/Makefile
@@ -6,7 +6,7 @@ help:
 	@echo "Available targets:"
 	@echo "  update-images     Build and push container images (REGISTRY=quay.io/...)"
 	@echo "  deploy            Deploy the initial state"
-	@echo "  deploy-easy       Deploy with per-service DB users (easier to diagnose)"
+	@echo "  deploy-easy       Easy mode: single namespace, per-service DB users, fewer alerts, no red herring"
 	@echo "  break             Roll out buggy reporting-service v1.0.2 and wait for failure"
 	@echo "  fix               Roll back to reporting-service v1.0.1"
 	@echo "  delete-history    Reset Prometheus TSDB and restart pods"
@@ -18,7 +18,7 @@ help:
 	@echo ""
 	@echo "Options:"
 	@echo "  SINGLE_NAMESPACE=1  Deploy everything into the payments namespace"
-	@echo "                      (only needed for deploy/deploy-easy; other targets auto-detect)"
+	@echo "                      (only for deploy; deploy-easy always uses single namespace)"
 
 update-images:
 	@./scripts/update-images.sh $(REGISTRY)
@@ -27,7 +27,7 @@ deploy:
 	@SINGLE_USER=1 SINGLE_NAMESPACE=$(SINGLE_NAMESPACE) ./scripts/deploy.sh
 
 deploy-easy:
-	@SINGLE_NAMESPACE=$(SINGLE_NAMESPACE) ./scripts/deploy.sh
+	@SINGLE_USER=0 SINGLE_NAMESPACE=1 ./scripts/deploy.sh
 
 break:
 	@./scripts/break.sh

--- a/generic/01-payments-api-failure/README.md
+++ b/generic/01-payments-api-failure/README.md
@@ -2,22 +2,35 @@
 
 ## Overview
 
-A routine service upgrade introduces a subtle database connection leak that exhausts shared infrastructure across namespaces. 
+A routine service upgrade introduces a subtle database connection leak that exhausts shared infrastructure.
 
-The reporting service rolls from a healthy v1.0.1 to a buggy v1.0.2 that never closes database connections, rapidly filling PostgreSQL's connection pool and causing the payments API in a separate namespace to fail with HTTP 503 errors. 
+The reporting service rolls from a healthy v1.0.1 to a buggy v1.0.2 that never closes database connections, rapidly filling PostgreSQL's connection pool and causing the payments API to fail with HTTP 503 errors.
 
-The AI assistant must correlate the deployment event with the cross-namespace failure and trace the connection leak to its source.
+The AI assistant must correlate the deployment event with the failure and trace the connection leak to its source.
 
 ## Usage
 
 ```bash
-export OPENAI_API_KEY=...   # required
 oc login ...                # required
 
-make deploy
-sleep 5m                    # optional, but recommended
-make break                  
+make deploy-easy            # easy mode (single namespace, fewer distractors)
+# or
+make deploy                 # hard mode (two namespaces, shared DB user, more alerts, red herring)
+
+sleep 5m                    # optional, let metrics accumulate
+make break                  # roll out buggy v1.0.2
 ```
+
+### Difficulty Modes
+
+| | `deploy-easy` | `deploy` |
+|---|---|---|
+| Namespaces | single (`payments`) | two (`payments`, `shared-services`) |
+| DB users | per-service (`payments`, `reporting`) | shared (`dbuser`) |
+| Alerts | 1 critical (payment), 1 warning (DB connections) | 2 critical (payment + DB), 2 warning (payment + DB) |
+| Red herring | none | `reconciliation-service` in CrashLoopBackOff |
+
+`deploy` also accepts `SINGLE_NAMESPACE=1` to collapse into one namespace while keeping the other hard-mode traits.
 
 ### Suggested Prompts
 
@@ -33,27 +46,27 @@ A deployment rollout updates the reporting service from v1.0.1 to v1.0.2, which 
 
 ## Components
 
-**Namespaces:** `shared-services` and `payments`
-
 ```mermaid
 graph LR
     subgraph payments [payments namespace]
         payment[payments-api<br/>Port: 8080 + 8081 metrics]
     end
 
-    subgraph shared [shared-services namespace]
+    subgraph shared [shared-services namespace *]
         postgres[(postgres<br/>max_connections: 20<br/>+ postgres-exporter sidecar :9187)]
-        report[reporting-service<br/>Port: 8081 metrics<br/>🚨 Connection leak in v1.0.2]
-        recon[reconciliation-service<br/>⚠️ Red herring]
+        report[reporting-service<br/>Port: 8081 metrics<br/>Connection leak in v1.0.2]
+        recon[reconciliation-service<br/>Red herring, deploy only]
     end
 
     payment -->|Cross-namespace access| postgres
     report --> postgres
 ```
 
+\* In easy mode and `SINGLE_NAMESPACE=1`, everything deploys to `payments`.
+
 | Service | Image | Purpose |
 |---------|-------|---------|
-| `payments-api` | Custom (Python/FastAPI) | Core payment processing API. Runs a background traffic simulator and exposes `GET /api/v1/process-payment`. **Appears independent but shares database.** |
-| `reporting-service` | Custom (Python) | Periodically queries the reports table. Has two versions: v1.0.1 (healthy) and v1.0.2 (buggy). |
-| `reconciliation-service` | `registry.redhat.io/rhel9/httpd-24:latest` (stock) | Reconciliation service. **Red herring** — overridden command exits immediately, always in CrashLoopBackOff. |
-| `postgres` | `postgres:16` + `postgres-exporter:v0.15.0` sidecar | Shared database for both services. Initialized with `max_connections = 20`. Sidecar exposes connection metrics on port 9187. |
+| `payments-api` | Custom (Python/FastAPI) | Core payment processing API. Runs a background traffic simulator and exposes `GET /api/v1/process-payment`. Shares database with reporting-service. |
+| `reporting-service` | Custom (Python) | Periodically queries the reports table. v1.0.1 (healthy) and v1.0.2 (buggy). |
+| `reconciliation-service` | `registry.redhat.io/rhel9/httpd-24:latest` (stock) | Red herring, `deploy` only. Overridden command exits immediately, always in CrashLoopBackOff. |
+| `postgres` | `postgres:16` + `postgres-exporter:v0.15.0` sidecar | Shared database. Initialized with `max_connections = 20`. Sidecar exposes connection metrics on port 9187. |

--- a/generic/01-payments-api-failure/manifests/payments/03-monitoring.yaml
+++ b/generic/01-payments-api-failure/manifests/payments/03-monitoring.yaml
@@ -25,17 +25,6 @@ spec:
         - alert: PaymentErrorRateHigh
           expr: |
             sum(rate(http_requests_total{namespace="payments", code=~"5.."}[1m]))
-            / sum(rate(http_requests_total{namespace="payments"}[1m])) * 100 > 3
-          for: 1m
-          labels:
-            severity: warning
-          annotations:
-            summary: Payment error rate exceeding threshold
-            description: Payment error rate is {{ $value | printf "%.2f" }}%, which
-              exceeds the 3% threshold.
-        - alert: PaymentErrorRateHigh
-          expr: |
-            sum(rate(http_requests_total{namespace="payments", code=~"5.."}[1m]))
             / sum(rate(http_requests_total{namespace="payments"}[1m])) * 100 > 15
           for: 1m
           labels:

--- a/generic/01-payments-api-failure/manifests/shared-services/05-prometheusrules.yaml
+++ b/generic/01-payments-api-failure/manifests/shared-services/05-prometheusrules.yaml
@@ -74,7 +74,7 @@ spec:
             sum(pg_stat_activity_count) > 13
           for: 1m
           labels:
-            severity: critical
+            severity: warning
           annotations:
             summary: Too many database connections
             description: '{{ $value }} active connections detected. This may indicate

--- a/generic/01-payments-api-failure/scripts/deploy.sh
+++ b/generic/01-payments-api-failure/scripts/deploy.sh
@@ -7,13 +7,9 @@ echo ""
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$SCRIPT_DIR"
 
-if [ "${SINGLE_USER:-}" = "1" ] || [ "${SINGLE_NAMESPACE:-}" = "1" ]; then
-  MANIFESTS=$(mktemp -d)
-  trap 'rm -rf $MANIFESTS' EXIT
-  cp -r manifests/* "$MANIFESTS/"
-else
-  MANIFESTS="manifests"
-fi
+MANIFESTS=$(mktemp -d)
+trap 'rm -rf $MANIFESTS' EXIT
+cp -r manifests/* "$MANIFESTS/"
 
 if [ "${SINGLE_USER:-}" = "1" ]; then
   # Both services use a single "dbuser" account
@@ -28,7 +24,40 @@ if [ "${SINGLE_USER:-}" = "1" ]; then
   sed -i "/CREATE USER payments/,/GRANT.*TO payments;/d" \
     "$MANIFESTS/shared-services/02-postgres.yaml"
 
+  # Upgrade database connection alert to critical (easy mode keeps it as warning)
+  sed -i '/PostgresqlTooManyConnections/,/severity:/{s/severity: warning/severity: critical/}' \
+    "$MANIFESTS/shared-services/05-prometheusrules.yaml"
+
+  # Add warning-level payment alert (easy mode only has critical)
+  cat > "$MANIFESTS/payments/03-monitoring-warning.yaml" <<'ALERT'
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: payment-alerts-warning
+  namespace: payments
+spec:
+  groups:
+    - name: payments.business.warning
+      rules:
+        - alert: PaymentErrorRateHigh
+          expr: |
+            sum(rate(http_requests_total{namespace="payments", code=~"5.."}[1m]))
+            / sum(rate(http_requests_total{namespace="payments"}[1m])) * 100 > 3
+          for: 1m
+          labels:
+            severity: warning
+          annotations:
+            summary: Payment error rate exceeding threshold
+            description: Payment error rate is {{ $value | printf "%.2f" }}%, which
+              exceeds the 3% threshold.
+ALERT
+
   echo "=== Single-user mode: all services will use 'dbuser' ==="
+else
+  rm -f "$MANIFESTS/shared-services/04-reconciliation-service.yaml"
+  sed -i '/alert: PostgresqlConnectionsHigh/,/alert: PostgresqlTooManyConnections/{/alert: PostgresqlTooManyConnections/!d}' \
+    "$MANIFESTS/shared-services/05-prometheusrules.yaml"
+  echo "=== Easy mode: reduced alerts, no red herring ==="
 fi
 
 if [ "${SINGLE_NAMESPACE:-}" = "1" ]; then


### PR DESCRIPTION
deploy-easy deploys to a single namespace with per-service DB users, fewer alerts (1 critical payment, 1 warning DB), and no red herring (reconciliation-service excluded). deploy (hard mode) retains all distractors: shared dbuser, graduated alerts, and CrashLoopBackOff red herring.

deploy.sh always works on a temp copy of manifests. Base manifests now reflect easy-mode defaults; hard-mode traits are applied via sed in the SINGLE_USER block.


Assisted-by: Claude Code:claude-opus-4-6