### PR TITLE
feat: add resource_quota agentic evaluation scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -12,6 +12,7 @@ SUITES ?= \
 	route_port \
 	recurring_batch_failure \
 	refused_connections \
+	resource_quota \
 	sporadic_api_timeout \
 	svc_port_mismatch \
 	timeout_connections \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -15,6 +15,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 | `route_port` | Route returns 503 but pod and service are healthy | Route targets port 9090 but service only exposes 8080; router has no valid backend | Normal | |
 | `svc_port_mismatch` | Service connections refused despite endpoints existing and pod Ready | Service targetPort (8081) doesn't match the container's listening port (8080) | Normal | |
 | `refused_connections` | Gateway-proxy returning connection refused errors | Config hot-reload loaded staging database/cache hosts into production; staging hosts unreachable from production VPC | Medium | |
+| `resource_quota` | Deployment has zero pods | ResourceQuota caps pods at 2, fully consumed by existing blocker deployment | Normal | |
 | `crashlooping_pod` | Pod in CrashLoopBackOff | Required environment variable `DEPLOY_ENV` is missing from the deployment spec | Normal | ~3min |
 | `failed_job` | inventory-sync-validator Job fails | Job cannot connect to database at prod-db:3333 (connection refused) | Normal | |
 | `oomkilled_pod` | Pods repeatedly OOMKilled / CrashLoopBackOff | Python app has a memory leak (~1MB/s) that exceeds the 60Mi container limit | Normal | ~2min |

--- a/agentic/resource_quota/cleanup.sh
+++ b/agentic/resource_quota/cleanup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="team-onboarding"
+
+oc delete deployment quota-victim-app -n "$NS" --ignore-not-found
+oc delete deployment quota-blocker -n "$NS" --ignore-not-found
+oc delete resourcequota team-pod-quota -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found
+
+echo "Cleanup complete: removed $NS namespace and resources"

--- a/agentic/resource_quota/evals.yaml
+++ b/agentic/resource_quota/evals.yaml
@@ -1,0 +1,131 @@
+- conversation_group_id: resource_quota_openai
+  tag: agentic_resource_quota
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: quota-victim-app
+          Namespace: team-onboarding
+          Status: 0 pods running
+          Description: The new deployment quota-victim-app in namespace
+          team-onboarding has zero pods and users cannot reach it. The
+          existing quota-blocker workload must keep running. The platform
+          team confirmed the namespace's pod quota is outdated and may be
+          raised to accommodate the new app. Analyze the root cause,
+          remediate, and verify quota-victim-app is running.
+        targetNamespaces:
+          - team-onboarding
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the namespace's ResourceQuota team-pod-quota caps
+        pods at 2, fully consumed by quota-blocker's 2 replicas — the
+        quota-victim-app ReplicaSet fails pod creation with "exceeded
+        quota" events and no pod is ever created. Fix: raise the pod
+        quota (e.g. to 3 or more, as authorized by the platform team)
+        without touching quota-blocker, and verify quota-victim-app's
+        pod is created and Running.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: resource_quota_anthropic
+  tag: agentic_resource_quota
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: quota-victim-app
+          Namespace: team-onboarding
+          Status: 0 pods running
+          Description: The new deployment quota-victim-app in namespace
+          team-onboarding has zero pods and users cannot reach it. The
+          existing quota-blocker workload must keep running. The platform
+          team confirmed the namespace's pod quota is outdated and may be
+          raised to accommodate the new app. Analyze the root cause,
+          remediate, and verify quota-victim-app is running.
+        targetNamespaces:
+          - team-onboarding
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the namespace's ResourceQuota team-pod-quota caps
+        pods at 2, fully consumed by quota-blocker's 2 replicas — the
+        quota-victim-app ReplicaSet fails pod creation with "exceeded
+        quota" events and no pod is ever created. Fix: raise the pod
+        quota (e.g. to 3 or more, as authorized by the platform team)
+        without touching quota-blocker, and verify quota-victim-app's
+        pod is created and Running.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: resource_quota_gemini
+  tag: agentic_resource_quota
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: quota-victim-app
+          Namespace: team-onboarding
+          Status: 0 pods running
+          Description: The new deployment quota-victim-app in namespace
+          team-onboarding has zero pods and users cannot reach it. The
+          existing quota-blocker workload must keep running. The platform
+          team confirmed the namespace's pod quota is outdated and may be
+          raised to accommodate the new app. Analyze the root cause,
+          remediate, and verify quota-victim-app is running.
+        targetNamespaces:
+          - team-onboarding
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the namespace's ResourceQuota team-pod-quota caps
+        pods at 2, fully consumed by quota-blocker's 2 replicas — the
+        quota-victim-app ReplicaSet fails pod creation with "exceeded
+        quota" events and no pod is ever created. Fix: raise the pod
+        quota (e.g. to 3 or more, as authorized by the platform team)
+        without touching quota-blocker, and verify quota-victim-app's
+        pod is created and Running.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/resource_quota/fixtures/manifest.yaml
+++ b/agentic/resource_quota/fixtures/manifest.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-onboarding
+  labels:
+    purpose: eval-test
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: team-pod-quota
+  namespace: team-onboarding
+spec:
+  hard:
+    pods: "2"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: quota-blocker
+  namespace: team-onboarding
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: quota-blocker
+  template:
+    metadata:
+      labels:
+        app: quota-blocker
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: quota-victim-app
+  namespace: team-onboarding
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: quota-victim-app
+  template:
+    metadata:
+      labels:
+        app: quota-victim-app
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"

--- a/agentic/resource_quota/setup.sh
+++ b/agentic/resource_quota/setup.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="team-onboarding"
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+echo "Waiting for quota-blocker to consume the pod quota..."
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 120 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  READY=$(oc get deployment quota-blocker -n "$NS" \
+    -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+  if [ "$READY" = "2" ]; then
+    echo "quota-blocker is fully available (attempt $ATTEMPT)"
+    break
+  fi
+  sleep 1
+done
+
+if [ "$READY" != "2" ]; then
+  echo "ERROR: quota-blocker did not become available within 120s"
+  oc get deployment quota-blocker -n "$NS"
+  exit 1
+fi
+
+echo "Confirming quota-victim-app pod creation is rejected by the quota..."
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 60 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  EVENTS=$(oc get events -n "$NS" \
+    --field-selector "reason=FailedCreate" \
+    -o jsonpath='{.items[*].message}' 2>/dev/null || true)
+  if echo "$EVENTS" | grep -q "exceeded quota"; then
+    echo "Setup complete: quota exceeded event detected (attempt $ATTEMPT)"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "WARNING: exceeded quota event not detected within 60s, but scenario may still work"
+oc get events -n "$NS"


### PR DESCRIPTION
Add ResourceQuota exhaustion scenario where a pod quota of 2 is fully consumed by a quota-blocker deployment, preventing quota-victim-app from creating any pods. Agents must identify the exceeded quota events, raise the pod limit (as authorized by the platform team), and verify the victim app starts without disrupting the blocker.

Based on proposal_quota from lightspeed-evaluation PR #287.