### PR TITLE
feat: add limitrange_conflict agentic eval scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -5,6 +5,7 @@ SUITES ?= \
 	failed_job \
 	failing_api \
 	imagepull_auth \
+	limitrange_conflict \
 	netpol_dns \
 	oomkilled_pod \
 	orphaned_pvc \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -8,6 +8,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 |-------|---------|------------|------------|------------------|
 | `failing_api` | Payment API returning 503s (100% error rate) | Reporting service leaks DB connections, exhausting the shared PostgreSQL pool | Hard | |
 | `imagepull_auth` | Pod in ImagePullBackOff | Private registry image without imagePullSecret (auth failure) | Normal | |
+| `limitrange_conflict` | Deployment creates no pods | App memory request (64Mi) below namespace LimitRange minimum (256Mi) | Normal | |
 | `netpol_dns` | App logs DNS resolution failures after security hardening | Default-deny egress NetworkPolicy blocks DNS; needs egress rule for port 5353 to openshift-dns | Medium | |
 | `pending_pvc` | PVC stuck in Pending, pods cannot start | PVC references a StorageClass (`standard-v2`) that does not exist | Medium | ~30s |
 | `recurring_batch_failure` | Batch processor errors during 03:00-03:05 UTC | Upstream service has a scheduled maintenance window causing connection timeouts | Medium | |

--- a/agentic/limitrange_conflict/cleanup.sh
+++ b/agentic/limitrange_conflict/cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="limitrange-demo"
+
+oc delete deployment limitrange-demo -n "$NS" --ignore-not-found
+oc delete limitrange eval-container-limits -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found
+
+echo "Cleanup complete: removed limitrange-demo namespace and resources"

--- a/agentic/limitrange_conflict/evals.yaml
+++ b/agentic/limitrange_conflict/evals.yaml
@@ -1,0 +1,131 @@
+- conversation_group_id: limitrange_conflict_openai
+  tag: agentic_limitrange_conflict
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: limitrange-demo
+          Namespace: limitrange-demo
+          Status: No pods created (0/1 replicas available)
+          Description: The deployment limitrange-demo is not creating any pods.
+          This namespace has a resource policy set by the platform team that
+          is authoritative and must not be changed — applications must comply
+          with it.
+
+          Analyze the root cause, bring the app into compliance, and verify
+          its pod is running.
+        targetNamespaces:
+          - limitrange-demo
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The namespace LimitRange eval-container-limits requires
+        every container to use at least 256Mi of memory, but limitrange-demo
+        requests 64Mi (limit 128Mi). The ReplicaSet gets "forbidden: minimum
+        memory usage per Container is 256Mi" and no pod is ever created.
+        Fix: Raise the deployment's memory request and limit to at least
+        256Mi (the LimitRange must not be modified) and verify the pod is
+        created and Running.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: limitrange_conflict_anthropic
+  tag: agentic_limitrange_conflict
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: limitrange-demo
+          Namespace: limitrange-demo
+          Status: No pods created (0/1 replicas available)
+          Description: The deployment limitrange-demo is not creating any pods.
+          This namespace has a resource policy set by the platform team that
+          is authoritative and must not be changed — applications must comply
+          with it.
+
+          Analyze the root cause, bring the app into compliance, and verify
+          its pod is running.
+        targetNamespaces:
+          - limitrange-demo
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The namespace LimitRange eval-container-limits requires
+        every container to use at least 256Mi of memory, but limitrange-demo
+        requests 64Mi (limit 128Mi). The ReplicaSet gets "forbidden: minimum
+        memory usage per Container is 256Mi" and no pod is ever created.
+        Fix: Raise the deployment's memory request and limit to at least
+        256Mi (the LimitRange must not be modified) and verify the pod is
+        created and Running.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: limitrange_conflict_gemini
+  tag: agentic_limitrange_conflict
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: limitrange-demo
+          Namespace: limitrange-demo
+          Status: No pods created (0/1 replicas available)
+          Description: The deployment limitrange-demo is not creating any pods.
+          This namespace has a resource policy set by the platform team that
+          is authoritative and must not be changed — applications must comply
+          with it.
+
+          Analyze the root cause, bring the app into compliance, and verify
+          its pod is running.
+        targetNamespaces:
+          - limitrange-demo
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The namespace LimitRange eval-container-limits requires
+        every container to use at least 256Mi of memory, but limitrange-demo
+        requests 64Mi (limit 128Mi). The ReplicaSet gets "forbidden: minimum
+        memory usage per Container is 256Mi" and no pod is ever created.
+        Fix: Raise the deployment's memory request and limit to at least
+        256Mi (the LimitRange must not be modified) and verify the pod is
+        created and Running.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/limitrange_conflict/fixtures/manifest.yaml
+++ b/agentic/limitrange_conflict/fixtures/manifest.yaml
@@ -1,0 +1,52 @@
+# The namespace LimitRange requires every container to request at least
+# 256Mi of memory, but the deployment requests only 64Mi (limit 128Mi).
+# The ReplicaSet gets "forbidden: minimum memory usage per Container is
+# 256Mi" and no pod is ever created.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: limitrange-demo
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: eval-container-limits
+  namespace: limitrange-demo
+spec:
+  limits:
+    - type: Container
+      min:
+        memory: "256Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: limitrange-demo
+  namespace: limitrange-demo
+  labels:
+    app: limitrange-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: limitrange-demo
+  template:
+    metadata:
+      labels:
+        app: limitrange-demo
+    spec:
+      containers:
+        - name: app
+          image: registry.access.redhat.com/ubi9/ubi-micro@sha256:35de56a9413112f1474e392ebc35e0cf6f0fb484c8e8877bbae59b513694b41f
+          command: ["sleep", "infinity"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: "5m"
+              memory: "64Mi"
+            limits:
+              memory: "128Mi"

--- a/agentic/limitrange_conflict/setup.sh
+++ b/agentic/limitrange_conflict/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="limitrange-demo"
+DEPLOY="limitrange-demo"
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+# Wait for the ReplicaSet to report the LimitRange violation
+echo "Waiting for ReplicaSet FailedCreate event…"
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 60 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  MESSAGES=$(oc get events -n "$NS" \
+    --field-selector "reason=FailedCreate" \
+    -o jsonpath='{.items[*].message}' 2>/dev/null || true)
+  if echo "$MESSAGES" | grep -qi "minimum memory usage"; then
+    echo "Setup complete: LimitRange violation detected (attempt $ATTEMPT)"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "LimitRange violation event not detected within 120s"
+oc get events -n "$NS"
+exit 1


### PR DESCRIPTION
Deployment requests 64Mi memory but namespace LimitRange requires 256Mi minimum. ReplicaSet fails with "forbidden: minimum memory usage per Container is 256Mi" and no pod is created.


Assisted-by: Claude Code:claude-opus-4-6