### PR TITLE
feat: add svc_port_mismatch agentic scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -9,6 +9,7 @@ SUITES ?= \
 	recurring_batch_failure \
 	refused_connections \
 	sporadic_api_timeout \
+	svc_port_mismatch \
 	timeout_connections \
 	unbalanced_replicas \
 	unready_pod \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -10,6 +10,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 | `pending_pvc` | PVC stuck in Pending, pods cannot start | PVC references a StorageClass (`standard-v2`) that does not exist | Medium | ~30s |
 | `recurring_batch_failure` | Batch processor errors during 03:00-03:05 UTC | Upstream service has a scheduled maintenance window causing connection timeouts | Medium | |
 | `sporadic_api_timeout` | Report generator timeouts during 03:00-03:05 window | Upstream API has a scheduled maintenance window, not a bug in the application | Medium | |
+| `svc_port_mismatch` | Service connections refused despite endpoints existing and pod Ready | Service targetPort (8081) doesn't match the container's listening port (8080) | Normal | |
 | `refused_connections` | Gateway-proxy returning connection refused errors | Config hot-reload loaded staging database/cache hosts into production; staging hosts unreachable from production VPC | Medium | |
 | `crashlooping_pod` | Pod in CrashLoopBackOff | Required environment variable `DEPLOY_ENV` is missing from the deployment spec | Normal | ~3min |
 | `failed_job` | inventory-sync-validator Job fails | Job cannot connect to database at prod-db:3333 (connection refused) | Normal | |

--- a/agentic/svc_port_mismatch/cleanup.sh
+++ b/agentic/svc_port_mismatch/cleanup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="svc-port-demo"
+
+echo "Removing svc_port_mismatch scenario resources from namespace ${NS}…"
+oc delete deployment svc-port-demo -n "$NS" --ignore-not-found
+oc delete svc svc-port-svc -n "$NS" --ignore-not-found
+
+oc delete namespace "$NS" --ignore-not-found
+echo "Cleanup complete — all svc_port_mismatch scenario resources removed."

--- a/agentic/svc_port_mismatch/evals.yaml
+++ b/agentic/svc_port_mismatch/evals.yaml
@@ -1,0 +1,110 @@
+- conversation_group_id: svc_port_mismatch_openai
+  tag: agentic_svc_port_mismatch
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Requests to the service svc-port-svc in namespace svc-port-demo
+          are refused, although the service has endpoints and the backing
+          pod is Ready.
+
+          Investigate the root cause and fix the connectivity issue.
+        targetNamespaces:
+          - svc-port-demo
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the service svc-port-svc forwards to targetPort 8081
+        but the nginx container listens on 8080 (its declared
+        containerPort), so connections through the service are refused
+        even though endpoints exist. Fix: correct the service's
+        targetPort to 8080 and verify connectivity through the service.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: svc_port_mismatch_anthropic
+  tag: agentic_svc_port_mismatch
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Requests to the service svc-port-svc in namespace svc-port-demo
+          are refused, although the service has endpoints and the backing
+          pod is Ready.
+
+          Investigate the root cause and fix the connectivity issue.
+        targetNamespaces:
+          - svc-port-demo
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the service svc-port-svc forwards to targetPort 8081
+        but the nginx container listens on 8080 (its declared
+        containerPort), so connections through the service are refused
+        even though endpoints exist. Fix: correct the service's
+        targetPort to 8080 and verify connectivity through the service.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: svc_port_mismatch_gemini
+  tag: agentic_svc_port_mismatch
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Requests to the service svc-port-svc in namespace svc-port-demo
+          are refused, although the service has endpoints and the backing
+          pod is Ready.
+
+          Investigate the root cause and fix the connectivity issue.
+        targetNamespaces:
+          - svc-port-demo
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the service svc-port-svc forwards to targetPort 8081
+        but the nginx container listens on 8080 (its declared
+        containerPort), so connections through the service are refused
+        even though endpoints exist. Fix: correct the service's
+        targetPort to 8080 and verify connectivity through the service.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/svc_port_mismatch/fixtures/manifest.yaml
+++ b/agentic/svc_port_mismatch/fixtures/manifest.yaml
@@ -1,0 +1,56 @@
+# The service selector is correct so endpoints exist, but targetPort 8081
+# doesn't match the container's listening port 8080 — every connection
+# through the service is refused. Distinct from svc-selector (zero
+# endpoints): here the endpoints are present but point at the wrong port.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: svc-port-demo
+  labels:
+    purpose: eval-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: svc-port-demo
+  namespace: svc-port-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: svc-port-demo
+  template:
+    metadata:
+      labels:
+        app: svc-port-demo
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-port-svc
+  namespace: svc-port-demo
+spec:
+  selector:
+    app: svc-port-demo
+  ports:
+    - port: 8080
+      targetPort: 8081

--- a/agentic/svc_port_mismatch/setup.sh
+++ b/agentic/svc_port_mismatch/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="svc-port-demo"
+
+echo "Applying svc_port_mismatch scenario manifests in namespace ${NS}…"
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+echo "Waiting for svc-port-demo deployment to be ready…"
+oc wait --for=condition=available deployment/svc-port-demo -n "$NS" --timeout=120s
+
+echo "Waiting for svc-port-svc endpoints (selector is correct, port is not)…"
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 20 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  EP_COUNT=$(oc get endpoints svc-port-svc -n "$NS" -o jsonpath='{.subsets[*].addresses}' 2>/dev/null | grep -c "ip" || true)
+  if [ "$EP_COUNT" -gt 0 ]; then
+    echo "Scenario svc_port_mismatch ready — endpoints populated (attempt ${ATTEMPT})"
+    exit 0
+  fi
+  echo "  attempt ${ATTEMPT}/20 — waiting 3s…"
+  sleep 3
+done
+
+echo "ERROR: Endpoints for svc-port-svc not populated within 60s"
+oc get endpoints svc-port-svc -n "$NS" -o yaml 2>/dev/null || true
+exit 1


### PR DESCRIPTION
Service targetPort mismatch eval: nginx listens on 8080 but the Service forwards to 8081, causing refused connections despite endpoints existing. Includes setup/cleanup scripts, fixtures, and evals for OpenAI, Anthropic, and Gemini agents.


Assisted-by: Claude Code:claude-opus-4-6