### PR TITLE
increasing timeout for prometheus

### DIFF
--- a/agentic/crashlooping_pod/setup.sh
+++ b/agentic/crashlooping_pod/setup.sh
@@ -28,4 +28,5 @@ oc wait --for=jsonpath='{.status.containerStatuses[0].state.waiting.reason}'=Cra
 
 echo "Setup complete: $APP is in CrashLoopBackOff state"
 
-"$SCRIPT_DIR/wait-for-alert.sh" "WarehouseOpsPodRestarting"
+SCRIPT_DIR="$(cd "$(dirname "$0")/../../scripts" && pwd)"
+"$SCRIPT_DIR/wait-for-alert.sh" "WarehouseOpsPodRestarting" "" 600


### PR DESCRIPTION
The crashlooping_pod scenario's setup.sh waits for the
  WarehouseOpsPodRestarting Prometheus alert to reach firing state
  before handing off to the e2e test. On freshly created namespaces,
  user workload monitoring can take significant time to discover the
  new PrometheusRule and begin evaluating it. Combined with the > 2
  restart threshold (3+ crashes needed) and the for: 15s pending
  duration, the default 300s timeout is too tight on slower CI
  clusters. Bumping to 600s gives Prometheus enough headroom for rule
  discovery + scrape cycles + restart accumulation without changing the
  alert semantics.


This is currently being one of the main failures from our product-e2e tests where we are leveraging troubleshooting scenarios.