### PR TITLE
feat: add priorityclass agentic eval scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -8,6 +8,7 @@ SUITES ?= \
 	oomkilled_pod \
 	orphaned_pvc \
 	pending_pvc \
+	priorityclass \
 	recurring_batch_failure \
 	refused_connections \
 	sporadic_api_timeout \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -8,6 +8,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 |-------|---------|------------|------------|------------------|
 | `failing_api` | Payment API returning 503s (100% error rate) | Reporting service leaks DB connections, exhausting the shared PostgreSQL pool | Hard | |
 | `imagepull_auth` | Pod in ImagePullBackOff | Private registry image without imagePullSecret (auth failure) | Normal | |
+| `priorityclass` | Deployment creates no pods | Pod template references nonexistent PriorityClass `eval-critical-priority`; ReplicaSet FailedCreate | Normal | |
 | `pending_pvc` | PVC stuck in Pending, pods cannot start | PVC references a StorageClass (`standard-v2`) that does not exist | Medium | ~30s |
 | `recurring_batch_failure` | Batch processor errors during 03:00-03:05 UTC | Upstream service has a scheduled maintenance window causing connection timeouts | Medium | |
 | `sporadic_api_timeout` | Report generator timeouts during 03:00-03:05 window | Upstream API has a scheduled maintenance window, not a bug in the application | Medium | |

--- a/agentic/priorityclass/cleanup.sh
+++ b/agentic/priorityclass/cleanup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="priorityclass-test"
+
+echo "Removing priorityclass scenario resources from namespace ${NS}…"
+oc delete -f "$(cd "$(dirname "$0")/fixtures" && pwd)/manifest.yaml" --ignore-not-found
+# Remove PriorityClass if the agent created it during remediation.
+oc delete priorityclass eval-critical-priority --ignore-not-found
+
+oc delete namespace "$NS" --ignore-not-found
+echo "Cleanup complete — all priorityclass scenario resources removed."

--- a/agentic/priorityclass/evals.yaml
+++ b/agentic/priorityclass/evals.yaml
@@ -1,0 +1,137 @@
+- conversation_group_id: priorityclass_openai
+  tag: agentic_priorityclass
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The deployment priorityclass-demo in namespace
+          priorityclass-test is not creating any pods. Its manifest came
+          from a different cluster, and the priority class it references
+          is a leftover that does not exist here — the app does not need
+          special scheduling priority. Analyze the root cause and suggest
+          a fix.
+        targetNamespaces:
+          - priorityclass-test
+        tools:
+          skills:
+            - image: quay.io/openshiftanalytics/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot/investigate-alert
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the pod template references
+        priorityClassName eval-critical-priority, which does not exist on
+        this cluster — the ReplicaSet gets FailedCreate ("no
+        PriorityClass with name eval-critical-priority was found") and no
+        pod is ever created. Remediation: remove the stale
+        priorityClassName from the pod template (the app needs no special
+        priority) and verify the pod is created and Running.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: priorityclass_anthropic
+  tag: agentic_priorityclass
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The deployment priorityclass-demo in namespace
+          priorityclass-test is not creating any pods. Its manifest came
+          from a different cluster, and the priority class it references
+          is a leftover that does not exist here — the app does not need
+          special scheduling priority. Analyze the root cause and suggest
+          a fix.
+        targetNamespaces:
+          - priorityclass-test
+        tools:
+          skills:
+            - image: quay.io/openshiftanalytics/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot/investigate-alert
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the pod template references
+        priorityClassName eval-critical-priority, which does not exist on
+        this cluster — the ReplicaSet gets FailedCreate ("no
+        PriorityClass with name eval-critical-priority was found") and no
+        pod is ever created. Remediation: remove the stale
+        priorityClassName from the pod template (the app needs no special
+        priority) and verify the pod is created and Running.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: priorityclass_gemini
+  tag: agentic_priorityclass
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          The deployment priorityclass-demo in namespace
+          priorityclass-test is not creating any pods. Its manifest came
+          from a different cluster, and the priority class it references
+          is a leftover that does not exist here — the app does not need
+          special scheduling priority. Analyze the root cause and suggest
+          a fix.
+        targetNamespaces:
+          - priorityclass-test
+        tools:
+          skills:
+            - image: quay.io/openshiftanalytics/agentic-skills:latest
+              paths:
+                - /skills/cluster-troubleshoot/investigate-alert
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the pod template references
+        priorityClassName eval-critical-priority, which does not exist on
+        this cluster — the ReplicaSet gets FailedCreate ("no
+        PriorityClass with name eval-critical-priority was found") and no
+        pod is ever created. Remediation: remove the stale
+        priorityClassName from the pod template (the app needs no special
+        priority) and verify the pod is created and Running.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/priorityclass/fixtures/manifest.yaml
+++ b/agentic/priorityclass/fixtures/manifest.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: priorityclass-test
+  labels:
+    purpose: eval-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: priorityclass-demo
+  namespace: priorityclass-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: priorityclass-demo
+  template:
+    metadata:
+      labels:
+        app: priorityclass-demo
+    spec:
+      priorityClassName: eval-critical-priority
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"

--- a/agentic/priorityclass/setup.sh
+++ b/agentic/priorityclass/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="priorityclass-test"
+APP="priorityclass-demo"
+
+echo "Applying priorityclass scenario manifests in namespace ${NS}…"
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+echo "Confirming no pods are created due to missing PriorityClass (up to 60s)…"
+ATTEMPT=0
+until oc get events -n "$NS" \
+  --field-selector "reason=FailedCreate" \
+  -o jsonpath='{.items[*].message}' 2>/dev/null | grep -q "eval-critical-priority"; do
+  ATTEMPT=$((ATTEMPT + 1))
+  if [ "$ATTEMPT" -ge 20 ]; then
+    echo "ERROR: FailedCreate event for missing PriorityClass not found after 60s"
+    oc get pods -n "$NS"
+    oc get events -n "$NS" --sort-by='.lastTimestamp' | tail -15
+    exit 1
+  fi
+  [ $((ATTEMPT % 5)) -eq 0 ] && echo "  attempt ${ATTEMPT}/20 — waiting…"
+  sleep 3
+done
+echo "Scenario priorityclass ready — FailedCreate event confirmed (attempt ${ATTEMPT})"


### PR DESCRIPTION
Migrate the priorityclass-demo scenario from lightspeed-evaluation. Deployment references nonexistent PriorityClass eval-critical-priority, causing ReplicaSet FailedCreate with no pods created. The eval verifies the agent identifies the stale reference as root cause.


Assisted-by: Claude Code:claude-opus-4-6