### PR TITLE
feat: add double_fault agentic evaluation scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -3,6 +3,7 @@ SCRIPTS_DIR := $(realpath ../scripts)
 SUITES ?= \
 	antiaffinity \
 	crashlooping_pod \
+	double_fault \
 	failed_job \
 	failing_api \
 	hpa_broken \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -9,6 +9,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 | `antiaffinity` | Several pods stuck in Pending | Required pod anti-affinity on hostname with 10 replicas exceeds node count; only 3 needed for HA | Normal | |
 | `failing_api` | Payment API returning 503s (100% error rate) | Reporting service leaks DB connections, exhausting the shared PostgreSQL pool | Hard | ~3min |
 | `hpa_broken` | HPA shows `<unknown>` CPU target, never scales | Deployment containers have no CPU resource requests, so HPA cannot compute utilization | Normal | |
+| `double_fault` | Pod will not stay up (two independent faults) | Missing ConfigMap `df-settings` causes CreateContainerConfigError; liveness probe targets wrong port (8081 vs 8080) causes crash loop after first fix | Medium | |
 | `imagepull_auth` | Pod in ImagePullBackOff | Private registry image without imagePullSecret (auth failure) | Normal | |
 | `limitrange_conflict` | Deployment creates no pods | App memory request (64Mi) below namespace LimitRange minimum (256Mi) | Normal | |
 | `priorityclass` | Deployment creates no pods | Pod template references nonexistent PriorityClass `eval-critical-priority`; ReplicaSet FailedCreate | Normal | |

--- a/agentic/double_fault/cleanup.sh
+++ b/agentic/double_fault/cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="multi-issue-app"
+
+oc delete deployment double-fault-demo -n "$NS" --ignore-not-found
+oc delete configmap df-settings -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found
+
+echo "Cleanup complete: removed $NS namespace and resources"

--- a/agentic/double_fault/evals.yaml
+++ b/agentic/double_fault/evals.yaml
@@ -1,0 +1,128 @@
+- conversation_group_id: double_fault_openai
+  tag: agentic_double_fault
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: double-fault-demo
+          Namespace: multi-issue-app
+          Status: Pod will not stay up
+          Description: The deployment double-fault-demo in namespace
+          multi-issue-app will not stay up. The app expects a ConfigMap
+          named df-settings whose only needed key is LOG_LEVEL (default
+          "info"). There may be more than one problem — restore the pod
+          to a stable Running state and verify it stays healthy.
+        targetNamespaces:
+          - multi-issue-app
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Two independent faults: (1) the container's envFrom references
+        the missing ConfigMap df-settings (CreateContainerConfigError),
+        and (2) the liveness probe targets port 8081 while nginx listens
+        on 8080, which kills the container as soon as fault 1 is fixed.
+        Fix: create the df-settings ConfigMap (LOG_LEVEL: info) AND
+        correct the liveness probe port to 8080, then verify the pod is
+        Running with no restart growth.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: double_fault_anthropic
+  tag: agentic_double_fault
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: double-fault-demo
+          Namespace: multi-issue-app
+          Status: Pod will not stay up
+          Description: The deployment double-fault-demo in namespace
+          multi-issue-app will not stay up. The app expects a ConfigMap
+          named df-settings whose only needed key is LOG_LEVEL (default
+          "info"). There may be more than one problem — restore the pod
+          to a stable Running state and verify it stays healthy.
+        targetNamespaces:
+          - multi-issue-app
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Two independent faults: (1) the container's envFrom references
+        the missing ConfigMap df-settings (CreateContainerConfigError),
+        and (2) the liveness probe targets port 8081 while nginx listens
+        on 8080, which kills the container as soon as fault 1 is fixed.
+        Fix: create the df-settings ConfigMap (LOG_LEVEL: info) AND
+        correct the liveness probe port to 8080, then verify the pod is
+        Running with no restart growth.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: double_fault_gemini
+  tag: agentic_double_fault
+
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: double-fault-demo
+          Namespace: multi-issue-app
+          Status: Pod will not stay up
+          Description: The deployment double-fault-demo in namespace
+          multi-issue-app will not stay up. The app expects a ConfigMap
+          named df-settings whose only needed key is LOG_LEVEL (default
+          "info"). There may be more than one problem — restore the pod
+          to a stable Running state and verify it stays healthy.
+        targetNamespaces:
+          - multi-issue-app
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Two independent faults: (1) the container's envFrom references
+        the missing ConfigMap df-settings (CreateContainerConfigError),
+        and (2) the liveness probe targets port 8081 while nginx listens
+        on 8080, which kills the container as soon as fault 1 is fixed.
+        Fix: create the df-settings ConfigMap (LOG_LEVEL: info) AND
+        correct the liveness probe port to 8080, then verify the pod is
+        Running with no restart growth.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/double_fault/fixtures/manifest.yaml
+++ b/agentic/double_fault/fixtures/manifest.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: multi-issue-app
+  labels:
+    purpose: eval-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: double-fault-demo
+  namespace: multi-issue-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: double-fault-demo
+  template:
+    metadata:
+      labels:
+        app: double-fault-demo
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: df-settings
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            failureThreshold: 2
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"

--- a/agentic/double_fault/setup.sh
+++ b/agentic/double_fault/setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="multi-issue-app"
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+echo "Waiting for CreateContainerConfigError on double-fault-demo..."
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 60 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  STATUS=$(oc get pods -n "$NS" -l app=double-fault-demo \
+    -o jsonpath='{.items[0].status.containerStatuses[0].state.waiting.reason}' 2>/dev/null || true)
+  if [ "$STATUS" = "CreateContainerConfigError" ]; then
+    echo "Setup complete: CreateContainerConfigError detected (attempt $ATTEMPT)"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "WARNING: CreateContainerConfigError not detected within 60s"
+oc get pods -n "$NS" -l app=double-fault-demo
+oc get events -n "$NS" --sort-by='.lastTimestamp' | tail -5


### PR DESCRIPTION
Add compound fault scenario with two independent issues in one pod: (1) envFrom references missing ConfigMap df-settings causing CreateContainerConfigError, and (2) liveness probe targets port 8081 while nginx listens on 8080, causing crash loop after the first fix. Agents must find and fix both faults to stabilize the pod.

Based on proposal_double_fault from lightspeed-evaluation PR #287.