### PR TITLE
feat: add overprivileged agentic eval scenario

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -13,6 +13,7 @@ SUITES ?= \
 	netpol_dns \
 	oomkilled_pod \
 	orphaned_pvc \
+	overprivileged \
 	pending_pvc \
 	priorityclass \
 	route_port \

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -27,6 +27,7 @@ Behavioral evals for automated troubleshooting with [OpenShift Agentic Lightspee
 | `failed_job` | inventory-sync-validator Job fails | Job cannot connect to database at prod-db:3333 (connection refused) | Normal | |
 | `oomkilled_pod` | Pods repeatedly OOMKilled / CrashLoopBackOff | Python app has a memory leak (~1MB/s) that exceeds the 60Mi container limit | Normal | ~2min |
 | `orphaned_pvc` | PVCs attached to no workload | Two of three PVCs are not mounted by any pod or deployment | Normal | |
+| `overprivileged` | ServiceAccount bound to cluster-admin (analysis-only) | Nginx webapp SA has full admin rights but makes no API calls; propose least-privilege | Normal | |
 | `svc_selector` | Service has zero endpoints despite healthy pods | Service selector `app=svc-selector-app` doesn't match pod label `app=svc-selector-demo` | Normal | |
 | `timeout_connections` | Frontend gets connection timeouts to backend | NetworkPolicy only allows ingress from `tier=backend`, blocking `tier=frontend` pods | Normal | |
 | `unbalanced_replicas` | Namespaces have different pod counts | fleet-alpha has 6 pods vs fleet-alpha1 with 9, due to different deployment sets | Normal | |

--- a/agentic/overprivileged/cleanup.sh
+++ b/agentic/overprivileged/cleanup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="overprivileged-demo"
+
+oc delete deployment overprivileged-webapp -n "$NS" --ignore-not-found
+oc delete rolebinding webapp-admin-binding -n "$NS" --ignore-not-found
+oc delete serviceaccount webapp-sa -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found
+
+echo "Cleanup complete: removed overprivileged-demo namespace and resources"

--- a/agentic/overprivileged/evals.yaml
+++ b/agentic/overprivileged/evals.yaml
@@ -1,0 +1,128 @@
+- conversation_group_id: overprivileged_openai
+  tag: agentic_overprivileged
+
+  turns:
+    - turn_id: turn_1
+      openshift_agentic_run_spec:
+        request: |
+          Namespace: overprivileged-demo
+          Task: RBAC security audit
+          Description: The security team is auditing namespace
+          overprivileged-demo. Review the RBAC bindings of the workloads'
+          ServiceAccounts, assess whether any grant more access than the
+          workload needs, and propose the least-privilege replacement.
+          Do not change anything.
+        targetNamespaces:
+          - overprivileged-demo
+        analysis:
+          agent: default
+
+      expected_openshift_agentic_run_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        The ServiceAccount webapp-sa is bound to the cluster-admin
+        ClusterRole via the RoleBinding webapp-admin-binding, granting it
+        full admin rights over the namespace — while the workload using
+        it (overprivileged-webapp, a plain nginx) makes no Kubernetes API
+        calls at all. This is a high-risk over-privilege: a compromised
+        pod could read every secret and modify every resource in the
+        namespace. Proposal: delete the webapp-admin-binding (the app
+        needs no API access) or, if some access is later required, bind a
+        purpose-built minimal Role instead.
+
+      turn_metrics:
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:openshift_agentic_run_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: overprivileged_anthropic
+  tag: agentic_overprivileged
+
+  turns:
+    - turn_id: turn_1
+      openshift_agentic_run_spec:
+        request: |
+          Namespace: overprivileged-demo
+          Task: RBAC security audit
+          Description: The security team is auditing namespace
+          overprivileged-demo. Review the RBAC bindings of the workloads'
+          ServiceAccounts, assess whether any grant more access than the
+          workload needs, and propose the least-privilege replacement.
+          Do not change anything.
+        targetNamespaces:
+          - overprivileged-demo
+        analysis:
+          agent: opus
+
+      expected_openshift_agentic_run_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        The ServiceAccount webapp-sa is bound to the cluster-admin
+        ClusterRole via the RoleBinding webapp-admin-binding, granting it
+        full admin rights over the namespace — while the workload using
+        it (overprivileged-webapp, a plain nginx) makes no Kubernetes API
+        calls at all. This is a high-risk over-privilege: a compromised
+        pod could read every secret and modify every resource in the
+        namespace. Proposal: delete the webapp-admin-binding (the app
+        needs no API access) or, if some access is later required, bind a
+        purpose-built minimal Role instead.
+
+      turn_metrics:
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:openshift_agentic_run_evaluation_correctness":
+          threshold: 0.75
+
+- conversation_group_id: overprivileged_gemini
+  tag: agentic_overprivileged
+
+  turns:
+    - turn_id: turn_1
+      openshift_agentic_run_spec:
+        request: |
+          Namespace: overprivileged-demo
+          Task: RBAC security audit
+          Description: The security team is auditing namespace
+          overprivileged-demo. Review the RBAC bindings of the workloads'
+          ServiceAccounts, assess whether any grant more access than the
+          workload needs, and propose the least-privilege replacement.
+          Do not change anything.
+        targetNamespaces:
+          - overprivileged-demo
+        analysis:
+          agent: gemini
+
+      expected_openshift_agentic_run_status:
+        phase: Completed
+        conditions:
+          - type: Analyzed
+            status: "True"
+
+      expected_outcome: >-
+        The ServiceAccount webapp-sa is bound to the cluster-admin
+        ClusterRole via the RoleBinding webapp-admin-binding, granting it
+        full admin rights over the namespace — while the workload using
+        it (overprivileged-webapp, a plain nginx) makes no Kubernetes API
+        calls at all. This is a high-risk over-privilege: a compromised
+        pod could read every secret and modify every resource in the
+        namespace. Proposal: delete the webapp-admin-binding (the app
+        needs no API access) or, if some access is later required, bind a
+        purpose-built minimal Role instead.
+
+      turn_metrics:
+        - "custom:openshift_agentic_run_status"
+        - "custom:openshift_agentic_run_evaluation_correctness"
+      turn_metrics_metadata:
+        "custom:openshift_agentic_run_evaluation_correctness":
+          threshold: 0.75

--- a/agentic/overprivileged/fixtures/manifest.yaml
+++ b/agentic/overprivileged/fixtures/manifest.yaml
@@ -1,0 +1,63 @@
+# A plain web app whose ServiceAccount is bound to cluster-admin within the
+# namespace — massive over-privilege for a workload that needs nothing from
+# the API. Analysis-only: classify the risk and propose least privilege.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: overprivileged-demo
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: webapp-sa
+  namespace: overprivileged-demo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: webapp-admin-binding
+  namespace: overprivileged-demo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: webapp-sa
+    namespace: overprivileged-demo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: overprivileged-webapp
+  namespace: overprivileged-demo
+  labels:
+    app: overprivileged-webapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: overprivileged-webapp
+  template:
+    metadata:
+      labels:
+        app: overprivileged-webapp
+    spec:
+      serviceAccountName: webapp-sa
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"

--- a/agentic/overprivileged/setup.sh
+++ b/agentic/overprivileged/setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="overprivileged-demo"
+DEPLOY="overprivileged-webapp"
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+# Wait for the deployment to become available
+echo "Waiting for deployment $DEPLOY to become available…"
+oc wait --for=condition=Available deployment/"$DEPLOY" \
+  -n "$NS" --timeout=120s
+
+echo "Setup complete: $DEPLOY is running with cluster-admin binding"


### PR DESCRIPTION
Analysis-only scenario: nginx webapp's ServiceAccount is bound to cluster-admin via RoleBinding but makes no API calls. Agent should classify the over-privilege and propose removal.


Assisted-by: Claude Code:claude-opus-4-6