### PR TITLE
feat: add missing_pvc agentic eval scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -5,6 +5,7 @@ SUITES ?= \
 	failed_job \
 	failing_api \
 	imagepull_auth \
+	missing_pvc \
 	oomkilled_pod \
 	orphaned_pvc \
 	pending_pvc \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -8,6 +8,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 |-------|---------|------------|------------|------------------|
 | `failing_api` | Payment API returning 503s (100% error rate) | Reporting service leaks DB connections, exhausting the shared PostgreSQL pool | Hard | |
 | `imagepull_auth` | Pod in ImagePullBackOff | Private registry image without imagePullSecret (auth failure) | Normal | |
+| `missing_pvc` | Deployment pod never scheduled | Deployment mounts PVC `app-data` that was never created; FailedScheduling | Normal | |
 | `pending_pvc` | PVC stuck in Pending, pods cannot start | PVC references a StorageClass (`standard-v2`) that does not exist | Medium | ~30s |
 | `recurring_batch_failure` | Batch processor errors during 03:00-03:05 UTC | Upstream service has a scheduled maintenance window causing connection timeouts | Medium | |
 | `sporadic_api_timeout` | Report generator timeouts during 03:00-03:05 window | Upstream API has a scheduled maintenance window, not a bug in the application | Medium | |

--- a/agentic/missing_pvc/cleanup.sh
+++ b/agentic/missing_pvc/cleanup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="missing-pvc-test"
+
+echo "Removing missing_pvc scenario resources from namespace ${NS}…"
+oc delete -f "$(cd "$(dirname "$0")/fixtures" && pwd)/manifest.yaml" --ignore-not-found
+# Remove any PVCs the agent may have created during remediation.
+oc delete pvc --all -n "$NS" --timeout=120s || true
+
+oc delete namespace "$NS" --ignore-not-found
+echo "Cleanup complete — all missing_pvc scenario resources removed."

--- a/agentic/missing_pvc/evals.yaml
+++ b/agentic/missing_pvc/evals.yaml
@@ -1,0 +1,128 @@
+- conversation_group_id: missing_pvc_openai
+  tag: agentic_missing_pvc
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The deployment missing-pvc-demo in namespace missing-pvc-test
+          never gets a pod scheduled. The team says it needs a 1Gi volume
+          named app-data that they forgot to create; the cluster's default
+          storage class is fine. Analyze the root cause and suggest a fix.
+        targetNamespaces:
+          - missing-pvc-test
+        tools:
+          skills:
+            - image: quay.io/openshiftanalytics/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot/investigate-alert
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the pod is unschedulable because its volume
+        references PersistentVolumeClaim app-data, which does not exist
+        in the namespace (FailedScheduling: "persistentvolumeclaim
+        app-data not found"). Remediation: create the app-data PVC (1Gi,
+        default StorageClass) so the claim binds and the pod can be
+        scheduled with the volume mounted.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: missing_pvc_anthropic
+  tag: agentic_missing_pvc
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The deployment missing-pvc-demo in namespace missing-pvc-test
+          never gets a pod scheduled. The team says it needs a 1Gi volume
+          named app-data that they forgot to create; the cluster's default
+          storage class is fine. Analyze the root cause and suggest a fix.
+        targetNamespaces:
+          - missing-pvc-test
+        tools:
+          skills:
+            - image: quay.io/openshiftanalytics/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot/investigate-alert
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the pod is unschedulable because its volume
+        references PersistentVolumeClaim app-data, which does not exist
+        in the namespace (FailedScheduling: "persistentvolumeclaim
+        app-data not found"). Remediation: create the app-data PVC (1Gi,
+        default StorageClass) so the claim binds and the pod can be
+        scheduled with the volume mounted.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: missing_pvc_gemini
+  tag: agentic_missing_pvc
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The deployment missing-pvc-demo in namespace missing-pvc-test
+          never gets a pod scheduled. The team says it needs a 1Gi volume
+          named app-data that they forgot to create; the cluster's default
+          storage class is fine. Analyze the root cause and suggest a fix.
+        targetNamespaces:
+          - missing-pvc-test
+        tools:
+          skills:
+            - image: quay.io/openshiftanalytics/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot/investigate-alert
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the pod is unschedulable because its volume
+        references PersistentVolumeClaim app-data, which does not exist
+        in the namespace (FailedScheduling: "persistentvolumeclaim
+        app-data not found"). Remediation: create the app-data PVC (1Gi,
+        default StorageClass) so the claim binds and the pod can be
+        scheduled with the volume mounted.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/missing_pvc/fixtures/manifest.yaml
+++ b/agentic/missing_pvc/fixtures/manifest.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: missing-pvc-test
+  labels:
+    purpose: eval-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: missing-pvc-demo
+  namespace: missing-pvc-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: missing-pvc-demo
+  template:
+    metadata:
+      labels:
+        app: missing-pvc-demo
+    spec:
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: app-data
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"

--- a/agentic/missing_pvc/setup.sh
+++ b/agentic/missing_pvc/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="missing-pvc-test"
+APP="missing-pvc-demo"
+
+echo "Applying missing_pvc scenario manifests in namespace ${NS}…"
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+echo "Waiting for pod to report unschedulable due to missing PVC (up to 120s)…"
+ATTEMPT=0
+until oc get events -n "$NS" \
+  --field-selector "reason=FailedScheduling" \
+  -o jsonpath='{.items[*].message}' 2>/dev/null | grep -q "app-data"; do
+  ATTEMPT=$((ATTEMPT + 1))
+  if [ "$ATTEMPT" -ge 40 ]; then
+    echo "ERROR: FailedScheduling event for missing PVC not found after 120s"
+    oc get pods -n "$NS"
+    oc get events -n "$NS" --sort-by='.lastTimestamp' | tail -15
+    exit 1
+  fi
+  [ $((ATTEMPT % 10)) -eq 0 ] && echo "  attempt ${ATTEMPT}/40 — waiting…"
+  sleep 3
+done
+echo "Scenario missing_pvc ready — FailedScheduling event confirmed (attempt ${ATTEMPT})"


### PR DESCRIPTION
Migrate the missing-pvc-demo scenario from lightspeed-evaluation. Deploys a Deployment that mounts a PVC (app-data) which was never created, leaving the pod unschedulable. The eval verifies the agent identifies the missing PVC as root cause and recommends creating it.


Assisted-by: Claude Code:claude-opus-4-6