### PR TITLE
feat: add missing_secret_key agentic evaluation scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -5,6 +5,7 @@ SUITES ?= \
 	failed_job \
 	failing_api \
 	imagepull_auth \
+	missing_secret_key \
 	netpol_dns \
 	oomkilled_pod \
 	orphaned_pvc \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -8,6 +8,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 |-------|---------|------------|------------|------------------|
 | `failing_api` | Payment API returning 503s (100% error rate) | Reporting service leaks DB connections, exhausting the shared PostgreSQL pool | Hard | |
 | `imagepull_auth` | Pod in ImagePullBackOff | Private registry image without imagePullSecret (auth failure) | Normal | |
+| `missing_secret_key` | Pod in CreateContainerConfigError | Secret `db-creds` exists but lacks the `password` key referenced by the container | Normal | |
 | `netpol_dns` | App logs DNS resolution failures after security hardening | Default-deny egress NetworkPolicy blocks DNS; needs egress rule for port 5353 to openshift-dns | Medium | |
 | `pending_pvc` | PVC stuck in Pending, pods cannot start | PVC references a StorageClass (`standard-v2`) that does not exist | Medium | ~30s |
 | `recurring_batch_failure` | Batch processor errors during 03:00-03:05 UTC | Upstream service has a scheduled maintenance window causing connection timeouts | Medium | |

--- a/agentic/missing_secret_key/cleanup.sh
+++ b/agentic/missing_secret_key/cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="credential-store"
+
+oc delete deployment missing-secret-key-demo -n "$NS" --ignore-not-found
+oc delete secret db-creds -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found
+
+echo "Cleanup complete: removed $NS namespace and resources"

--- a/agentic/missing_secret_key/evals.yaml
+++ b/agentic/missing_secret_key/evals.yaml
@@ -1,0 +1,128 @@
+- conversation_group_id: missing_secret_key_openai
+  tag: agentic_missing_secret_key
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: missing-secret-key-demo
+          Namespace: credential-store
+          Status: CreateContainerConfigError
+          Description: The deployment missing-secret-key-demo in namespace
+          credential-store cannot start its container. It reads database
+          credentials from the Secret db-creds. Analyze the root cause
+          and fix it — if a credential value is missing, use the
+          placeholder value "changeme" so the team can rotate it later.
+          Verify the pod is running.
+        targetNamespaces:
+          - credential-store
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the container is in CreateContainerConfigError
+        because its DB_PASSWORD env var references key "password" in
+        Secret db-creds, but the secret only contains the "username"
+        key. Fix: add the missing "password" key to the db-creds
+        Secret (placeholder value "changeme") and verify the pod
+        reaches Running state.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: missing_secret_key_anthropic
+  tag: agentic_missing_secret_key
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: missing-secret-key-demo
+          Namespace: credential-store
+          Status: CreateContainerConfigError
+          Description: The deployment missing-secret-key-demo in namespace
+          credential-store cannot start its container. It reads database
+          credentials from the Secret db-creds. Analyze the root cause
+          and fix it — if a credential value is missing, use the
+          placeholder value "changeme" so the team can rotate it later.
+          Verify the pod is running.
+        targetNamespaces:
+          - credential-store
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the container is in CreateContainerConfigError
+        because its DB_PASSWORD env var references key "password" in
+        Secret db-creds, but the secret only contains the "username"
+        key. Fix: add the missing "password" key to the db-creds
+        Secret (placeholder value "changeme") and verify the pod
+        reaches Running state.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: missing_secret_key_gemini
+  tag: agentic_missing_secret_key
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: missing-secret-key-demo
+          Namespace: credential-store
+          Status: CreateContainerConfigError
+          Description: The deployment missing-secret-key-demo in namespace
+          credential-store cannot start its container. It reads database
+          credentials from the Secret db-creds. Analyze the root cause
+          and fix it — if a credential value is missing, use the
+          placeholder value "changeme" so the team can rotate it later.
+          Verify the pod is running.
+        targetNamespaces:
+          - credential-store
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the container is in CreateContainerConfigError
+        because its DB_PASSWORD env var references key "password" in
+        Secret db-creds, but the secret only contains the "username"
+        key. Fix: add the missing "password" key to the db-creds
+        Secret (placeholder value "changeme") and verify the pod
+        reaches Running state.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/missing_secret_key/fixtures/manifest.yaml
+++ b/agentic/missing_secret_key/fixtures/manifest.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: credential-store
+  labels:
+    purpose: eval-test
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-creds
+  namespace: credential-store
+type: Opaque
+stringData:
+  username: app-user
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: missing-secret-key-demo
+  namespace: credential-store
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: missing-secret-key-demo
+  template:
+    metadata:
+      labels:
+        app: missing-secret-key-demo
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+          env:
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: db-creds
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-creds
+                  key: password
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"

--- a/agentic/missing_secret_key/setup.sh
+++ b/agentic/missing_secret_key/setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="credential-store"
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+echo "Waiting for CreateContainerConfigError on missing-secret-key-demo..."
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 60 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  STATUS=$(oc get pods -n "$NS" -l app=missing-secret-key-demo \
+    -o jsonpath='{.items[0].status.containerStatuses[0].state.waiting.reason}' 2>/dev/null || true)
+  if [ "$STATUS" = "CreateContainerConfigError" ]; then
+    echo "Setup complete: CreateContainerConfigError detected (attempt $ATTEMPT)"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "WARNING: CreateContainerConfigError not detected within 60s"
+oc get pods -n "$NS" -l app=missing-secret-key-demo
+oc get events -n "$NS" --sort-by='.lastTimestamp' | tail -5


### PR DESCRIPTION
Add scenario where a Secret exists but lacks the referenced key, causing CreateContainerConfigError. The db-creds Secret contains only a 'username' key but the deployment also references a 'password' key. Agents must identify the missing key, add it with a placeholder value, and verify the pod starts.

Based on proposal_missing_secret_key from lightspeed-evaluation PR #287.