### PR TITLE
feat: add imagepull_auth agentic eval scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -4,6 +4,7 @@ SUITES ?= \
 	crashlooping_pod \
 	failed_job \
 	failing_api \
+	imagepull_auth \
 	oomkilled_pod \
 	pending_pvc \
 	recurring_batch_failure \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -7,6 +7,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 | Suite | Symptom | Root Cause | Difficulty | Alert (fires in) |
 |-------|---------|------------|------------|------------------|
 | `failing_api` | Payment API returning 503s (100% error rate) | Reporting service leaks DB connections, exhausting the shared PostgreSQL pool | Hard | |
+| `imagepull_auth` | Pod in ImagePullBackOff | Private registry image without imagePullSecret (auth failure) | Normal | |
 | `pending_pvc` | PVC stuck in Pending, pods cannot start | PVC references a StorageClass (`standard-v2`) that does not exist | Medium | ~30s |
 | `recurring_batch_failure` | Batch processor errors during 03:00-03:05 UTC | Upstream service has a scheduled maintenance window causing connection timeouts | Medium | |
 | `sporadic_api_timeout` | Report generator timeouts during 03:00-03:05 window | Upstream API has a scheduled maintenance window, not a bug in the application | Medium | |

--- a/agentic/imagepull_auth/cleanup.sh
+++ b/agentic/imagepull_auth/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+oc delete namespace imagepull-auth --ignore-not-found
+
+echo "Cleanup complete: removed imagepull-auth namespace"

--- a/agentic/imagepull_auth/evals.yaml
+++ b/agentic/imagepull_auth/evals.yaml
@@ -1,0 +1,128 @@
+- conversation_group_id: imagepull_auth_openai
+  tag: agentic_imagepull_auth
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The deployment imagepull-auth-app in namespace imagepull-auth
+          cannot start its pod. The image
+          quay.io/noexistingorg/internal-app:1.0 is published in a
+          private registry organization. Analyze why the pod is not
+          starting and explain what the team needs to do to fix it.
+          Do not make any changes.
+        targetNamespaces:
+          - imagepull-auth
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        The pod is in ImagePullBackOff because pulling
+        quay.io/noexistingorg/internal-app:1.0 fails with an
+        authorization error — the image is in a private registry
+        organization and neither the pod nor its service account
+        references an imagePullSecret with registry credentials.
+        The fix is to create a docker-registry pull secret with valid
+        credentials and reference it via imagePullSecrets on the pod
+        spec or linked to the service account.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: imagepull_auth_anthropic
+  tag: agentic_imagepull_auth
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The deployment imagepull-auth-app in namespace imagepull-auth
+          cannot start its pod. The image
+          quay.io/noexistingorg/internal-app:1.0 is published in a
+          private registry organization. Analyze why the pod is not
+          starting and explain what the team needs to do to fix it.
+          Do not make any changes.
+        targetNamespaces:
+          - imagepull-auth
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        The pod is in ImagePullBackOff because pulling
+        quay.io/noexistingorg/internal-app:1.0 fails with an
+        authorization error — the image is in a private registry
+        organization and neither the pod nor its service account
+        references an imagePullSecret with registry credentials.
+        The fix is to create a docker-registry pull secret with valid
+        credentials and reference it via imagePullSecrets on the pod
+        spec or linked to the service account.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: imagepull_auth_gemini
+  tag: agentic_imagepull_auth
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The deployment imagepull-auth-app in namespace imagepull-auth
+          cannot start its pod. The image
+          quay.io/noexistingorg/internal-app:1.0 is published in a
+          private registry organization. Analyze why the pod is not
+          starting and explain what the team needs to do to fix it.
+          Do not make any changes.
+        targetNamespaces:
+          - imagepull-auth
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        The pod is in ImagePullBackOff because pulling
+        quay.io/noexistingorg/internal-app:1.0 fails with an
+        authorization error — the image is in a private registry
+        organization and neither the pod nor its service account
+        references an imagePullSecret with registry credentials.
+        The fix is to create a docker-registry pull secret with valid
+        credentials and reference it via imagePullSecrets on the pod
+        spec or linked to the service account.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/imagepull_auth/fixtures/manifest.yaml
+++ b/agentic/imagepull_auth/fixtures/manifest.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: imagepull-auth
+  labels:
+    purpose: eval-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: imagepull-auth-app
+  namespace: imagepull-auth
+  labels:
+    app: imagepull-auth-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: imagepull-auth-app
+  template:
+    metadata:
+      labels:
+        app: imagepull-auth-app
+    spec:
+      containers:
+        - name: internal-app
+          image: quay.io/noexistingorg/internal-app:1.0
+          ports:
+            - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"

--- a/agentic/imagepull_auth/setup.sh
+++ b/agentic/imagepull_auth/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="imagepull-auth"
+APP="imagepull-auth-app"
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+echo "Waiting for $APP to exhibit ImagePullBackOff..."
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 30 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  STATE=$(oc get pods -n "$NS" -l "app=$APP" \
+    -o jsonpath='{.items[0].status.containerStatuses[0].state.waiting.reason}' 2>/dev/null || true)
+  if [[ "$STATE" == "ErrImagePull" || "$STATE" == "ImagePullBackOff" ]]; then
+    break
+  fi
+  sleep 4
+done
+
+echo "Setup complete: $APP is in ImagePullBackOff state"


### PR DESCRIPTION
## Summary

- Adds `imagepull_auth` agentic eval scenario — analysis-only diagnosis of ImagePullBackOff caused by a private registry without an imagePullSecret
- Deploys a pod referencing `quay.io/noexistingorg/internal-app:1.0` (nonexistent org triggers auth error, not 404)
- Agent must distinguish authorization failure from missing-tag failure and recommend creating an imagePullSecret
- Includes 3 provider variants (openai/anthropic/gemini), setup/cleanup scripts, and fixture manifest
- Migrated from `lightspeed-evaluation` repo (`proposal_imagepull_auth`)

## Test plan

- [ ] `yamllint` passes on manifest.yaml and evals.yaml (warning-only: missing `---`, consistent with all other scenarios)
- [ ] `shellcheck` passes on setup.sh and cleanup.sh
- [ ] `make evals SUITES=imagepull_auth` runs successfully on a live cluster
- [ ] Pod enters ImagePullBackOff state with "unauthorized" error message (not "manifest unknown")

🤖 Generated with [Claude Code](https://claude.com/claude-code)