### PR TITLE
refactor: decentralize alert scenario setup

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -30,16 +30,7 @@ RUNS ?= 1
 
 .PHONY: setup evals cleanup help
 
-ALERT_SUITES := crashlooping_pod oomkilled_pod pending_pvc unready_pod
-
 setup:
-	@$(SCRIPTS_DIR)/enable-uwm.sh
-	@for suite in $(ALERT_SUITES); do \
-	  echo "==> Deploying alert scenario: $$suite"; \
-	  bash $$suite/setup.sh; \
-	done
-	@echo ""
-	@echo "All alert scenarios deployed."
 	$(SCRIPTS_DIR)/setup-venv.sh
 	@echo ""
 	@echo "NOTE: Install lightspeed-agentic-operator manually by following:"

--- a/agentic/crashlooping_pod/setup.sh
+++ b/agentic/crashlooping_pod/setup.sh
@@ -2,9 +2,11 @@
 set -euo pipefail
 
 FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")/../../scripts" && pwd)"
 NS="warehouse-ops"
 APP="order-fulfillment-daemon"
 
+"$SCRIPT_DIR/enable-uwm.sh"
 oc apply -f "$FIXTURE_DIR/deployment.yaml"
 oc apply -f "$FIXTURE_DIR/prometheusrule.yaml"
 
@@ -26,5 +28,4 @@ oc wait --for=jsonpath='{.status.containerStatuses[0].state.waiting.reason}'=Cra
 
 echo "Setup complete: $APP is in CrashLoopBackOff state"
 
-SCRIPT_DIR="$(cd "$(dirname "$0")/../../scripts" && pwd)"
 "$SCRIPT_DIR/wait-for-alert.sh" "WarehouseOpsPodRestarting"

--- a/agentic/oomkilled_pod/setup.sh
+++ b/agentic/oomkilled_pod/setup.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")/../../scripts" && pwd)"
 NS="data-processing"
 APP="report-generator"
 
+"$SCRIPT_DIR/enable-uwm.sh"
 oc apply -f "$FIXTURE_DIR/manifest.yaml"
 oc apply -f "$FIXTURE_DIR/prometheusrule.yaml"
 

--- a/agentic/pending_pvc/setup.sh
+++ b/agentic/pending_pvc/setup.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")/../../scripts" && pwd)"
 NS="cache-tier"
 PVC="memcached-data-pvc"
 
+"$SCRIPT_DIR/enable-uwm.sh"
 oc apply -f "$FIXTURE_DIR/manifest.yaml"
 oc apply -f "$FIXTURE_DIR/prometheusrule.yaml"
 

--- a/agentic/unready_pod/setup.sh
+++ b/agentic/unready_pod/setup.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")/../../scripts" && pwd)"
 NS="discovery-hub"
 POD_NAME="catalog-index-service"
 
+"$SCRIPT_DIR/enable-uwm.sh"
 echo "Applying unready_pod scenario manifests in namespace ${NS}…"
 oc apply -f "$FIXTURE_DIR/manifest.yaml"
 oc apply -f "$FIXTURE_DIR/prometheusrule.yaml"


### PR DESCRIPTION
Move user workload monitoring (UWM) enablement from the centralized Makefile setup target into individual scenario setup scripts. Each scenario now self-contains its infrastructure prerequisites.


Assisted-by: Claude Code:claude-haiku-4-5-20251001