### PR TITLE
feat: add netpol_dns agentic eval scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -5,6 +5,7 @@ SUITES ?= \
 	failed_job \
 	failing_api \
 	imagepull_auth \
+	netpol_dns \
 	oomkilled_pod \
 	orphaned_pvc \
 	pending_pvc \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -8,6 +8,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 |-------|---------|------------|------------|------------------|
 | `failing_api` | Payment API returning 503s (100% error rate) | Reporting service leaks DB connections, exhausting the shared PostgreSQL pool | Hard | |
 | `imagepull_auth` | Pod in ImagePullBackOff | Private registry image without imagePullSecret (auth failure) | Normal | |
+| `netpol_dns` | App logs DNS resolution failures after security hardening | Default-deny egress NetworkPolicy blocks DNS; needs egress rule for port 5353 to openshift-dns | Medium | |
 | `pending_pvc` | PVC stuck in Pending, pods cannot start | PVC references a StorageClass (`standard-v2`) that does not exist | Medium | ~30s |
 | `recurring_batch_failure` | Batch processor errors during 03:00-03:05 UTC | Upstream service has a scheduled maintenance window causing connection timeouts | Medium | |
 | `sporadic_api_timeout` | Report generator timeouts during 03:00-03:05 window | Upstream API has a scheduled maintenance window, not a bug in the application | Medium | |

--- a/agentic/netpol_dns/cleanup.sh
+++ b/agentic/netpol_dns/cleanup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="netpol-dns-test"
+
+echo "Removing netpol_dns scenario resources from namespace ${NS}…"
+oc delete -f "$(cd "$(dirname "$0")/fixtures" && pwd)/manifest.yaml" --ignore-not-found
+# Remove any NetworkPolicies the agent may have created during remediation.
+oc delete networkpolicy --all -n "$NS" --ignore-not-found
+
+oc delete namespace "$NS" --ignore-not-found
+echo "Cleanup complete — all netpol_dns scenario resources removed."

--- a/agentic/netpol_dns/evals.yaml
+++ b/agentic/netpol_dns/evals.yaml
@@ -1,0 +1,143 @@
+- conversation_group_id: netpol_dns_openai
+  tag: agentic_netpol_dns
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          After a security hardening change, the app netpol-dns-demo in
+          namespace netpol-dns-test logs DNS resolution failures for every
+          lookup. The default-deny egress posture is required by the
+          security team and must stay. Analyze the root cause and suggest
+          how to restore name resolution without dropping the deny-by-default
+          posture.
+        targetNamespaces:
+          - netpol-dns-test
+        tools:
+          skills:
+            - image: quay.io/openshiftanalytics/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot/investigate-alert
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the NetworkPolicy default-deny-egress blocks ALL
+        egress from netpol-dns-demo pods, including DNS queries to the
+        cluster DNS service, so every hostname lookup fails. Remediation:
+        add an egress rule permitting DNS queries to the cluster DNS pods
+        in the openshift-dns namespace on UDP/TCP port 5353 (on
+        OVN-Kubernetes a rule for port 53 alone is NOT sufficient — the
+        CoreDNS pods listen on 5353 and policy applies after service
+        DNAT; port 53 may be allowed in addition) while keeping the
+        default-deny policy.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: netpol_dns_anthropic
+  tag: agentic_netpol_dns
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          After a security hardening change, the app netpol-dns-demo in
+          namespace netpol-dns-test logs DNS resolution failures for every
+          lookup. The default-deny egress posture is required by the
+          security team and must stay. Analyze the root cause and suggest
+          how to restore name resolution without dropping the deny-by-default
+          posture.
+        targetNamespaces:
+          - netpol-dns-test
+        tools:
+          skills:
+            - image: quay.io/openshiftanalytics/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot/investigate-alert
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the NetworkPolicy default-deny-egress blocks ALL
+        egress from netpol-dns-demo pods, including DNS queries to the
+        cluster DNS service, so every hostname lookup fails. Remediation:
+        add an egress rule permitting DNS queries to the cluster DNS pods
+        in the openshift-dns namespace on UDP/TCP port 5353 (on
+        OVN-Kubernetes a rule for port 53 alone is NOT sufficient — the
+        CoreDNS pods listen on 5353 and policy applies after service
+        DNAT; port 53 may be allowed in addition) while keeping the
+        default-deny policy.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: netpol_dns_gemini
+  tag: agentic_netpol_dns
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          After a security hardening change, the app netpol-dns-demo in
+          namespace netpol-dns-test logs DNS resolution failures for every
+          lookup. The default-deny egress posture is required by the
+          security team and must stay. Analyze the root cause and suggest
+          how to restore name resolution without dropping the deny-by-default
+          posture.
+        targetNamespaces:
+          - netpol-dns-test
+        tools:
+          skills:
+            - image: quay.io/openshiftanalytics/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot/investigate-alert
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the NetworkPolicy default-deny-egress blocks ALL
+        egress from netpol-dns-demo pods, including DNS queries to the
+        cluster DNS service, so every hostname lookup fails. Remediation:
+        add an egress rule permitting DNS queries to the cluster DNS pods
+        in the openshift-dns namespace on UDP/TCP port 5353 (on
+        OVN-Kubernetes a rule for port 53 alone is NOT sufficient — the
+        CoreDNS pods listen on 5353 and policy applies after service
+        DNAT; port 53 may be allowed in addition) while keeping the
+        default-deny policy.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/netpol_dns/fixtures/manifest.yaml
+++ b/agentic/netpol_dns/fixtures/manifest.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netpol-dns-test
+  labels:
+    purpose: eval-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netpol-dns-demo
+  namespace: netpol-dns-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: netpol-dns-demo
+  template:
+    metadata:
+      labels:
+        app: netpol-dns-demo
+    spec:
+      containers:
+        - name: app
+          image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+          command:
+            - /bin/sh
+            - -c
+            - >-
+              while true; do
+              if getent hosts kubernetes.default.svc.cluster.local >/dev/null 2>&1; then
+              echo "DNS resolution OK";
+              else
+              echo "ERROR: DNS resolution failed for kubernetes.default.svc.cluster.local";
+              fi;
+              sleep 5;
+              done
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "25m"
+            limits:
+              memory: "64Mi"
+              cpu: "50m"
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+  namespace: netpol-dns-test
+spec:
+  podSelector:
+    matchLabels:
+      app: netpol-dns-demo
+  policyTypes:
+    - Egress
+  egress: []

--- a/agentic/netpol_dns/setup.sh
+++ b/agentic/netpol_dns/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="netpol-dns-test"
+APP="netpol-dns-demo"
+
+echo "Applying netpol_dns scenario manifests in namespace ${NS}…"
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+echo "Waiting for deployment to be available (up to 120s)…"
+oc rollout status deployment/"$APP" -n "$NS" --timeout=120s
+
+echo "Waiting for DNS resolution failure logs (up to 60s)…"
+ATTEMPT=0
+until oc logs -l "app=$APP" -n "$NS" --tail=20 2>/dev/null | grep -q "DNS resolution failed"; do
+  ATTEMPT=$((ATTEMPT + 1))
+  if [ "$ATTEMPT" -ge 20 ]; then
+    echo "ERROR: DNS failure logs not found after 60s"
+    oc get pods -n "$NS"
+    oc logs -l "app=$APP" -n "$NS" --tail=10 || true
+    exit 1
+  fi
+  [ $((ATTEMPT % 5)) -eq 0 ] && echo "  attempt ${ATTEMPT}/20 — waiting…"
+  sleep 3
+done
+echo "Scenario netpol_dns ready — DNS resolution failure logs confirmed (attempt ${ATTEMPT})"


### PR DESCRIPTION
Migrate the netpol-dns-demo scenario from lightspeed-evaluation into this repo. Deploys a default-deny egress NetworkPolicy without a DNS exception so the pod cannot resolve hostnames. The eval verifies the agent identifies the missing DNS egress rule as root cause and recommends port 5353 (OVN-Kubernetes) without removing the deny posture.


Assisted-by: Claude Code:claude-opus-4-6