### PR TITLE
feat: add rbac_forbidden agentic eval scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -12,6 +12,7 @@ SUITES ?= \
 	orphaned_pvc \
 	pending_pvc \
 	route_port \
+	rbac_forbidden \
 	recurring_batch_failure \
 	refused_connections \
 	resource_quota \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -12,6 +12,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 | `missing_secret_key` | Pod in CreateContainerConfigError | Secret `db-creds` exists but lacks the `password` key referenced by the container | Normal | |
 | `netpol_dns` | App logs DNS resolution failures after security hardening | Default-deny egress NetworkPolicy blocks DNS; needs egress rule for port 5353 to openshift-dns | Medium | |
 | `pending_pvc` | PVC stuck in Pending, pods cannot start | PVC references a StorageClass (`standard-v2`) that does not exist | Medium | ~30s |
+| `rbac_forbidden` | App logging HTTP 403 from Kubernetes API | ServiceAccount has no Role/RoleBinding for pod list calls | Normal | |
 | `recurring_batch_failure` | Batch processor errors during 03:00-03:05 UTC | Upstream service has a scheduled maintenance window causing connection timeouts | Medium | |
 | `sporadic_api_timeout` | Report generator timeouts during 03:00-03:05 window | Upstream API has a scheduled maintenance window, not a bug in the application | Medium | |
 | `route_port` | Route returns 503 but pod and service are healthy | Route targets port 9090 but service only exposes 8080; router has no valid backend | Normal | |

--- a/agentic/rbac_forbidden/cleanup.sh
+++ b/agentic/rbac_forbidden/cleanup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="rbac-forbidden"
+
+oc delete deployment rbac-forbidden-demo -n "$NS" --ignore-not-found
+oc delete serviceaccount app-inspector-sa -n "$NS" --ignore-not-found
+
+# Remove agent-created RBAC scoped to the scenario ServiceAccount.
+# Namespaced Roles are all scenario-created, so delete them wholesale.
+oc delete role --all -n "$NS" --ignore-not-found
+for rb in $(oc get rolebindings -n "$NS" \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{range .subjects[*]}{.name}{" "}{end}{"\n"}{end}' 2>/dev/null \
+  | grep -w app-inspector-sa | cut -d'|' -f1); do
+  oc delete rolebinding "$rb" -n "$NS" --ignore-not-found
+done
+
+# Clean up any cluster-scoped bindings the agent may have created
+# (the anticipated wrong fix).
+for crb in $(oc get clusterrolebindings \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{range .subjects[*]}{.name}{":"}{.namespace}{" "}{end}{"\n"}{end}' 2>/dev/null \
+  | grep -w "app-inspector-sa:$NS" | cut -d'|' -f1); do
+  oc delete clusterrolebinding "$crb" --ignore-not-found
+done
+
+oc delete namespace "$NS" --ignore-not-found
+
+echo "Cleanup complete: removed rbac-forbidden namespace and resources"

--- a/agentic/rbac_forbidden/evals.yaml
+++ b/agentic/rbac_forbidden/evals.yaml
@@ -1,0 +1,128 @@
+- conversation_group_id: rbac_forbidden_openai
+  tag: agentic_rbac_forbidden
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: rbac-forbidden-demo
+          Namespace: rbac-forbidden
+          Status: App logging "ERROR: cannot list pods" with HTTP 403
+          Description: The rbac-forbidden-demo app calls the Kubernetes API to
+          list pods in its own namespace, but every call returns HTTP 403. The
+          app legitimately requires listing pods in its own namespace, nothing
+          more.
+
+          Analyze the root cause, grant exactly the access the app needs
+          (least privilege), and verify the app logs successful API calls.
+        targetNamespaces:
+          - rbac-forbidden
+        analysis:
+          agent: default
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The app runs as ServiceAccount app-inspector-sa, which
+        has no Role or RoleBinding, so its pod-list API calls return HTTP
+        403. Fix: Create a namespaced Role granting only get/list on pods
+        and a RoleBinding attaching it to app-inspector-sa — not
+        cluster-admin or a ClusterRoleBinding — then verify the app's logs
+        show HTTP 200 responses.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: rbac_forbidden_anthropic
+  tag: agentic_rbac_forbidden
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: rbac-forbidden-demo
+          Namespace: rbac-forbidden
+          Status: App logging "ERROR: cannot list pods" with HTTP 403
+          Description: The rbac-forbidden-demo app calls the Kubernetes API to
+          list pods in its own namespace, but every call returns HTTP 403. The
+          app legitimately requires listing pods in its own namespace, nothing
+          more.
+
+          Analyze the root cause, grant exactly the access the app needs
+          (least privilege), and verify the app logs successful API calls.
+        targetNamespaces:
+          - rbac-forbidden
+        analysis:
+          agent: opus
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The app runs as ServiceAccount app-inspector-sa, which
+        has no Role or RoleBinding, so its pod-list API calls return HTTP
+        403. Fix: Create a namespaced Role granting only get/list on pods
+        and a RoleBinding attaching it to app-inspector-sa — not
+        cluster-admin or a ClusterRoleBinding — then verify the app's logs
+        show HTTP 200 responses.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: rbac_forbidden_gemini
+  tag: agentic_rbac_forbidden
+
+  turns:
+    - turn_id: turn_1
+      proposal_spec:
+        request: |
+          Deployment: rbac-forbidden-demo
+          Namespace: rbac-forbidden
+          Status: App logging "ERROR: cannot list pods" with HTTP 403
+          Description: The rbac-forbidden-demo app calls the Kubernetes API to
+          list pods in its own namespace, but every call returns HTTP 403. The
+          app legitimately requires listing pods in its own namespace, nothing
+          more.
+
+          Analyze the root cause, grant exactly the access the app needs
+          (least privilege), and verify the app logs successful API calls.
+        targetNamespaces:
+          - rbac-forbidden
+        analysis:
+          agent: gemini
+
+      expected_proposal_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        Root cause: The app runs as ServiceAccount app-inspector-sa, which
+        has no Role or RoleBinding, so its pod-list API calls return HTTP
+        403. Fix: Create a namespaced Role granting only get/list on pods
+        and a RoleBinding attaching it to app-inspector-sa — not
+        cluster-admin or a ClusterRoleBinding — then verify the app's logs
+        show HTTP 200 responses.
+
+      turn_metrics:
+        - "custom:proposal_status"
+        - "custom:proposal_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:proposal_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/rbac_forbidden/fixtures/manifest.yaml
+++ b/agentic/rbac_forbidden/fixtures/manifest.yaml
@@ -1,0 +1,66 @@
+# The app lists pods in its own namespace via the Kubernetes API, but its
+# ServiceAccount has no Role/RoleBinding — every call returns HTTP 403 and
+# the app logs it. The fix is a least-privilege Role (get/list pods) bound
+# to app-inspector-sa.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rbac-forbidden
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: app-inspector-sa
+  namespace: rbac-forbidden
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rbac-forbidden-demo
+  namespace: rbac-forbidden
+  labels:
+    app: rbac-forbidden-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rbac-forbidden-demo
+  template:
+    metadata:
+      labels:
+        app: rbac-forbidden-demo
+    spec:
+      serviceAccountName: app-inspector-sa
+      containers:
+        - name: inspector
+          image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+              CA=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              TOKEN_FILE=/var/run/secrets/kubernetes.io/serviceaccount/token
+              while true; do
+                CODE=$(curl -s -o /dev/null -w '%{http_code}' --cacert "$CA" \
+                  -H "Authorization: Bearer $(cat $TOKEN_FILE)" \
+                  "https://kubernetes.default.svc/api/v1/namespaces/${NS}/pods")
+                if [ "$CODE" = "200" ]; then
+                  echo "pod list OK: HTTP $CODE"
+                else
+                  echo "ERROR: cannot list pods in ${NS}: HTTP $CODE"
+                fi
+                sleep 5
+              done
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "25m"
+            limits:
+              memory: "64Mi"
+              cpu: "50m"

--- a/agentic/rbac_forbidden/setup.sh
+++ b/agentic/rbac_forbidden/setup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="rbac-forbidden"
+DEPLOY="rbac-forbidden-demo"
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+# Wait for the deployment to become available
+echo "Waiting for deployment $DEPLOY to become available…"
+oc wait --for=condition=Available deployment/"$DEPLOY" \
+  -n "$NS" --timeout=120s
+
+# Wait for the app to log 403 responses
+echo "Waiting for the app to log HTTP 403 responses…"
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 60 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  POD=$(oc get pods -n "$NS" -l "app=$DEPLOY" -o name 2>/dev/null | head -1)
+  if [ -n "$POD" ]; then
+    LOGS=$(oc logs "$POD" -n "$NS" --tail=20 2>/dev/null || true)
+    if echo "$LOGS" | grep -q "HTTP 403"; then
+      echo "Setup complete: app is logging HTTP 403 errors (attempt $ATTEMPT)"
+      exit 0
+    fi
+  fi
+  sleep 2
+done
+
+echo "HTTP 403 log line not detected within 120s"
+oc logs -n "$NS" -l "app=$DEPLOY" --tail=10 2>/dev/null || true
+exit 1


### PR DESCRIPTION
ServiceAccount lacks Role/RoleBinding so app's Kubernetes API calls return HTTP 403. Cleanup handles agent-created RBAC including wrongly-scoped ClusterRoleBindings.


Assisted-by: Claude Code:claude-opus-4-6