### PR TITLE
fix: clone agentic-operator repo for quickstart install

### DIFF
--- a/scripts/test-troubleshooting-scenarios-agentic.sh
+++ b/scripts/test-troubleshooting-scenarios-agentic.sh
@@ -19,7 +19,11 @@ NAMESPACE="openshift-lightspeed"
 
 function install_operator() {
     echo "==> Installing lightspeed-agentic-operator..."
-    bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh)
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    git clone --depth 1 https://github.com/openshift/lightspeed-agentic-operator.git "$tmpdir"
+    bash "$tmpdir/hack/quickstart/install.sh"
+    rm -rf "$tmpdir"
     echo "==> Operator installed."
 }
 


### PR DESCRIPTION
The quickstart install.sh uses dirname to find sibling scripts (deploy-otel.sh, deploy-operator.sh, etc). Running via process substitution (bash <(curl ...)) sets $0 to /dev/fd/N, causing "Missing script" errors. Clone to a temp directory instead so all sibling scripts are discoverable.


Assisted-by: Claude Code:claude-opus-4-6