### PR TITLE
feat: add svc_selector agentic eval scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -11,6 +11,7 @@ SUITES ?= \
 	recurring_batch_failure \
 	refused_connections \
 	sporadic_api_timeout \
+	svc_selector \
 	timeout_connections \
 	unbalanced_replicas \
 	unready_pod \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -16,6 +16,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 | `failed_job` | inventory-sync-validator Job fails | Job cannot connect to database at prod-db:3333 (connection refused) | Normal | |
 | `oomkilled_pod` | Pods repeatedly OOMKilled / CrashLoopBackOff | Python app has a memory leak (~1MB/s) that exceeds the 60Mi container limit | Normal | ~2min |
 | `orphaned_pvc` | PVCs attached to no workload | Two of three PVCs are not mounted by any pod or deployment | Normal | |
+| `svc_selector` | Service has zero endpoints despite healthy pods | Service selector `app=svc-selector-app` doesn't match pod label `app=svc-selector-demo` | Normal | |
 | `timeout_connections` | Frontend gets connection timeouts to backend | NetworkPolicy only allows ingress from `tier=backend`, blocking `tier=frontend` pods | Normal | |
 | `unbalanced_replicas` | Namespaces have different pod counts | fleet-alpha has 6 pods vs fleet-alpha1 with 9, due to different deployment sets | Normal | |
 | `unready_pod` | Pod running but not becoming Ready | HTTP readiness probe targets port 9200 but container has no HTTP server | Normal | ~1.5min |

--- a/agentic/svc_selector/cleanup.sh
+++ b/agentic/svc_selector/cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="svc-selector-test"
+
+echo "Removing svc_selector scenario resources from namespace ${NS}…"
+oc delete -f "$(cd "$(dirname "$0")/fixtures" && pwd)/manifest.yaml" --ignore-not-found
+
+oc delete namespace "$NS" --ignore-not-found
+echo "Cleanup complete — all svc_selector scenario resources removed."

--- a/agentic/svc_selector/evals.yaml
+++ b/agentic/svc_selector/evals.yaml
@@ -1,0 +1,125 @@
+- conversation_group_id: svc_selector_openai
+  tag: agentic_svc_selector
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The service svc-selector-svc in namespace svc-selector-test
+          serves no traffic even though its backing application is
+          running and healthy. Analyze the root cause and suggest a fix.
+        targetNamespaces:
+          - svc-selector-test
+        tools:
+          skills:
+            - image: quay.io/openshiftanalytics/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot/investigate-alert
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the service svc-selector-svc selects pods labelled
+        app=svc-selector-app, but the deployment's pods are labelled
+        app=svc-selector-demo, so the service has zero endpoints while
+        the pods are Running and Ready. Remediation: fix the service
+        selector (or the pod labels) so they match, and verify the
+        service's endpoints are populated with the ready pod.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: svc_selector_anthropic
+  tag: agentic_svc_selector
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The service svc-selector-svc in namespace svc-selector-test
+          serves no traffic even though its backing application is
+          running and healthy. Analyze the root cause and suggest a fix.
+        targetNamespaces:
+          - svc-selector-test
+        tools:
+          skills:
+            - image: quay.io/openshiftanalytics/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot/investigate-alert
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the service svc-selector-svc selects pods labelled
+        app=svc-selector-app, but the deployment's pods are labelled
+        app=svc-selector-demo, so the service has zero endpoints while
+        the pods are Running and Ready. Remediation: fix the service
+        selector (or the pod labels) so they match, and verify the
+        service's endpoints are populated with the ready pod.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: svc_selector_gemini
+  tag: agentic_svc_selector
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The service svc-selector-svc in namespace svc-selector-test
+          serves no traffic even though its backing application is
+          running and healthy. Analyze the root cause and suggest a fix.
+        targetNamespaces:
+          - svc-selector-test
+        tools:
+          skills:
+            - image: quay.io/openshiftanalytics/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot/investigate-alert
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the service svc-selector-svc selects pods labelled
+        app=svc-selector-app, but the deployment's pods are labelled
+        app=svc-selector-demo, so the service has zero endpoints while
+        the pods are Running and Ready. Remediation: fix the service
+        selector (or the pod labels) so they match, and verify the
+        service's endpoints are populated with the ready pod.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/svc_selector/fixtures/manifest.yaml
+++ b/agentic/svc_selector/fixtures/manifest.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: svc-selector-test
+  labels:
+    purpose: eval-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: svc-selector-demo
+  namespace: svc-selector-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: svc-selector-demo
+  template:
+    metadata:
+      labels:
+        app: svc-selector-demo
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-selector-svc
+  namespace: svc-selector-test
+spec:
+  selector:
+    app: svc-selector-app
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/agentic/svc_selector/setup.sh
+++ b/agentic/svc_selector/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="svc-selector-test"
+APP="svc-selector-demo"
+SVC="svc-selector-svc"
+
+echo "Applying svc_selector scenario manifests in namespace ${NS}…"
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+echo "Waiting for deployment to be available (up to 120s)…"
+oc rollout status deployment/"$APP" -n "$NS" --timeout=120s
+
+echo "Confirming service has zero endpoints…"
+EP_COUNT=$(oc get endpoints "$SVC" -n "$NS" -o jsonpath='{.subsets[*].addresses}' 2>/dev/null | wc -c)
+if [ "$EP_COUNT" -gt 2 ]; then
+  echo "ERROR: Service $SVC unexpectedly has endpoints"
+  oc get endpoints "$SVC" -n "$NS" -o yaml
+  exit 1
+fi
+echo "Scenario svc_selector ready — deployment available, service has zero endpoints"


### PR DESCRIPTION
Migrate the svc-selector-demo scenario from lightspeed-evaluation. Service selector targets app=svc-selector-app but pods are labelled app=svc-selector-demo, resulting in zero endpoints. The eval verifies the agent identifies the selector/label mismatch as root cause.


Assisted-by: Claude Code:claude-opus-4-6