### PR TITLE
feat: add hpa_broken agentic eval scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -4,6 +4,7 @@ SUITES ?= \
 	crashlooping_pod \
 	failed_job \
 	failing_api \
+	hpa_broken \
 	imagepull_auth \
 	netpol_dns \
 	oomkilled_pod \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -7,6 +7,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 | Suite | Symptom | Root Cause | Difficulty | Alert (fires in) |
 |-------|---------|------------|------------|------------------|
 | `failing_api` | Payment API returning 503s (100% error rate) | Reporting service leaks DB connections, exhausting the shared PostgreSQL pool | Hard | |
+| `hpa_broken` | HPA shows `<unknown>` CPU target, never scales | Deployment containers have no CPU resource requests, so HPA cannot compute utilization | Normal | |
 | `imagepull_auth` | Pod in ImagePullBackOff | Private registry image without imagePullSecret (auth failure) | Normal | |
 | `netpol_dns` | App logs DNS resolution failures after security hardening | Default-deny egress NetworkPolicy blocks DNS; needs egress rule for port 5353 to openshift-dns | Medium | |
 | `pending_pvc` | PVC stuck in Pending, pods cannot start | PVC references a StorageClass (`standard-v2`) that does not exist | Medium | ~30s |

--- a/agentic/hpa_broken/cleanup.sh
+++ b/agentic/hpa_broken/cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="hpa-scaling"
+
+oc delete hpa hpa-underspecified-demo -n "$NS" --ignore-not-found
+oc delete deployment hpa-underspecified-demo -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found
+
+echo "Cleanup complete: removed hpa-scaling namespace and resources"

--- a/agentic/hpa_broken/evals.yaml
+++ b/agentic/hpa_broken/evals.yaml
@@ -1,0 +1,128 @@
+- conversation_group_id: hpa_broken_openai
+  tag: agentic_hpa_broken
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          HPA: hpa-underspecified-demo
+          Namespace: hpa-scaling
+          Status: ScalingActive=False, CPU target shows <unknown>
+          Description: The HorizontalPodAutoscaler for hpa-underspecified-demo
+          never scales the app and shows its CPU target as <unknown>.
+
+          Investigate why the autoscaler cannot read metrics, fix the
+          configuration, and verify the HPA reports a real utilization value.
+        targetNamespaces:
+          - hpa-scaling
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The HPA targets CPU utilization, which is computed as
+        a percentage of the pod's CPU request, but the
+        hpa-underspecified-demo containers set no resource requests. The
+        HPA reports FailedGetResourceMetric ("missing request for cpu")
+        and ScalingActive=False. Fix: Add CPU requests (e.g. 50m-100m)
+        to the deployment's containers so utilization can be computed,
+        then verify the HPA reports a concrete CPU utilization value and
+        ScalingActive=True.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: hpa_broken_anthropic
+  tag: agentic_hpa_broken
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          HPA: hpa-underspecified-demo
+          Namespace: hpa-scaling
+          Status: ScalingActive=False, CPU target shows <unknown>
+          Description: The HorizontalPodAutoscaler for hpa-underspecified-demo
+          never scales the app and shows its CPU target as <unknown>.
+
+          Investigate why the autoscaler cannot read metrics, fix the
+          configuration, and verify the HPA reports a real utilization value.
+        targetNamespaces:
+          - hpa-scaling
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The HPA targets CPU utilization, which is computed as
+        a percentage of the pod's CPU request, but the
+        hpa-underspecified-demo containers set no resource requests. The
+        HPA reports FailedGetResourceMetric ("missing request for cpu")
+        and ScalingActive=False. Fix: Add CPU requests (e.g. 50m-100m)
+        to the deployment's containers so utilization can be computed,
+        then verify the HPA reports a concrete CPU utilization value and
+        ScalingActive=True.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: hpa_broken_gemini
+  tag: agentic_hpa_broken
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          HPA: hpa-underspecified-demo
+          Namespace: hpa-scaling
+          Status: ScalingActive=False, CPU target shows <unknown>
+          Description: The HorizontalPodAutoscaler for hpa-underspecified-demo
+          never scales the app and shows its CPU target as <unknown>.
+
+          Investigate why the autoscaler cannot read metrics, fix the
+          configuration, and verify the HPA reports a real utilization value.
+        targetNamespaces:
+          - hpa-scaling
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The HPA targets CPU utilization, which is computed as
+        a percentage of the pod's CPU request, but the
+        hpa-underspecified-demo containers set no resource requests. The
+        HPA reports FailedGetResourceMetric ("missing request for cpu")
+        and ScalingActive=False. Fix: Add CPU requests (e.g. 50m-100m)
+        to the deployment's containers so utilization can be computed,
+        then verify the HPA reports a concrete CPU utilization value and
+        ScalingActive=True.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/hpa_broken/fixtures/manifest.yaml
+++ b/agentic/hpa_broken/fixtures/manifest.yaml
@@ -1,0 +1,55 @@
+# The deployment sets no resource requests, so the HPA's CPU utilization
+# target can never be computed — targets show <unknown> and ScalingActive
+# is False with FailedGetResourceMetric ("missing request for cpu").
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hpa-scaling
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hpa-underspecified-demo
+  namespace: hpa-scaling
+  labels:
+    app: hpa-underspecified-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hpa-underspecified-demo
+  template:
+    metadata:
+      labels:
+        app: hpa-underspecified-demo
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: hpa-underspecified-demo
+  namespace: hpa-scaling
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: hpa-underspecified-demo
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50

--- a/agentic/hpa_broken/setup.sh
+++ b/agentic/hpa_broken/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="hpa-scaling"
+DEPLOY="hpa-underspecified-demo"
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+# Wait for the deployment to become available
+echo "Waiting for deployment $DEPLOY to become available…"
+oc wait --for=condition=Available deployment/"$DEPLOY" \
+  -n "$NS" --timeout=120s
+
+# Wait for the HPA to report failed metrics (ScalingActive=False)
+echo "Waiting for the HPA to report failed metrics (ScalingActive=False)…"
+oc wait --for=condition=ScalingActive=false hpa/"$DEPLOY" \
+  -n "$NS" --timeout=120s
+
+echo "Setup complete: HPA reports ScalingActive=False"


### PR DESCRIPTION
Add evaluation scenario for a broken HorizontalPodAutoscaler where missing CPU resource requests cause ScalingActive=False. The deployment sets no resource requests so the HPA's CPU utilization target reports <unknown> with FailedGetResourceMetric.

Includes setup/cleanup scripts, Kubernetes fixtures, and eval conversations for OpenAI, Anthropic, and Gemini agents.


Assisted-by: Claude Code:claude-opus-4-6