### PR TITLE
Rename proposal to openshift_agentic_run in agentic evals

### DIFF
--- a/agentic/antiaffinity/evals.yaml
+++ b/agentic/antiaffinity/evals.yaml
@@ -4,7 +4,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Deployment: antiaffinity-demo
           Namespace: ha-services
@@ -19,7 +19,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -35,10 +35,10 @@
         replicas are Running.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: antiaffinity_anthropic
@@ -47,7 +47,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Deployment: antiaffinity-demo
           Namespace: ha-services
@@ -62,7 +62,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -78,10 +78,10 @@
         replicas are Running.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: antiaffinity_gemini
@@ -90,7 +90,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Deployment: antiaffinity-demo
           Namespace: ha-services
@@ -105,7 +105,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -121,8 +121,8 @@
         replicas are Running.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/crashlooping_pod/evals.yaml
+++ b/agentic/crashlooping_pod/evals.yaml
@@ -4,7 +4,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Alert: WarehouseOpsPodRestarting (warning)
           Namespace: warehouse-ops
@@ -20,7 +20,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -34,10 +34,10 @@
         DEPLOY_ENV environment variable to the deployment spec.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: crashlooping_pod_anthropic
@@ -46,7 +46,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Alert: WarehouseOpsPodRestarting (warning)
           Namespace: warehouse-ops
@@ -62,7 +62,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -76,10 +76,10 @@
         DEPLOY_ENV environment variable to the deployment spec.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: crashlooping_pod_gemini
@@ -88,7 +88,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Alert: WarehouseOpsPodRestarting (warning)
           Namespace: warehouse-ops
@@ -104,7 +104,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -118,8 +118,8 @@
         DEPLOY_ENV environment variable to the deployment spec.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/failed_job/evals.yaml
+++ b/agentic/failed_job/evals.yaml
@@ -5,7 +5,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The inventory-sync-validator job in the catalog-mgmt namespace
           has failed. The job is part of a batch processing pipeline that
@@ -18,7 +18,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -37,10 +37,10 @@
         job's database connection configuration.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: failed_job_anthropic
@@ -50,7 +50,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The inventory-sync-validator job in the catalog-mgmt namespace
           has failed. The job is part of a batch processing pipeline that
@@ -63,7 +63,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -82,10 +82,10 @@
         job's database connection configuration.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: failed_job_gemini
@@ -95,7 +95,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The inventory-sync-validator job in the catalog-mgmt namespace
           has failed. The job is part of a batch processing pipeline that
@@ -108,7 +108,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -127,8 +127,8 @@
         job's database connection configuration.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/failing_api/evals.yaml
+++ b/agentic/failing_api/evals.yaml
@@ -3,7 +3,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Alert: PaymentErrorRateHigh (critical)
           Namespace: payments
@@ -19,7 +19,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -34,10 +34,10 @@
         Fix: rollback, restart, or scale down reporting-service.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.80
 
 - conversation_group_id: failing_api_anthropic
@@ -45,7 +45,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Alert: PaymentErrorRateHigh (critical)
           Namespace: payments
@@ -61,7 +61,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -76,10 +76,10 @@
         Fix: rollback, restart, or scale down reporting-service.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.80
 
 - conversation_group_id: failing_api_gemini
@@ -87,7 +87,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Alert: PaymentErrorRateHigh (critical)
           Namespace: payments
@@ -103,7 +103,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -118,8 +118,8 @@
         Fix: rollback, restart, or scale down reporting-service.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.80

--- a/agentic/hpa_broken/evals.yaml
+++ b/agentic/hpa_broken/evals.yaml
@@ -3,7 +3,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           HPA: hpa-underspecified-demo
           Namespace: hpa-scaling
@@ -18,7 +18,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -35,10 +35,10 @@
         ScalingActive=True.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: hpa_broken_anthropic
@@ -46,7 +46,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           HPA: hpa-underspecified-demo
           Namespace: hpa-scaling
@@ -61,7 +61,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -78,10 +78,10 @@
         ScalingActive=True.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: hpa_broken_gemini
@@ -89,7 +89,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           HPA: hpa-underspecified-demo
           Namespace: hpa-scaling
@@ -104,7 +104,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -121,8 +121,8 @@
         ScalingActive=True.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/imagepull_auth/evals.yaml
+++ b/agentic/imagepull_auth/evals.yaml
@@ -5,7 +5,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The deployment imagepull-auth-app in namespace imagepull-auth
           cannot start its pod. The image
@@ -18,7 +18,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -35,10 +35,10 @@
         spec or linked to the service account.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: imagepull_auth_anthropic
@@ -48,7 +48,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The deployment imagepull-auth-app in namespace imagepull-auth
           cannot start its pod. The image
@@ -61,7 +61,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -78,10 +78,10 @@
         spec or linked to the service account.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: imagepull_auth_gemini
@@ -91,7 +91,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The deployment imagepull-auth-app in namespace imagepull-auth
           cannot start its pod. The image
@@ -104,7 +104,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -121,8 +121,8 @@
         spec or linked to the service account.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/limitrange_conflict/evals.yaml
+++ b/agentic/limitrange_conflict/evals.yaml
@@ -3,7 +3,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Deployment: limitrange-demo
           Namespace: limitrange-demo
@@ -20,7 +20,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -36,10 +36,10 @@
         created and Running.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: limitrange_conflict_anthropic
@@ -47,7 +47,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Deployment: limitrange-demo
           Namespace: limitrange-demo
@@ -64,7 +64,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -80,10 +80,10 @@
         created and Running.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: limitrange_conflict_gemini
@@ -91,7 +91,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Deployment: limitrange-demo
           Namespace: limitrange-demo
@@ -108,7 +108,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -124,8 +124,8 @@
         created and Running.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/missing_pvc/evals.yaml
+++ b/agentic/missing_pvc/evals.yaml
@@ -4,7 +4,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The deployment missing-pvc-demo in namespace missing-pvc-test
           never gets a pod scheduled. The team says it needs a 1Gi volume
@@ -20,7 +20,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -35,10 +35,10 @@
         scheduled with the volume mounted.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: missing_pvc_anthropic
@@ -47,7 +47,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The deployment missing-pvc-demo in namespace missing-pvc-test
           never gets a pod scheduled. The team says it needs a 1Gi volume
@@ -63,7 +63,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -78,10 +78,10 @@
         scheduled with the volume mounted.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: missing_pvc_gemini
@@ -90,7 +90,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The deployment missing-pvc-demo in namespace missing-pvc-test
           never gets a pod scheduled. The team says it needs a 1Gi volume
@@ -106,7 +106,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -121,8 +121,8 @@
         scheduled with the volume mounted.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/missing_secret_key/evals.yaml
+++ b/agentic/missing_secret_key/evals.yaml
@@ -4,7 +4,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Deployment: missing-secret-key-demo
           Namespace: credential-store
@@ -20,7 +20,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -35,10 +35,10 @@
         reaches Running state.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: missing_secret_key_anthropic
@@ -47,7 +47,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Deployment: missing-secret-key-demo
           Namespace: credential-store
@@ -63,7 +63,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -78,10 +78,10 @@
         reaches Running state.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: missing_secret_key_gemini
@@ -90,7 +90,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Deployment: missing-secret-key-demo
           Namespace: credential-store
@@ -106,7 +106,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -121,8 +121,8 @@
         reaches Running state.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/netpol_dns/evals.yaml
+++ b/agentic/netpol_dns/evals.yaml
@@ -4,7 +4,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           After a security hardening change, the app netpol-dns-demo in
           namespace netpol-dns-test logs DNS resolution failures for every
@@ -22,7 +22,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -40,10 +40,10 @@
         default-deny policy.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: netpol_dns_anthropic
@@ -52,7 +52,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           After a security hardening change, the app netpol-dns-demo in
           namespace netpol-dns-test logs DNS resolution failures for every
@@ -70,7 +70,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -88,10 +88,10 @@
         default-deny policy.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: netpol_dns_gemini
@@ -100,7 +100,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           After a security hardening change, the app netpol-dns-demo in
           namespace netpol-dns-test logs DNS resolution failures for every
@@ -118,7 +118,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -136,8 +136,8 @@
         default-deny policy.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/oomkilled_pod/evals.yaml
+++ b/agentic/oomkilled_pod/evals.yaml
@@ -3,7 +3,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Alert: DataProcessingPodRestarting (warning)
           Namespace: data-processing
@@ -19,7 +19,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -34,10 +34,10 @@
         memory limit or fix the application code to avoid the memory leak.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: oomkilled_pod_anthropic
@@ -45,7 +45,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Alert: DataProcessingPodRestarting (warning)
           Namespace: data-processing
@@ -61,7 +61,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -76,10 +76,10 @@
         memory limit or fix the application code to avoid the memory leak.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: oomkilled_pod_gemini
@@ -87,7 +87,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Alert: DataProcessingPodRestarting (warning)
           Namespace: data-processing
@@ -103,7 +103,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -118,8 +118,8 @@
         memory limit or fix the application code to avoid the memory leak.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/orphaned_pvc/evals.yaml
+++ b/agentic/orphaned_pvc/evals.yaml
@@ -5,7 +5,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The platform team suspects namespace pvc-orphans is paying for
           storage nobody uses. Analyze which PersistentVolumeClaims in
@@ -17,7 +17,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -27,16 +27,16 @@
         In use: active-data-pvc, mounted at /data by the running
         pvc-user-app deployment. Orphaned cleanup candidates:
         old-backup-pvc and tmp-scratch-pvc, which are referenced by no
-        pod or workload template in the namespace. The proposal should
+        pod or workload template in the namespace. The analysis should
         recommend confirming with the owning team and then deleting the
         two orphaned claims to release their storage, without touching
         active-data-pvc.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: orphaned_pvc_anthropic
@@ -46,7 +46,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The platform team suspects namespace pvc-orphans is paying for
           storage nobody uses. Analyze which PersistentVolumeClaims in
@@ -58,7 +58,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -68,16 +68,16 @@
         In use: active-data-pvc, mounted at /data by the running
         pvc-user-app deployment. Orphaned cleanup candidates:
         old-backup-pvc and tmp-scratch-pvc, which are referenced by no
-        pod or workload template in the namespace. The proposal should
+        pod or workload template in the namespace. The analysis should
         recommend confirming with the owning team and then deleting the
         two orphaned claims to release their storage, without touching
         active-data-pvc.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: orphaned_pvc_gemini
@@ -87,7 +87,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The platform team suspects namespace pvc-orphans is paying for
           storage nobody uses. Analyze which PersistentVolumeClaims in
@@ -99,7 +99,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -109,14 +109,14 @@
         In use: active-data-pvc, mounted at /data by the running
         pvc-user-app deployment. Orphaned cleanup candidates:
         old-backup-pvc and tmp-scratch-pvc, which are referenced by no
-        pod or workload template in the namespace. The proposal should
+        pod or workload template in the namespace. The analysis should
         recommend confirming with the owning team and then deleting the
         two orphaned claims to release their storage, without touching
         active-data-pvc.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/pending_pvc/evals.yaml
+++ b/agentic/pending_pvc/evals.yaml
@@ -4,7 +4,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Alert: CacheTierPersistentVolumeClaimPending (warning)
           Namespace: cache-tier
@@ -20,7 +20,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -39,10 +39,10 @@
         a UID within the namespace's allowed range.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: pending_pvc_anthropic
@@ -51,7 +51,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Alert: CacheTierPersistentVolumeClaimPending (warning)
           Namespace: cache-tier
@@ -67,7 +67,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -86,10 +86,10 @@
         a UID within the namespace's allowed range.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: pending_pvc_gemini
@@ -98,7 +98,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Alert: CacheTierPersistentVolumeClaimPending (warning)
           Namespace: cache-tier
@@ -114,7 +114,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -133,8 +133,8 @@
         a UID within the namespace's allowed range.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/priorityclass/evals.yaml
+++ b/agentic/priorityclass/evals.yaml
@@ -4,7 +4,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The deployment priorityclass-demo in namespace
           priorityclass-test is not creating any pods. Its manifest came
@@ -22,7 +22,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -38,10 +38,10 @@
         priority) and verify the pod is created and Running.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: priorityclass_anthropic
@@ -50,7 +50,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The deployment priorityclass-demo in namespace
           priorityclass-test is not creating any pods. Its manifest came
@@ -68,7 +68,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -84,10 +84,10 @@
         priority) and verify the pod is created and Running.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: priorityclass_gemini
@@ -96,7 +96,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The deployment priorityclass-demo in namespace
           priorityclass-test is not creating any pods. Its manifest came
@@ -114,7 +114,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -130,8 +130,8 @@
         priority) and verify the pod is created and Running.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/recurring_batch_failure/evals.yaml
+++ b/agentic/recurring_batch_failure/evals.yaml
@@ -4,7 +4,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The batch-processor in the data-pipeline namespace is processing
           historical records. Some pod ERROR logs reported issues.
@@ -15,7 +15,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -34,10 +34,10 @@
         unavailability.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: recurring_batch_failure_anthropic
@@ -46,7 +46,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The batch-processor in the data-pipeline namespace is processing
           historical records. Some pod ERROR logs reported issues.
@@ -57,7 +57,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -76,10 +76,10 @@
         unavailability.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: recurring_batch_failure_gemini
@@ -88,7 +88,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The batch-processor in the data-pipeline namespace is processing
           historical records. Some pod ERROR logs reported issues.
@@ -99,7 +99,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -118,8 +118,8 @@
         unavailability.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/refused_connections/evals.yaml
+++ b/agentic/refused_connections/evals.yaml
@@ -3,7 +3,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The gateway-proxy in the ingress-layer namespace is returning
           connection refused errors. Pod logs show repeated failures.
@@ -13,7 +13,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -30,10 +30,10 @@
         upstream endpoints (db-prod.internal, redis-prod.internal).
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: refused_connections_anthropic
@@ -42,7 +42,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The gateway-proxy in the ingress-layer namespace is returning
           connection refused errors. Pod logs show repeated failures.
@@ -52,7 +52,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -69,10 +69,10 @@
         upstream endpoints (db-prod.internal, redis-prod.internal).
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: refused_connections_gemini
@@ -81,7 +81,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The gateway-proxy in the ingress-layer namespace is returning
           connection refused errors. Pod logs show repeated failures.
@@ -91,7 +91,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -108,8 +108,8 @@
         upstream endpoints (db-prod.internal, redis-prod.internal).
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/resource_quota/evals.yaml
+++ b/agentic/resource_quota/evals.yaml
@@ -4,7 +4,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Deployment: quota-victim-app
           Namespace: team-onboarding
@@ -20,7 +20,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -36,10 +36,10 @@
         pod is created and Running.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: resource_quota_anthropic
@@ -48,7 +48,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Deployment: quota-victim-app
           Namespace: team-onboarding
@@ -64,7 +64,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -80,10 +80,10 @@
         pod is created and Running.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: resource_quota_gemini
@@ -92,7 +92,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Deployment: quota-victim-app
           Namespace: team-onboarding
@@ -108,7 +108,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -124,8 +124,8 @@
         pod is created and Running.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/route_port/evals.yaml
+++ b/agentic/route_port/evals.yaml
@@ -4,7 +4,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The externally exposed route route-port-demo in namespace
           route-port-test returns 503 for every request, but the
@@ -20,7 +20,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -34,10 +34,10 @@
         name "web") so requests reach the nginx container.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: route_port_anthropic
@@ -46,7 +46,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The externally exposed route route-port-demo in namespace
           route-port-test returns 503 for every request, but the
@@ -62,7 +62,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -76,10 +76,10 @@
         name "web") so requests reach the nginx container.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: route_port_gemini
@@ -88,7 +88,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The externally exposed route route-port-demo in namespace
           route-port-test returns 503 for every request, but the
@@ -104,7 +104,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -118,8 +118,8 @@
         name "web") so requests reach the nginx container.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/sporadic_api_timeout/evals.yaml
+++ b/agentic/sporadic_api_timeout/evals.yaml
@@ -4,7 +4,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The report-generator in the analytics-platform namespace is
           processing historical records. Analyze the pod logs to identify
@@ -17,7 +17,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -33,10 +33,10 @@
         and not caused by a bug in the report-generator itself.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: sporadic_api_timeout_anthropic
@@ -45,7 +45,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The report-generator in the analytics-platform namespace is
           processing historical records. Analyze the pod logs to identify
@@ -58,7 +58,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -74,10 +74,10 @@
         and not caused by a bug in the report-generator itself.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: sporadic_api_timeout_gemini
@@ -86,7 +86,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The report-generator in the analytics-platform namespace is
           processing historical records. Analyze the pod logs to identify
@@ -99,7 +99,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -115,8 +115,8 @@
         and not caused by a bug in the report-generator itself.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/svc_port_mismatch/evals.yaml
+++ b/agentic/svc_port_mismatch/evals.yaml
@@ -3,7 +3,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Requests to the service svc-port-svc in namespace svc-port-demo
           are refused, although the service has endpoints and the backing
@@ -15,7 +15,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -29,10 +29,10 @@
         targetPort to 8080 and verify connectivity through the service.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: svc_port_mismatch_anthropic
@@ -40,7 +40,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Requests to the service svc-port-svc in namespace svc-port-demo
           are refused, although the service has endpoints and the backing
@@ -52,7 +52,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -66,10 +66,10 @@
         targetPort to 8080 and verify connectivity through the service.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: svc_port_mismatch_gemini
@@ -77,7 +77,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Requests to the service svc-port-svc in namespace svc-port-demo
           are refused, although the service has endpoints and the backing
@@ -89,7 +89,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -103,8 +103,8 @@
         targetPort to 8080 and verify connectivity through the service.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/svc_selector/evals.yaml
+++ b/agentic/svc_selector/evals.yaml
@@ -4,7 +4,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The service svc-selector-svc in namespace svc-selector-test
           serves no traffic even though its backing application is
@@ -19,7 +19,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -34,10 +34,10 @@
         service's endpoints are populated with the ready pod.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: svc_selector_anthropic
@@ -46,7 +46,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The service svc-selector-svc in namespace svc-selector-test
           serves no traffic even though its backing application is
@@ -61,7 +61,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -76,10 +76,10 @@
         service's endpoints are populated with the ready pod.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: svc_selector_gemini
@@ -88,7 +88,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The service svc-selector-svc in namespace svc-selector-test
           serves no traffic even though its backing application is
@@ -103,7 +103,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -118,8 +118,8 @@
         service's endpoints are populated with the ready pod.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/system.yaml
+++ b/agentic/system.yaml
@@ -19,10 +19,10 @@ agents:
     agent_config:
       timeout: 600
   eval_agent:
-    type: proposal
+    type: openshift_agentic_run
     namespace: openshift-lightspeed
     auto_approve: true
-    cleanup_proposals: false
+    cleanup_openshift_agentic_runs: false
     timeout: 600
     poll_interval: 5
 

--- a/agentic/timeout_connections/evals.yaml
+++ b/agentic/timeout_connections/evals.yaml
@@ -4,7 +4,7 @@
   
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The frontend application in the service-mesh namespace is logging
           repeated "ERROR: Connection timeout to backend-service!" messages.
@@ -16,7 +16,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -31,10 +31,10 @@
         (or app=frontend), or relabel the frontend pod to tier=backend.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: timeout_connections_anthropic
@@ -43,7 +43,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The frontend application in the service-mesh namespace is logging
           repeated "ERROR: Connection timeout to backend-service!" messages.
@@ -55,7 +55,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -70,10 +70,10 @@
         (or app=frontend), or relabel the frontend pod to tier=backend.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: timeout_connections_gemini
@@ -82,7 +82,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           The frontend application in the service-mesh namespace is logging
           repeated "ERROR: Connection timeout to backend-service!" messages.
@@ -94,7 +94,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -109,8 +109,8 @@
         (or app=frontend), or relabel the frontend pod to tier=backend.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/unbalanced_replicas/evals.yaml
+++ b/agentic/unbalanced_replicas/evals.yaml
@@ -4,7 +4,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Namespaces: fleet-alpha, fleet-alpha1
           Description: We expect both namespaces to have the same number of
@@ -19,7 +19,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -35,10 +35,10 @@
         2 deployments and 4 standalone pods (6 total).
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: unbalanced_replicas_anthropic
@@ -47,7 +47,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Namespaces: fleet-alpha, fleet-alpha1
           Description: We expect both namespaces to have the same number of
@@ -62,7 +62,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -78,10 +78,10 @@
         2 deployments and 4 standalone pods (6 total).
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: unbalanced_replicas_gemini
@@ -90,7 +90,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Namespaces: fleet-alpha, fleet-alpha1
           Description: We expect both namespaces to have the same number of
@@ -105,7 +105,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -121,8 +121,8 @@
         2 deployments and 4 standalone pods (6 total).
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/unready_pod/evals.yaml
+++ b/agentic/unready_pod/evals.yaml
@@ -4,7 +4,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Alert: DiscoveryHubPodNotReady (warning)
           Namespace: discovery-hub
@@ -20,7 +20,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -37,10 +37,10 @@
         what the container actually runs, or remove the readiness probe.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: unready_pod_anthropic
@@ -49,7 +49,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Alert: DiscoveryHubPodNotReady (warning)
           Namespace: discovery-hub
@@ -65,7 +65,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -82,10 +82,10 @@
         what the container actually runs, or remove the readiness probe.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: unready_pod_gemini
@@ -94,7 +94,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Alert: DiscoveryHubPodNotReady (warning)
           Namespace: discovery-hub
@@ -110,7 +110,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -127,8 +127,8 @@
         what the container actually runs, or remove the readiness probe.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/agentic/unscheduled_pod/evals.yaml
+++ b/agentic/unscheduled_pod/evals.yaml
@@ -4,7 +4,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Pod: user-profile-import
           Namespace: user-imports
@@ -18,7 +18,7 @@
         analysis:
           agent: default
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -33,10 +33,10 @@
         nodeSelector in the deployment spec.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: unscheduled_pod_anthropic
@@ -45,7 +45,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Pod: user-profile-import
           Namespace: user-imports
@@ -59,7 +59,7 @@
         analysis:
           agent: opus
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -74,10 +74,10 @@
         nodeSelector in the deployment spec.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75
 
 - conversation_group_id: unscheduled_pod_gemini
@@ -86,7 +86,7 @@
 
   turns:
     - turn_id: turn_1
-      proposal_spec:
+      openshift_agentic_run_spec:
         request: |
           Pod: user-profile-import
           Namespace: user-imports
@@ -100,7 +100,7 @@
         analysis:
           agent: gemini
 
-      expected_proposal_status:
+      expected_openshift_agentic_run_status:
         phase: Completed
         conditions:
           - type: Analyzed
@@ -115,8 +115,8 @@
         nodeSelector in the deployment spec.
 
       turn_metrics:
-        - "custom:proposal_status"
-        - "custom:proposal_evaluation_correctness"
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
       turn_metrics_metadata:
-        "custom:proposal_evaluation_correctness":
+        "custom:openshift_agentic_run_evaluation_correctness":
           threshold: 0.75

--- a/scripts/summarize-agentic-evals.py
+++ b/scripts/summarize-agentic-evals.py
@@ -10,8 +10,8 @@ from pathlib import Path
 import yaml
 
 METRIC_LABELS = {
-    "custom:proposal_status": "Completed",
-    "custom:proposal_evaluation_correctness": "Correctness",
+    "custom:openshift_agentic_run_status": "Completed",
+    "custom:openshift_agentic_run_evaluation_correctness": "Correctness",
 }
 
 GREEN = "\033[0;32m"


### PR DESCRIPTION
## Summary
- Renames `proposal_spec` → `openshift_agentic_run_spec`, `expected_proposal_status` → `expected_openshift_agentic_run_status`, and the corresponding custom metrics across all 25 agentic scenario `evals.yaml` files
- Updates `system.yaml` agent type from `proposal` to `openshift_agentic_run` and `cleanup_proposals` to `cleanup_openshift_agentic_runs`

Aligns with [lightspeed-evaluation#318](https://github.com/lightspeed-core/lightspeed-evaluation/pull/318).

> **⚠️ Merge order:** This PR must be merged **after** lightspeed-evaluation#318 is merged, since the old field names are still accepted (with deprecation warnings) but the new names require the updated framework.

## Test plan
- [x] Verify lightspeed-evaluation#318 is merged first
- [x] Run `make evals` against a scenario to confirm the new field names are accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)