### PR TITLE
feat: add scc_rejection agentic evaluation scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -21,6 +21,7 @@ SUITES ?= \
 	recurring_batch_failure \
 	refused_connections \
 	resource_quota \
+	scc_rejection \
 	sporadic_api_timeout \
 	svc_selector \
 	svc_port_mismatch \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -23,6 +23,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 | `svc_port_mismatch` | Service connections refused despite endpoints existing and pod Ready | Service targetPort (8081) doesn't match the container's listening port (8080) | Normal | |
 | `refused_connections` | Gateway-proxy returning connection refused errors | Config hot-reload loaded staging database/cache hosts into production; staging hosts unreachable from production VPC | Medium | |
 | `resource_quota` | Deployment has zero pods | ResourceQuota caps pods at 2, fully consumed by existing blocker deployment | Normal | |
+| `scc_rejection` | Deployment creates no pods | Pod template requests `privileged: true` and `runAsUser: 0`, rejected by OpenShift's restricted SCC | Normal | |
 | `crashlooping_pod` | Pod in CrashLoopBackOff | Required environment variable `DEPLOY_ENV` is missing from the deployment spec | Normal | ~3min |
 | `failed_job` | inventory-sync-validator Job fails | Job cannot connect to database at prod-db:3333 (connection refused) | Normal | |
 | `oomkilled_pod` | Pods repeatedly OOMKilled / CrashLoopBackOff | Python app has a memory leak (~1MB/s) that exceeds the 60Mi container limit | Normal | ~2min |

--- a/agentic/antiaffinity/setup.sh
+++ b/agentic/antiaffinity/setup.sh
@@ -23,3 +23,4 @@ done
 echo "WARNING: FailedScheduling event not detected within 90s"
 oc get pods -n "$NS" -l app=antiaffinity-demo
 oc get events -n "$NS" --sort-by='.lastTimestamp' | tail -10
+exit 1

--- a/agentic/missing_secret_key/setup.sh
+++ b/agentic/missing_secret_key/setup.sh
@@ -22,3 +22,4 @@ done
 echo "WARNING: CreateContainerConfigError not detected within 60s"
 oc get pods -n "$NS" -l app=missing-secret-key-demo
 oc get events -n "$NS" --sort-by='.lastTimestamp' | tail -5
+exit 1

--- a/agentic/resource_quota/setup.sh
+++ b/agentic/resource_quota/setup.sh
@@ -39,5 +39,6 @@ until [ "$ATTEMPT" -ge 60 ]; do
   sleep 1
 done
 
-echo "WARNING: exceeded quota event not detected within 60s, but scenario may still work"
+echo "WARNING: exceeded quota event not detected within 60s"
 oc get events -n "$NS"
+exit 1

--- a/agentic/scc_rejection/cleanup.sh
+++ b/agentic/scc_rejection/cleanup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="legacy-migration"
+
+oc delete deployment scc-demo -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found
+
+echo "Cleanup complete: removed $NS namespace and resources"

--- a/agentic/scc_rejection/evals.yaml
+++ b/agentic/scc_rejection/evals.yaml
@@ -1,0 +1,137 @@
+- conversation_group_id: scc_rejection_openai
+  tag: agentic_scc_rejection
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: scc-demo
+          Namespace: legacy-migration
+          Status: 0 pods created
+          Description: The deployment scc-demo in namespace
+          legacy-migration creates no pods. Its manifest was ported from
+          a docker-compose setup; the app is plain nginx and does not
+          actually need any special privileges. Cluster security settings
+          must not be changed. Analyze the root cause, fix the workload
+          so it runs under the cluster's standard security constraints,
+          and verify the pod is running.
+        targetNamespaces:
+          - legacy-migration
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the pod template requests privileged: true and
+        runAsUser: 0, which OpenShift's restricted SCC rejects — the
+        ReplicaSet logs FailedCreate ("unable to validate against any
+        security context constraint") and no pod is created. Fix:
+        remove the privileged and runAsUser demands from the container
+        securityContext (the nginx-unprivileged image needs neither)
+        so the pod passes the restricted SCC. Verify the pod runs
+        under the standard constraints.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: scc_rejection_anthropic
+  tag: agentic_scc_rejection
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: scc-demo
+          Namespace: legacy-migration
+          Status: 0 pods created
+          Description: The deployment scc-demo in namespace
+          legacy-migration creates no pods. Its manifest was ported from
+          a docker-compose setup; the app is plain nginx and does not
+          actually need any special privileges. Cluster security settings
+          must not be changed. Analyze the root cause, fix the workload
+          so it runs under the cluster's standard security constraints,
+          and verify the pod is running.
+        targetNamespaces:
+          - legacy-migration
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the pod template requests privileged: true and
+        runAsUser: 0, which OpenShift's restricted SCC rejects — the
+        ReplicaSet logs FailedCreate ("unable to validate against any
+        security context constraint") and no pod is created. Fix:
+        remove the privileged and runAsUser demands from the container
+        securityContext (the nginx-unprivileged image needs neither)
+        so the pod passes the restricted SCC. Verify the pod runs
+        under the standard constraints.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: scc_rejection_gemini
+  tag: agentic_scc_rejection
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: scc-demo
+          Namespace: legacy-migration
+          Status: 0 pods created
+          Description: The deployment scc-demo in namespace
+          legacy-migration creates no pods. Its manifest was ported from
+          a docker-compose setup; the app is plain nginx and does not
+          actually need any special privileges. Cluster security settings
+          must not be changed. Analyze the root cause, fix the workload
+          so it runs under the cluster's standard security constraints,
+          and verify the pod is running.
+        targetNamespaces:
+          - legacy-migration
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: the pod template requests privileged: true and
+        runAsUser: 0, which OpenShift's restricted SCC rejects — the
+        ReplicaSet logs FailedCreate ("unable to validate against any
+        security context constraint") and no pod is created. Fix:
+        remove the privileged and runAsUser demands from the container
+        securityContext (the nginx-unprivileged image needs neither)
+        so the pod passes the restricted SCC. Verify the pod runs
+        under the standard constraints.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/scc_rejection/fixtures/manifest.yaml
+++ b/agentic/scc_rejection/fixtures/manifest.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: legacy-migration
+  labels:
+    purpose: eval-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scc-demo
+  namespace: legacy-migration
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scc-demo
+  template:
+    metadata:
+      labels:
+        app: scc-demo
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"

--- a/agentic/scc_rejection/setup.sh
+++ b/agentic/scc_rejection/setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="legacy-migration"
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+echo "Waiting for SCC rejection FailedCreate event on scc-demo..."
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 60 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  EVENTS=$(oc get events -n "$NS" \
+    --field-selector "reason=FailedCreate" \
+    -o jsonpath='{.items[*].message}' 2>/dev/null || true)
+  if echo "$EVENTS" | grep -qi "security context constraint"; then
+    echo "Setup complete: SCC rejection detected (attempt $ATTEMPT)"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "WARNING: SCC rejection event not detected within 60s"
+oc get events -n "$NS" --sort-by='.lastTimestamp' | tail -10
+exit 1


### PR DESCRIPTION
Add scenario where a deployment ported from docker-compose requests privileged: true and runAsUser: 0, causing OpenShift's restricted SCC to reject pod creation. Agents must identify the SCC admission errors, remove the unnecessary privilege demands from the securityContext (not grant an elevated SCC), and verify the pod runs.

Based on proposal_scc_rejection from lightspeed-evaluation PR #287.