### PR TITLE
feat: add orphaned_pvc agentic eval scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -5,6 +5,7 @@ SUITES ?= \
 	failed_job \
 	failing_api \
 	oomkilled_pod \
+	orphaned_pvc \
 	pending_pvc \
 	recurring_batch_failure \
 	refused_connections \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -14,6 +14,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 | `crashlooping_pod` | Pod in CrashLoopBackOff | Required environment variable `DEPLOY_ENV` is missing from the deployment spec | Normal | ~3min |
 | `failed_job` | inventory-sync-validator Job fails | Job cannot connect to database at prod-db:3333 (connection refused) | Normal | |
 | `oomkilled_pod` | Pods repeatedly OOMKilled / CrashLoopBackOff | Python app has a memory leak (~1MB/s) that exceeds the 60Mi container limit | Normal | ~2min |
+| `orphaned_pvc` | PVCs attached to no workload | Two of three PVCs are not mounted by any pod or deployment | Normal | |
 | `timeout_connections` | Frontend gets connection timeouts to backend | NetworkPolicy only allows ingress from `tier=backend`, blocking `tier=frontend` pods | Normal | |
 | `unbalanced_replicas` | Namespaces have different pod counts | fleet-alpha has 6 pods vs fleet-alpha1 with 9, due to different deployment sets | Normal | |
 | `unready_pod` | Pod running but not becoming Ready | HTTP readiness probe targets port 9200 but container has no HTTP server | Normal | ~1.5min |

--- a/agentic/orphaned_pvc/cleanup.sh
+++ b/agentic/orphaned_pvc/cleanup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+
+oc delete -f "$FIXTURE_DIR/manifest.yaml" --ignore-not-found --wait=false
+oc delete namespace pvc-orphans --ignore-not-found
+
+echo "Cleanup complete: removed pvc-orphans namespace and resources"

--- a/agentic/orphaned_pvc/evals.yaml
+++ b/agentic/orphaned_pvc/evals.yaml
@@ -1,0 +1,122 @@
+- conversation_group_id: orphaned_pvc_openai
+  tag: agentic_orphaned_pvc
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The platform team suspects namespace pvc-orphans is paying for
+          storage nobody uses. Analyze which PersistentVolumeClaims in
+          the namespace are mounted by running workloads and which are
+          orphaned, and propose a cleanup plan for the orphaned ones.
+          Do not delete anything.
+        targetNamespaces:
+          - pvc-orphans
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        In use: active-data-pvc, mounted at /data by the running
+        pvc-user-app deployment. Orphaned cleanup candidates:
+        old-backup-pvc and tmp-scratch-pvc, which are referenced by no
+        pod or workload template in the namespace. The proposal should
+        recommend confirming with the owning team and then deleting the
+        two orphaned claims to release their storage, without touching
+        active-data-pvc.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: orphaned_pvc_anthropic
+  tag: agentic_orphaned_pvc
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The platform team suspects namespace pvc-orphans is paying for
+          storage nobody uses. Analyze which PersistentVolumeClaims in
+          the namespace are mounted by running workloads and which are
+          orphaned, and propose a cleanup plan for the orphaned ones.
+          Do not delete anything.
+        targetNamespaces:
+          - pvc-orphans
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        In use: active-data-pvc, mounted at /data by the running
+        pvc-user-app deployment. Orphaned cleanup candidates:
+        old-backup-pvc and tmp-scratch-pvc, which are referenced by no
+        pod or workload template in the namespace. The proposal should
+        recommend confirming with the owning team and then deleting the
+        two orphaned claims to release their storage, without touching
+        active-data-pvc.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: orphaned_pvc_gemini
+  tag: agentic_orphaned_pvc
+  setup_script: ./setup.sh
+  cleanup_script: ./cleanup.sh
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The platform team suspects namespace pvc-orphans is paying for
+          storage nobody uses. Analyze which PersistentVolumeClaims in
+          the namespace are mounted by running workloads and which are
+          orphaned, and propose a cleanup plan for the orphaned ones.
+          Do not delete anything.
+        targetNamespaces:
+          - pvc-orphans
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        In use: active-data-pvc, mounted at /data by the running
+        pvc-user-app deployment. Orphaned cleanup candidates:
+        old-backup-pvc and tmp-scratch-pvc, which are referenced by no
+        pod or workload template in the namespace. The proposal should
+        recommend confirming with the owning team and then deleting the
+        two orphaned claims to release their storage, without touching
+        active-data-pvc.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/orphaned_pvc/fixtures/manifest.yaml
+++ b/agentic/orphaned_pvc/fixtures/manifest.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pvc-orphans
+  labels:
+    purpose: eval-test
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: active-data-pvc
+  namespace: pvc-orphans
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pvc-user-app
+  namespace: pvc-orphans
+  labels:
+    app: pvc-user-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pvc-user-app
+  template:
+    metadata:
+      labels:
+        app: pvc-user-app
+    spec:
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: active-data-pvc
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: old-backup-pvc
+  namespace: pvc-orphans
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tmp-scratch-pvc
+  namespace: pvc-orphans
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/agentic/orphaned_pvc/setup.sh
+++ b/agentic/orphaned_pvc/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="pvc-orphans"
+APP="pvc-user-app"
+
+# Guard: a default StorageClass is required for PVCs to bind.
+if ! oc get storageclass -o jsonpath='{range .items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")]}{.metadata.name}{end}' | grep -q .; then
+  echo "ERROR: no default StorageClass found — PVCs cannot bind."
+  exit 1
+fi
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+echo "Waiting for $APP deployment to become available..."
+oc wait deployment "$APP" -n "$NS" --for=condition=Available --timeout=180s
+
+echo "Setup complete: $APP is running with active-data-pvc bound; old-backup-pvc and tmp-scratch-pvc are orphaned"


### PR DESCRIPTION
## Summary

- Adds `orphaned_pvc` agentic eval scenario — analysis-only classification of in-use vs orphaned PVCs
- Deploys 3 PVCs: `active-data-pvc` (mounted by `pvc-user-app` deployment), `old-backup-pvc` and `tmp-scratch-pvc` (unattached)
- Agent must map PVCs to workloads, classify orphans, and propose cleanup without deleting anything
- Includes 3 provider variants (openai/anthropic/gemini), setup/cleanup scripts, and fixture manifest
- Setup guards against missing default StorageClass
- Migrated from `lightspeed-evaluation` repo (`proposal_pvc_orphans`)

## Test plan

- [x] `yamllint` passes (warning-only: missing `---`, consistent with all other scenarios)
- [x] `shellcheck` passes on setup.sh and cleanup.sh
- [ ] `bash orphaned_pvc/setup.sh` deploys 3 PVCs + 1 running deployment on live cluster
- [ ] `bash orphaned_pvc/cleanup.sh` removes all resources cleanly
- [ ] `make evals SUITES=orphaned_pvc` runs successfully end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)