### PR TITLE
feat: add route_port agentic eval scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -8,6 +8,7 @@ SUITES ?= \
 	oomkilled_pod \
 	orphaned_pvc \
 	pending_pvc \
+	route_port \
 	recurring_batch_failure \
 	refused_connections \
 	sporadic_api_timeout \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -11,6 +11,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 | `pending_pvc` | PVC stuck in Pending, pods cannot start | PVC references a StorageClass (`standard-v2`) that does not exist | Medium | ~30s |
 | `recurring_batch_failure` | Batch processor errors during 03:00-03:05 UTC | Upstream service has a scheduled maintenance window causing connection timeouts | Medium | |
 | `sporadic_api_timeout` | Report generator timeouts during 03:00-03:05 window | Upstream API has a scheduled maintenance window, not a bug in the application | Medium | |
+| `route_port` | Route returns 503 but pod and service are healthy | Route targets port 9090 but service only exposes 8080; router has no valid backend | Normal | |
 | `refused_connections` | Gateway-proxy returning connection refused errors | Config hot-reload loaded staging database/cache hosts into production; staging hosts unreachable from production VPC | Medium | |
 | `crashlooping_pod` | Pod in CrashLoopBackOff | Required environment variable `DEPLOY_ENV` is missing from the deployment spec | Normal | ~3min |
 | `failed_job` | inventory-sync-validator Job fails | Job cannot connect to database at prod-db:3333 (connection refused) | Normal | |

--- a/agentic/route_port/cleanup.sh
+++ b/agentic/route_port/cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="route-port-test"
+
+echo "Removing route_port scenario resources from namespace ${NS}…"
+oc delete -f "$(cd "$(dirname "$0")/fixtures" && pwd)/manifest.yaml" --ignore-not-found
+
+oc delete namespace "$NS" --ignore-not-found
+echo "Cleanup complete — all route_port scenario resources removed."

--- a/agentic/route_port/evals.yaml
+++ b/agentic/route_port/evals.yaml
@@ -1,0 +1,125 @@
+- conversation_group_id: route_port_openai
+  tag: agentic_route_port
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The externally exposed route route-port-demo in namespace
+          route-port-test returns 503 for every request, but the
+          application pod and its service look healthy. Analyze the
+          root cause and suggest a fix.
+        targetNamespaces:
+          - route-port-test
+        tools:
+          skills:
+            - image: quay.io/openshiftanalytics/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot/investigate-alert
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the route route-port-demo targets port 9090, but its
+        service route-port-svc only exposes port 8080 (named "web"), so
+        the router has no valid backend mapping and answers 503.
+        Remediation: point the route's targetPort at 8080 (or the port
+        name "web") so requests reach the nginx container.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: route_port_anthropic
+  tag: agentic_route_port
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The externally exposed route route-port-demo in namespace
+          route-port-test returns 503 for every request, but the
+          application pod and its service look healthy. Analyze the
+          root cause and suggest a fix.
+        targetNamespaces:
+          - route-port-test
+        tools:
+          skills:
+            - image: quay.io/openshiftanalytics/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot/investigate-alert
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the route route-port-demo targets port 9090, but its
+        service route-port-svc only exposes port 8080 (named "web"), so
+        the router has no valid backend mapping and answers 503.
+        Remediation: point the route's targetPort at 8080 (or the port
+        name "web") so requests reach the nginx container.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: route_port_gemini
+  tag: agentic_route_port
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The externally exposed route route-port-demo in namespace
+          route-port-test returns 503 for every request, but the
+          application pod and its service look healthy. Analyze the
+          root cause and suggest a fix.
+        targetNamespaces:
+          - route-port-test
+        tools:
+          skills:
+            - image: quay.io/openshiftanalytics/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot/investigate-alert
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the route route-port-demo targets port 9090, but its
+        service route-port-svc only exposes port 8080 (named "web"), so
+        the router has no valid backend mapping and answers 503.
+        Remediation: point the route's targetPort at 8080 (or the port
+        name "web") so requests reach the nginx container.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/route_port/fixtures/manifest.yaml
+++ b/agentic/route_port/fixtures/manifest.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: route-port-test
+  labels:
+    purpose: eval-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: route-port-demo
+  namespace: route-port-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: route-port-demo
+  template:
+    metadata:
+      labels:
+        app: route-port-demo
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: route-port-svc
+  namespace: route-port-test
+spec:
+  selector:
+    app: route-port-demo
+  ports:
+    - name: web
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: route-port-demo
+  namespace: route-port-test
+spec:
+  to:
+    kind: Service
+    name: route-port-svc
+  port:
+    targetPort: 9090

--- a/agentic/route_port/setup.sh
+++ b/agentic/route_port/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="route-port-test"
+APP="route-port-demo"
+
+echo "Applying route_port scenario manifests in namespace ${NS}…"
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+echo "Waiting for deployment to be available (up to 120s)…"
+oc rollout status deployment/"$APP" -n "$NS" --timeout=120s
+
+echo "Waiting for route to be admitted (up to 60s)…"
+ATTEMPT=0
+until oc get route "$APP" -n "$NS" -o jsonpath='{.status.ingress[0].conditions[?(@.type=="Admitted")].status}' 2>/dev/null | grep -q "True"; do
+  ATTEMPT=$((ATTEMPT + 1))
+  if [ "$ATTEMPT" -ge 20 ]; then
+    echo "ERROR: Route not admitted after 60s"
+    oc get route "$APP" -n "$NS" -o yaml
+    exit 1
+  fi
+  [ $((ATTEMPT % 5)) -eq 0 ] && echo "  attempt ${ATTEMPT}/20 — waiting…"
+  sleep 3
+done
+echo "Scenario route_port ready — deployment available and route admitted (attempt ${ATTEMPT})"


### PR DESCRIPTION
Migrate the route-port-demo scenario from lightspeed-evaluation. Deploys a Route targeting port 9090 while the Service only exposes 8080, causing the router to return 503. The eval verifies the agent identifies the targetPort mismatch as root cause.


Assisted-by: Claude Code:claude-opus-4-6