### PR TITLE
fix: extract judge from JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ agentic/results/logs/
 **/.caches/
 __pycache__/
 venv/
+.tools/
 
 # Secrets / credentials — never commit API keys
 .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,8 @@ Each suite Makefile declares a `SCENARIOS` variable and includes `../scripts/eva
 The root Makefile has maintenance targets only:
 
 ```bash
+make tools          # Install local lint tools in .tools/
+make lint           # Install tools if needed, then run all linters
 make cleanup        # Remove OLS operator + local venv
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,18 @@ cleanup:
 | `<tag>-eval` | Run a single scenario |
 | `help` | List available targets |
 
-## 5. Test
+## 5. Lint
+
+Run all linters from the repository root:
+
+```bash
+make lint
+```
+
+This installs the pinned lint tools into `.tools/` when needed. To install them
+without running lint, use `make tools`.
+
+## 6. Test
 
 ```bash
 export OPENAI_API_KEY=<your-key>
@@ -122,7 +133,7 @@ make evals
 make cleanup
 ```
 
-## 6. Shared scripts reference
+## 7. Shared scripts reference
 
 All shared scripts live in `scripts/` at the repo root. Teams should not need to modify them.
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ $(TOOLS_STAMP): $(TOOLS_REQUIREMENTS)
 
 lint: tools lint-shell lint-yaml ## Install tools and run all linters
 
+lint-shell lint-yaml: tools
+
 lint-shell: ## Lint shell scripts with shellcheck
 	@files=$$(git ls-files --cached --others --exclude-standard -- $(LINT_DIRS) | \
 	  awk '/\.sh$$/'); \

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,42 @@
 ##@ Linting
 
 LINT_DIRS ?= generic kiali-ossm kubevirt netobserv
+TOOLS_VENV ?= .tools
+TOOLS_PYTHON ?= python3
+TOOLS_REQUIREMENTS := requirements-tools.txt
+TOOLS_STAMP := $(TOOLS_VENV)/.installed
 
-.PHONY: lint lint-shell lint-yaml
+.PHONY: tools lint lint-shell lint-yaml
 
-lint: lint-shell lint-yaml ## Run all linters (shellcheck + yamllint)
+tools: $(TOOLS_STAMP) ## Install local development tools
+
+$(TOOLS_STAMP): $(TOOLS_REQUIREMENTS)
+	@command -v $(TOOLS_PYTHON) >/dev/null 2>&1 || \
+	  { printf '\033[0;31mERROR:\033[0m %s not found.\n' "$(TOOLS_PYTHON)"; exit 1; }
+	$(TOOLS_PYTHON) -m venv $(TOOLS_VENV)
+	$(TOOLS_VENV)/bin/python -m pip install --quiet --requirement $(TOOLS_REQUIREMENTS)
+	@touch $(TOOLS_STAMP)
+
+lint: tools lint-shell lint-yaml ## Install tools and run all linters
 
 lint-shell: ## Lint shell scripts with shellcheck
-	@command -v shellcheck >/dev/null 2>&1 || \
-	  { printf '\033[0;31mERROR:\033[0m shellcheck not found. Install: sudo dnf install ShellCheck\n'; exit 1; }
-	@files=$$(find $(LINT_DIRS) -name '*.sh' -type f 2>/dev/null); \
+	@files=$$(git ls-files --cached --others --exclude-standard -- $(LINT_DIRS) | \
+	  awk '/\.sh$$/'); \
 	if [ -z "$$files" ]; then \
 	  printf 'No .sh files found in: %s\n' "$(LINT_DIRS)"; \
 	else \
 	  printf '==> shellcheck %s file(s)\n' "$$(echo "$$files" | wc -w)"; \
-	  echo "$$files" | xargs shellcheck; \
+	  echo "$$files" | xargs $(TOOLS_VENV)/bin/shellcheck; \
 	fi
 
 lint-yaml: ## Lint YAML files with yamllint
-	@command -v yamllint >/dev/null 2>&1 || \
-	  { printf '\033[0;31mERROR:\033[0m yamllint not found. Install: pip install yamllint\n'; exit 1; }
-	@files=$$(find $(LINT_DIRS) -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null); \
+	@files=$$(git ls-files --cached --others --exclude-standard -- $(LINT_DIRS) | \
+	  awk '/\.ya?ml$$/'); \
 	if [ -z "$$files" ]; then \
 	  printf 'No YAML files found in: %s\n' "$(LINT_DIRS)"; \
 	else \
 	  printf '==> yamllint %s file(s)\n' "$$(echo "$$files" | wc -w)"; \
-	  echo "$$files" | xargs yamllint -c .yamllint.yml; \
+	  echo "$$files" | xargs $(TOOLS_VENV)/bin/yamllint -c .yamllint.yml; \
 	fi
 
 ##@ Maintenance
@@ -38,8 +49,9 @@ SCRIPTS_DIR := scripts
 help: ## Show available targets
 	@echo ""
 	@echo "  Root targets (maintenance):"
+	@echo "    make tools            Install local development tools"
 	@echo "    make cleanup          Remove OLS operator + venv"
-	@echo "    make lint             Run all linters"
+	@echo "    make lint             Install tools and run all linters"
 	@echo ""
 	@echo "  Per-team workflow (run from team directory):"
 	@echo "    cd kiali-ossm && make setup && make evals && make cleanup"

--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -96,7 +96,6 @@ else
 	$(eval EVAL_DIR := results/logs/$(DATETIME))
 	$(eval _AGENTS := $(shell ../venv/bin/python3 -c "import yaml; c=yaml.safe_load(open('system.yaml')); print(' '.join(c.get('agents',{}).get('default',{}).get('agent',[])))"))
 	$(eval _REPEAT := $(shell ../venv/bin/python3 -c "import yaml; c=yaml.safe_load(open('system.yaml')); print(c.get('agents',{}).get('default',{}).get('repeat',1))"))
-	$(eval _JUDGE := $(shell ../venv/bin/python3 -c "import yaml; c=yaml.safe_load(open('system.yaml')); p=c.get('llm_pool',{}).get('models',{}); j=c.get('judge_panel',{}).get('judges',[''])[0]; print(p.get(j,{}).get('model','') if j else c.get('llm',{}).get('model',''))"))
 ifeq ($(SETUP_MODE),run)
 	@echo "==> SETUP_MODE=run: $(_REPEAT) repeat(s), agents: $(subst $(SPACE),$(COMMA) ,$(_AGENTS))"
 	@for scenario in $(SCENARIOS); do \
@@ -136,8 +135,7 @@ endif
 	@echo "==> Generating report..."
 	@../venv/bin/python3 $(SCRIPTS_DIR)/generate-report-agentic.py \
 	  $(EVAL_DIR) \
-	  --output results/results_$(DATETIME).md \
-	  $(if $(_JUDGE),--judge $(_JUDGE))
+	  --output results/results_$(DATETIME).md
 	@echo "==> Results: results/results_$(DATETIME).md"
 endif
 

--- a/agentic/results/example.md
+++ b/agentic/results/example.md
@@ -59,7 +59,7 @@ Average duration across all repeats of a scenario per agent.
 
 ## Cost
 
-Average token usage across all repeats of a scenario per agent. ** Note: lightspeed-eval does not expose this data yet; values will appear once it does. **
+Total token usage for each scenario across all repeats per agent; the Average row shows average usage per evaluation. **Note: lightspeed-eval does not expose this data yet; values will appear once it does.**
 
 | Scenario | claude-opus-4-6 | gemini-2.5-pro | gpt-5.4 |
 |---|---|---|---|

--- a/agentic/results/example.md
+++ b/agentic/results/example.md
@@ -15,22 +15,22 @@ Passed repeats / total repeats. Score: 0-1.00 (1.00 = perfect, 0.75 = minimum to
 
 | Scenario | claude-opus-4-6 | gemini-2.5-pro | gpt-5.4 |
 |---|---|---|---|
-| [cascading_failure](#cascading_failure) | [✅ 3/3](#claude-opus-4-6--cascading_failure) (0.98) | [ 2/3](#gemini-2.5-pro--cascading_failure) (0.64) | [✅ 3/3](#gpt-5.4--cascading_failure) (0.99) |
-| [crashlooping_pod](#crashlooping_pod) | [✅ 3/3](#claude-opus-4-6--crashlooping_pod) (0.99) | [✅ 3/3](#gemini-2.5-pro--crashlooping_pod) (1.00) | [✅ 3/3](#gpt-5.4--crashlooping_pod) (0.96) |
-| [diagnostic_trap](#diagnostic_trap) | [✅ 3/3](#claude-opus-4-6--diagnostic_trap) (0.98) | [✅ 3/3](#gemini-2.5-pro--diagnostic_trap) (0.99) | [ 2/3](#gpt-5.4--diagnostic_trap) (0.64) |
-| [empty_endpoints](#empty_endpoints) | [✅ 3/3](#claude-opus-4-6--empty_endpoints) (0.98) | [ 2/3](#gemini-2.5-pro--empty_endpoints) (0.65) | [✅ 3/3](#gpt-5.4--empty_endpoints) (0.98) |
-| [evicted_pod](#evicted_pod) | [✅ 3/3](#claude-opus-4-6--evicted_pod) (0.98) | [ 2/3](#gemini-2.5-pro--evicted_pod) (0.65) | [✅ 3/3](#gpt-5.4--evicted_pod) (0.97) |
-| [failed_job](#failed_job) | [❌ 0/3](#claude-opus-4-6--failed_job) (0.03) | [❌ 0/3](#gemini-2.5-pro--failed_job) (0.00) | [❌ 0/3](#gpt-5.4--failed_job) (0.00) |
-| [failing_api](#failing_api) | [ 2/3](#claude-opus-4-6--failing_api) (0.74) | [❌ 0/3](#gemini-2.5-pro--failing_api) (0.07) | [ 2/3](#gpt-5.4--failing_api) (0.70) |
-| [failing_route](#failing_route) | [✅ 3/3](#claude-opus-4-6--failing_route) (1.00) | [✅ 3/3](#gemini-2.5-pro--failing_route) (1.00) | [✅ 3/3](#gpt-5.4--failing_route) (1.00) |
-| [missing_configmap](#missing_configmap) | [ 2/3](#claude-opus-4-6--missing_configmap) (0.63) | [✅ 3/3](#gemini-2.5-pro--missing_configmap) (0.94) | [✅ 3/3](#gpt-5.4--missing_configmap) (0.98) |
-| [pending_pvc](#pending_pvc) | [ 2/3](#claude-opus-4-6--pending_pvc) (0.60) | [ 1/3](#gemini-2.5-pro--pending_pvc) (0.67) | [✅ 3/3](#gpt-5.4--pending_pvc) (0.93) |
-| [refused_service](#refused_service) | [✅ 3/3](#claude-opus-4-6--refused_service) (0.98) | [✅ 3/3](#gemini-2.5-pro--refused_service) (1.00) | [✅ 3/3](#gpt-5.4--refused_service) (1.00) |
-| [stuck_rollout](#stuck_rollout) | [ 2/3](#claude-opus-4-6--stuck_rollout) (0.66) | [✅ 3/3](#gemini-2.5-pro--stuck_rollout) (0.96) | [✅ 3/3](#gpt-5.4--stuck_rollout) (1.00) |
-| [stuck_rollout_alert](#stuck_rollout_alert) | [✅ 3/3](#claude-opus-4-6--stuck_rollout_alert) (0.98) | [ 2/3](#gemini-2.5-pro--stuck_rollout_alert) (0.63) | [✅ 3/3](#gpt-5.4--stuck_rollout_alert) (0.99) |
-| [timeout_connections](#timeout_connections) | [✅ 3/3](#claude-opus-4-6--timeout_connections) (0.98) | [✅ 3/3](#gemini-2.5-pro--timeout_connections) (0.92) | [ 2/3](#gpt-5.4--timeout_connections) (0.65) |
-| [unbalanced_replicas](#unbalanced_replicas) | [ 1/3](#claude-opus-4-6--unbalanced_replicas) (0.50) | [❌ 0/3](#gemini-2.5-pro--unbalanced_replicas) (0.23) | [ 2/3](#gpt-5.4--unbalanced_replicas) (0.75) |
-| [unready_pod](#unready_pod) | [✅ 3/3](#claude-opus-4-6--unready_pod) (0.83) | [✅ 3/3](#gemini-2.5-pro--unready_pod) (0.90) | [✅ 3/3](#gpt-5.4--unready_pod) (0.92) |
+| [cascading_failure](#cascading_failure) | [✅ 3/3](#claude-opus-4-6--cascading_failure) (0.98) | [ 2/3](#gemini-2.5-pro--cascading_failure) (0.64) | **[✅ 3/3](#gpt-5.4--cascading_failure) (0.99)** |
+| [crashlooping_pod](#crashlooping_pod) | [✅ 3/3](#claude-opus-4-6--crashlooping_pod) (0.99) | **[✅ 3/3](#gemini-2.5-pro--crashlooping_pod) (1.00)** | [✅ 3/3](#gpt-5.4--crashlooping_pod) (0.96) |
+| [diagnostic_trap](#diagnostic_trap) | [✅ 3/3](#claude-opus-4-6--diagnostic_trap) (0.98) | **[✅ 3/3](#gemini-2.5-pro--diagnostic_trap) (0.99)** | [ 2/3](#gpt-5.4--diagnostic_trap) (0.64) |
+| [empty_endpoints](#empty_endpoints) | **[✅ 3/3](#claude-opus-4-6--empty_endpoints) (0.98)** | [ 2/3](#gemini-2.5-pro--empty_endpoints) (0.65) | [✅ 3/3](#gpt-5.4--empty_endpoints) (0.98) |
+| [evicted_pod](#evicted_pod) | **[✅ 3/3](#claude-opus-4-6--evicted_pod) (0.98)** | [ 2/3](#gemini-2.5-pro--evicted_pod) (0.65) | [✅ 3/3](#gpt-5.4--evicted_pod) (0.97) |
+| [failed_job](#failed_job) | **[❌ 0/3](#claude-opus-4-6--failed_job) (0.03)** | [❌ 0/3](#gemini-2.5-pro--failed_job) (0.00) | [❌ 0/3](#gpt-5.4--failed_job) (0.00) |
+| [failing_api](#failing_api) | **[ 2/3](#claude-opus-4-6--failing_api) (0.74)** | [❌ 0/3](#gemini-2.5-pro--failing_api) (0.07) | [ 2/3](#gpt-5.4--failing_api) (0.70) |
+| [failing_route](#failing_route) | **[✅ 3/3](#claude-opus-4-6--failing_route) (1.00)** | **[✅ 3/3](#gemini-2.5-pro--failing_route) (1.00)** | **[✅ 3/3](#gpt-5.4--failing_route) (1.00)** |
+| [missing_configmap](#missing_configmap) | [ 2/3](#claude-opus-4-6--missing_configmap) (0.63) | [✅ 3/3](#gemini-2.5-pro--missing_configmap) (0.94) | **[✅ 3/3](#gpt-5.4--missing_configmap) (0.98)** |
+| [pending_pvc](#pending_pvc) | [ 2/3](#claude-opus-4-6--pending_pvc) (0.60) | [ 1/3](#gemini-2.5-pro--pending_pvc) (0.67) | **[✅ 3/3](#gpt-5.4--pending_pvc) (0.93)** |
+| [refused_service](#refused_service) | [✅ 3/3](#claude-opus-4-6--refused_service) (0.98) | **[✅ 3/3](#gemini-2.5-pro--refused_service) (1.00)** | **[✅ 3/3](#gpt-5.4--refused_service) (1.00)** |
+| [stuck_rollout](#stuck_rollout) | [ 2/3](#claude-opus-4-6--stuck_rollout) (0.66) | [✅ 3/3](#gemini-2.5-pro--stuck_rollout) (0.96) | **[✅ 3/3](#gpt-5.4--stuck_rollout) (1.00)** |
+| [stuck_rollout_alert](#stuck_rollout_alert) | [✅ 3/3](#claude-opus-4-6--stuck_rollout_alert) (0.98) | [ 2/3](#gemini-2.5-pro--stuck_rollout_alert) (0.63) | **[✅ 3/3](#gpt-5.4--stuck_rollout_alert) (0.99)** |
+| [timeout_connections](#timeout_connections) | **[✅ 3/3](#claude-opus-4-6--timeout_connections) (0.98)** | [✅ 3/3](#gemini-2.5-pro--timeout_connections) (0.92) | [ 2/3](#gpt-5.4--timeout_connections) (0.65) |
+| [unbalanced_replicas](#unbalanced_replicas) | [ 1/3](#claude-opus-4-6--unbalanced_replicas) (0.50) | [❌ 0/3](#gemini-2.5-pro--unbalanced_replicas) (0.23) | **[ 2/3](#gpt-5.4--unbalanced_replicas) (0.75)** |
+| [unready_pod](#unready_pod) | [✅ 3/3](#claude-opus-4-6--unready_pod) (0.83) | [✅ 3/3](#gemini-2.5-pro--unready_pod) (0.90) | **[✅ 3/3](#gpt-5.4--unready_pod) (0.92)** |
 | **Pass rate** | 81% (39/48) | 69% (33/48) | **85% (41/48)** |
 
 ## Time
@@ -59,7 +59,7 @@ Average duration across all repeats of a scenario per agent.
 
 ## Cost
 
-Average token usage across all repeats of a scenario per agent. Note: lightspeed-eval does not expose this data yet; values will appear once it does.
+Average token usage across all repeats of a scenario per agent. ** Note: lightspeed-eval does not expose this data yet; values will appear once it does. **
 
 | Scenario | claude-opus-4-6 | gemini-2.5-pro | gpt-5.4 |
 |---|---|---|---|

--- a/agentic/results/example.md
+++ b/agentic/results/example.md
@@ -9,7 +9,9 @@
 | Avg duration | 2m 2s | 51s | **33s** |
 | Avg tokens | 0 | 0 | 0 |
 
-## Performance
+## Correctness
+
+Passed repeats / total repeats. Score: 0-1.00 (1.00 = perfect, 0.75 = minimum to pass).
 
 | Scenario | claude-opus-4-6 | gemini-2.5-pro | gpt-5.4 |
 |---|---|---|---|
@@ -33,6 +35,8 @@
 
 ## Time
 
+Average duration across all repeats of a scenario per agent.
+
 | Scenario | claude-opus-4-6 | gemini-2.5-pro | gpt-5.4 |
 |---|---|---|---|
 | [cascading_failure](#cascading_failure) | [1m 54s](#claude-opus-4-6--cascading_failure) | [28s](#gemini-2.5-pro--cascading_failure) | **[24s](#gpt-5.4--cascading_failure)** |
@@ -54,6 +58,8 @@
 | **Average** | 2m 2s | 51s | **33s** |
 
 ## Cost
+
+Average token usage across all repeats of a scenario per agent. Note: lightspeed-eval does not expose this data yet; values will appear once it does.
 
 | Scenario | claude-opus-4-6 | gemini-2.5-pro | gpt-5.4 |
 |---|---|---|---|

--- a/agentic/system.yaml
+++ b/agentic/system.yaml
@@ -45,6 +45,7 @@ agents:
 storage:
   - type: file
     output_dir: ./eval_output
+    summary_config_sections: [llm_pool, judge_panel]
     enabled_outputs: [csv, json]
 
 environment:

--- a/requirements-tools.txt
+++ b/requirements-tools.txt
@@ -1,0 +1,2 @@
+shellcheck-py==0.11.0.1
+yamllint==1.38.0

--- a/scripts/generate-report-agentic.py
+++ b/scripts/generate-report-agentic.py
@@ -728,9 +728,10 @@ def generate_report(eval_dir: Path) -> str:
     # Tokens per scenario
     lines.append("## Cost")
     lines.append("")
-    lines.append("Average token usage across all repeats of a scenario per agent."
-                 " ** Note: lightspeed-eval does not expose this data yet;"
-                 " values will appear once it does. **")
+    lines.append("Total token usage for each scenario across all repeats per agent;"
+                 " the Average row shows average usage per evaluation."
+                 " **Note: lightspeed-eval does not expose this data yet;"
+                 " values will appear once it does.**")
     lines.append("")
     lines.append(generate_tokens_table(conversations, agent_names, agent_amended))
     lines.append("")

--- a/scripts/generate-report-agentic.py
+++ b/scripts/generate-report-agentic.py
@@ -10,6 +10,7 @@ Usage:
 
 EVAL_DIR is the eval session directory
 (e.g., eval_output/eval_20260829_210316/).
+The judge model is extracted from the summary JSON configuration.
 """
 
 import json
@@ -63,6 +64,24 @@ def load_run_summary(run_dir: Path) -> list[dict] | None:
             data = json.load(fh)
         results.extend(data.get("results", []))
     return results
+
+
+def extract_judge_model(eval_dir: Path, agent_names: list[str]) -> str:
+    """Extract the judge model name from the first available summary JSON."""
+    for agent in agent_names:
+        for rd in find_run_dirs(eval_dir, agent):
+            for f in sorted(rd.glob("*_summary.json")):
+                with open(f) as fh:
+                    data = json.load(fh)
+                config = data.get("configuration", {})
+                judges = config.get("judge_panel", {}).get("judges", [])
+                if not judges:
+                    continue
+                models = config.get("llm_pool", {}).get("models", {})
+                model = models.get(judges[0], {}).get("model", "")
+                if model:
+                    return model
+    return ""
 
 
 
@@ -236,6 +255,18 @@ def overall_score_cell(passed: int, total: int, bold: bool = False) -> str:
     return text
 
 
+def scenario_mean_score(agent_runs: list, conversation_id: str) -> float | None:
+    """Mean correctness score for one agent on one scenario across all runs."""
+    scores = []
+    for results in agent_runs:
+        if results is None:
+            continue
+        s = get_score(results, conversation_id, CORRECTNESS_METRIC)
+        if s is not None:
+            scores.append(s)
+    return sum(scores) / len(scores) if scores else None
+
+
 def mean_score(agent_runs: list, conversations: list[str]) -> float | None:
     """Mean correctness score across all runs and conversations."""
     scores = []
@@ -321,7 +352,7 @@ def bold_best(values: dict[str, str | None], best_val, cmp="max") -> dict[str, s
     for a, text in values.items():
         if text is None:
             result[a] = "N/A"
-        elif best_val is not None and text == best_val and len(values) > 1:
+        elif best_val is not None and text == best_val:
             result[a] = f"**{text}**"
         else:
             result[a] = text
@@ -348,7 +379,7 @@ def generate_overview_table(
             cells.append("N/A")
         else:
             text = f"{pcts[a]}%"
-            if pcts[a] == best_pct and len(agent_names) > 1:
+            if pcts[a] == best_pct:
                 text = f"**{text}**"
             cells.append(text)
     lines.append(f"| Pass rate | {' | '.join(cells)} |")
@@ -363,7 +394,7 @@ def generate_overview_table(
             cells.append("N/A")
         else:
             text = f"{s:.2f}"
-            if best_mean is not None and s == best_mean and len(agent_names) > 1:
+            if best_mean is not None and s == best_mean:
                 text = f"**{text}**"
             cells.append(text)
     lines.append(f"| Avg score | {' | '.join(cells)} |")
@@ -378,7 +409,7 @@ def generate_overview_table(
             cells.append("N/A")
         else:
             text = format_duration(d)
-            if best_dur is not None and d == best_dur and len(agent_names) > 1:
+            if best_dur is not None and d == best_dur:
                 text = f"**{text}**"
             cells.append(text)
     lines.append(f"| Avg duration | {' | '.join(cells)} |")
@@ -418,7 +449,7 @@ def generate_duration_table(
             else:
                 anchor = anchor_id(a, cid)
                 text = f"[{format_duration(d)}](#{anchor})"
-                if best is not None and d == best and len(agent_names) > 1:
+                if best is not None and d == best:
                     text = f"**{text}**"
                 cells.append(text)
         cid_anchor = cid.lower().replace(" ", "-")
@@ -434,7 +465,7 @@ def generate_duration_table(
             cells.append("N/A")
         else:
             text = format_duration(d)
-            if best_mean is not None and d == best_mean and len(agent_names) > 1:
+            if best_mean is not None and d == best_mean:
                 text = f"**{text}**"
             cells.append(text)
     lines.append(f"| **Average** | {' | '.join(cells)} |")
@@ -479,8 +510,15 @@ def generate_summary_table(
     lines = [header, separator]
     for cid in conversations:
         anchor = cid.lower().replace(" ", "-")
-        cells = " | ".join(score_cell(agent_runs[a], cid, a) for a in agent_names)
-        lines.append(f"| [{cid}](#{anchor}) | {cells} |")
+        avg_scores = {a: scenario_mean_score(agent_runs[a], cid) for a in agent_names}
+        best = max((s for s in avg_scores.values() if s is not None), default=None)
+        cells = []
+        for a in agent_names:
+            cell = score_cell(agent_runs[a], cid, a)
+            if best is not None and avg_scores[a] is not None and avg_scores[a] == best:
+                cell = f"**{cell}**"
+            cells.append(cell)
+        lines.append(f"| [{cid}](#{anchor}) | {' | '.join(cells)} |")
     scores = {a: overall_score(agent_runs[a], conversations) for a in agent_names}
     best_pct = max(
         (p / t if t > 0 else -1 for p, t in scores.values()),
@@ -609,7 +647,7 @@ def generate_scenario_details(
     return "\n".join(lines)
 
 
-def generate_report(eval_dir: Path, judge: str = "") -> str:
+def generate_report(eval_dir: Path) -> str:
     agent_names = discover_agents(eval_dir)
 
     # Load per-run data for each agent
@@ -644,6 +682,8 @@ def generate_report(eval_dir: Path, judge: str = "") -> str:
                     break
         if timestamp_str:
             break
+
+    judge = extract_judge_model(eval_dir, agent_names)
 
     # Build the report
     lines = ["# Evaluation Summary"]
@@ -689,8 +729,8 @@ def generate_report(eval_dir: Path, judge: str = "") -> str:
     lines.append("## Cost")
     lines.append("")
     lines.append("Average token usage across all repeats of a scenario per agent."
-                 " Note: lightspeed-eval does not expose this data yet;"
-                 " values will appear once it does.")
+                 " ** Note: lightspeed-eval does not expose this data yet;"
+                 " values will appear once it does. **")
     lines.append("")
     lines.append(generate_tokens_table(conversations, agent_names, agent_amended))
     lines.append("")
@@ -798,11 +838,6 @@ def main():
         "--output", "-o",
         help="Output file path (default: EVAL_DIR/results.md)",
     )
-    parser.add_argument(
-        "--judge", "-j",
-        default="",
-        help="Judge model name to display in the report header",
-    )
     args = parser.parse_args()
 
     eval_dir = Path(args.eval_dir)
@@ -810,7 +845,7 @@ def main():
         print(f"Error: {eval_dir} is not a directory", file=sys.stderr)
         sys.exit(1)
 
-    md = generate_report(eval_dir, judge=args.judge)
+    md = generate_report(eval_dir)
 
     output = Path(args.output) if args.output else eval_dir / "results.md"
     output.write_text(md)

--- a/scripts/generate-report-agentic.py
+++ b/scripts/generate-report-agentic.py
@@ -669,7 +669,10 @@ def generate_report(eval_dir: Path, judge: str = "") -> str:
     lines.append("")
 
     # Results per scenario
-    lines.append("## Performance")
+    lines.append("## Correctness")
+    lines.append("")
+    lines.append("Passed repeats / total repeats."
+                 " Score: 0-1.00 (1.00 = perfect, 0.75 = minimum to pass).")
     lines.append("")
     lines.append(generate_summary_table(conversations, agent_names, agent_runs))
     lines.append("")
@@ -677,11 +680,17 @@ def generate_report(eval_dir: Path, judge: str = "") -> str:
     # Duration per scenario
     lines.append("## Time")
     lines.append("")
+    lines.append("Average duration across all repeats of a scenario per agent.")
+    lines.append("")
     lines.append(generate_duration_table(conversations, agent_names, agent_amended))
     lines.append("")
 
     # Tokens per scenario
     lines.append("## Cost")
+    lines.append("")
+    lines.append("Average token usage across all repeats of a scenario per agent."
+                 " Note: lightspeed-eval does not expose this data yet;"
+                 " values will appear once it does.")
     lines.append("")
     lines.append(generate_tokens_table(conversations, agent_names, agent_amended))
     lines.append("")
@@ -726,7 +735,7 @@ def _colorize(passed: int, total: int) -> str:
     return text
 
 
-def print_performance_table(
+def print_correctness_table(
     conversations: list[str],
     agent_names: list[str],
     agent_runs: dict[str, list],
@@ -813,7 +822,7 @@ def main():
     conversations = collect_conversations(agent_runs)
 
     print()
-    print_performance_table(conversations, agent_names, agent_runs)
+    print_correctness_table(conversations, agent_names, agent_runs)
     print()
     print(f"Report written to {output}")
 

--- a/scripts/tests/test_generate_report_agentic.py
+++ b/scripts/tests/test_generate_report_agentic.py
@@ -349,12 +349,17 @@ class TestGenerateReport:
         assert report.count("**✅ 100% (1/1)**") == 2
 
     def test_judge_in_header(self, tmp_path):
+        config = {
+            "llm_pool": {"models": {"judge": {"model": "gpt-5.4"}}},
+            "judge_panel": {"judges": ["judge"]},
+        }
         _write_run(
             tmp_path / "gpt-5.4" / "run_1",
             results=[_make_result("s1")],
             amended_entries=[{"conversation_id": "s1"}],
+            config=config,
         )
-        report = mod.generate_report(tmp_path, judge="gpt-5.4")
+        report = mod.generate_report(tmp_path)
         assert "Judge: gpt-5.4" in report
 
     def test_no_judge_by_default(self, tmp_path):

--- a/scripts/tests/test_generate_report_agentic.py
+++ b/scripts/tests/test_generate_report_agentic.py
@@ -384,7 +384,7 @@ class TestGenerateReport:
         assert "| **Average** | 100 |" in report
 
 
-class TestPrintPerformanceTable:
+class TestPrintCorrectnessTable:
     def test_basic_output(self, tmp_path, capsys):
         for agent, result in [("agentA", "PASS"), ("agentB", "FAIL")]:
             _write_run(
@@ -397,7 +397,7 @@ class TestPrintPerformanceTable:
             for a in ["agentA", "agentB"]
         }
         conversations = mod.collect_conversations(agent_runs)
-        mod.print_performance_table(conversations, ["agentA", "agentB"], agent_runs)
+        mod.print_correctness_table(conversations, ["agentA", "agentB"], agent_runs)
         out = capsys.readouterr().out
         assert "s1" in out
         assert "1/1" in out
@@ -420,6 +420,6 @@ class TestPrintPerformanceTable:
             mod.load_run_summary(tmp_path / "a" / "run_2"),
         ]}
         conversations = mod.collect_conversations(agent_runs)
-        mod.print_performance_table(conversations, ["a"], agent_runs)
+        mod.print_correctness_table(conversations, ["a"], agent_runs)
         out = capsys.readouterr().out
         assert "1/2" in out


### PR DESCRIPTION
- Rename "Performance" section to "Correctness" to match the underlying metric and avoid ambiguity with speed
- Add descriptions under Correctness, Time, and Cost sections explaining what the numbers represent
- Standardize terminology on "repeats" across all descriptions
- Extract the judge model from the summary JSON configuration section instead of requiring a --judge CLI flag
- Bold the best correctness score per scenario row, matching the pattern in Time and Cost tables
- Bold values even with a single agent (winner by default)