### PR TITLE
feat: add antiaffinity agentic evaluation scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -1,6 +1,7 @@
 SCRIPTS_DIR := $(realpath ../scripts)
 
 SUITES ?= \
+	antiaffinity \
 	crashlooping_pod \
 	failed_job \
 	failing_api \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -6,6 +6,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 
 | Suite | Symptom | Root Cause | Difficulty | Alert (fires in) |
 |-------|---------|------------|------------|------------------|
+| `antiaffinity` | Several pods stuck in Pending | Required pod anti-affinity on hostname with 10 replicas exceeds node count; only 3 needed for HA | Normal | |
 | `failing_api` | Payment API returning 503s (100% error rate) | Reporting service leaks DB connections, exhausting the shared PostgreSQL pool | Hard | |
 | `imagepull_auth` | Pod in ImagePullBackOff | Private registry image without imagePullSecret (auth failure) | Normal | |
 | `netpol_dns` | App logs DNS resolution failures after security hardening | Default-deny egress NetworkPolicy blocks DNS; needs egress rule for port 5353 to openshift-dns | Medium | |

--- a/agentic/antiaffinity/cleanup.sh
+++ b/agentic/antiaffinity/cleanup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="ha-services"
+
+oc delete deployment antiaffinity-demo -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found
+
+echo "Cleanup complete: removed $NS namespace and resources"

--- a/agentic/antiaffinity/evals.yaml
+++ b/agentic/antiaffinity/evals.yaml
@@ -1,0 +1,128 @@
+- conversation_group_id: antiaffinity_openai
+  tag: agentic_antiaffinity
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: antiaffinity-demo
+          Namespace: ha-services
+          Status: Several pods stuck in Pending
+          Description: Several pods of deployment antiaffinity-demo in
+          namespace ha-services are stuck in Pending. The service only
+          needs 3 replicas spread across different nodes for high
+          availability. Analyze the root cause, fix the deployment so
+          the desired replicas all run, and verify.
+        targetNamespaces:
+          - ha-services
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the deployment requests 10 replicas with required
+        pod anti-affinity on kubernetes.io/hostname, allowing at most
+        one pod per node — the cluster has fewer than 10 nodes so the
+        surplus pods stay Pending with FailedScheduling events. Fix:
+        reduce replicas to 3 (the stated HA requirement) and optionally
+        soften the rule to preferred anti-affinity, then verify all
+        replicas are Running.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: antiaffinity_anthropic
+  tag: agentic_antiaffinity
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: antiaffinity-demo
+          Namespace: ha-services
+          Status: Several pods stuck in Pending
+          Description: Several pods of deployment antiaffinity-demo in
+          namespace ha-services are stuck in Pending. The service only
+          needs 3 replicas spread across different nodes for high
+          availability. Analyze the root cause, fix the deployment so
+          the desired replicas all run, and verify.
+        targetNamespaces:
+          - ha-services
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the deployment requests 10 replicas with required
+        pod anti-affinity on kubernetes.io/hostname, allowing at most
+        one pod per node — the cluster has fewer than 10 nodes so the
+        surplus pods stay Pending with FailedScheduling events. Fix:
+        reduce replicas to 3 (the stated HA requirement) and optionally
+        soften the rule to preferred anti-affinity, then verify all
+        replicas are Running.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: antiaffinity_gemini
+  tag: agentic_antiaffinity
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: antiaffinity-demo
+          Namespace: ha-services
+          Status: Several pods stuck in Pending
+          Description: Several pods of deployment antiaffinity-demo in
+          namespace ha-services are stuck in Pending. The service only
+          needs 3 replicas spread across different nodes for high
+          availability. Analyze the root cause, fix the deployment so
+          the desired replicas all run, and verify.
+        targetNamespaces:
+          - ha-services
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the deployment requests 10 replicas with required
+        pod anti-affinity on kubernetes.io/hostname, allowing at most
+        one pod per node — the cluster has fewer than 10 nodes so the
+        surplus pods stay Pending with FailedScheduling events. Fix:
+        reduce replicas to 3 (the stated HA requirement) and optionally
+        soften the rule to preferred anti-affinity, then verify all
+        replicas are Running.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/antiaffinity/fixtures/manifest.yaml
+++ b/agentic/antiaffinity/fixtures/manifest.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ha-services
+  labels:
+    purpose: eval-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: antiaffinity-demo
+  namespace: ha-services
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: antiaffinity-demo
+  template:
+    metadata:
+      labels:
+        app: antiaffinity-demo
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: antiaffinity-demo
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"

--- a/agentic/antiaffinity/setup.sh
+++ b/agentic/antiaffinity/setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="ha-services"
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+echo "Waiting for FailedScheduling events on antiaffinity-demo pods..."
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 90 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  REASONS=$(oc get events -n "$NS" \
+    --field-selector "reason=FailedScheduling" \
+    -o jsonpath='{.items[*].reason}' 2>/dev/null || true)
+  if echo "$REASONS" | grep -q "FailedScheduling"; then
+    echo "Setup complete: FailedScheduling event detected (attempt $ATTEMPT)"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "WARNING: FailedScheduling event not detected within 90s"
+oc get pods -n "$NS" -l app=antiaffinity-demo
+oc get events -n "$NS" --sort-by='.lastTimestamp' | tail -10


### PR DESCRIPTION
Add scenario where a deployment requests 10 replicas with required pod anti-affinity on kubernetes.io/hostname, but the cluster has fewer than 10 nodes. Surplus pods stay Pending with FailedScheduling events. Agents must identify the replicas-vs-nodes mismatch, reduce replicas to 3 (the stated HA requirement), and verify all pods run.

Based on proposal_antiaffinity from lightspeed-evaluation PR #287.