### PR TITLE
fix: resolve CI failures in OLS eval suites

### DIFF
--- a/kiali-ossm/Makefile
+++ b/kiali-ossm/Makefile
@@ -47,4 +47,4 @@ check_mesh_status_no_kiali-eval:
 	@bash $(SCRIPTS_DIR)/run-evals.sh \
 	  --system-config $(SYSTEM_CONFIG) --evals $(EVALS) \
 	  --results-dir $(RESULTS_DIR) --ols-url $(OLS_URL) \
-	  --tag check_mesh_status_no_kiali
+	  --tags check_mesh_status_no_kiali

--- a/kiali-ossm/build/ossm.mk
+++ b/kiali-ossm/build/ossm.mk
@@ -222,8 +222,13 @@ validate-bookinfo-kiali-health: ## Wait until Bookinfo workload is Healthy accor
 	fi; \
 	kiali_token="$$( $$client whoami -t 2>/dev/null || true )"; \
 	if [ -z "$$kiali_token" ]; then \
-	  echo "Cannot obtain token from $$client whoami -t (required for Kiali API auth)."; \
-	  exit 1; \
+	  echo "==> No OAuth token found, creating service account token..."; \
+	  $$client adm policy add-cluster-role-to-user cluster-reader -z default -n "$$cpns" >/dev/null 2>&1 || true; \
+	  kiali_token="$$( $$client create token default -n "$$cpns" --duration=1h 2>/dev/null || true )"; \
+	  if [ -z "$$kiali_token" ]; then \
+	    echo "Cannot obtain token from $$client whoami -t or service account (required for Kiali API auth)."; \
+	    exit 1; \
+	  fi; \
 	fi; \
 	api_url="https://$$kiali_host/api/clusters/workloads?health=true&istioResources=true&namespaces=$$ns&clusterName=$$cluster_name"; \
 	echo "==> Kiali route: https://$$kiali_host"; \

--- a/kubevirt/Makefile
+++ b/kubevirt/Makefile
@@ -14,26 +14,26 @@ include ../scripts/eval.mk
 .PHONY: evals
 evals:
 	@if bash build/require-kvm.sh --check 2>/dev/null; then \
-	  tags="$(foreach s,$(SCENARIOS),--tag $(s))"; \
+	  tags="$(SCENARIOS)"; \
 	else \
 	  echo "WARNING: No KVM devices on worker nodes. Skipping: $(KVM_SCENARIOS)"; \
-	  tags="$(foreach s,$(filter-out $(KVM_SCENARIOS),$(SCENARIOS)),--tag $(s))"; \
+	  tags="$(filter-out $(KVM_SCENARIOS),$(SCENARIOS))"; \
 	fi; \
 	if [ -z "$$tags" ]; then echo "No scenarios to evaluate."; exit 0; fi; \
 	bash $(SCRIPTS_DIR)/run-evals.sh \
 	  --system-config $(SYSTEM_CONFIG) --evals $(EVALS) \
 	  --results-dir $(RESULTS_DIR) --ols-url $(OLS_URL) \
 	  $(_PROVIDER_FLAGS) \
-	  $$tags
+	  --tags $$tags
 
 # KVM-aware evals-all-providers: skip KVM scenarios when no devices are available
 .PHONY: evals-all-providers
 evals-all-providers:
 	@if bash build/require-kvm.sh --check 2>/dev/null; then \
-	  tags="$(foreach s,$(SCENARIOS),--tag $(s))"; \
+	  tags="$(SCENARIOS)"; \
 	else \
 	  echo "WARNING: No KVM devices on worker nodes. Skipping: $(KVM_SCENARIOS)"; \
-	  tags="$(foreach s,$(filter-out $(KVM_SCENARIOS),$(SCENARIOS)),--tag $(s))"; \
+	  tags="$(filter-out $(KVM_SCENARIOS),$(SCENARIOS))"; \
 	fi; \
 	if [ -z "$$tags" ]; then echo "No scenarios to evaluate."; exit 0; fi; \
 	providers=$$(oc get olsconfig cluster -o jsonpath='{range .spec.llm.providers[*]}{.name},{.models[0].name}{"\n"}{end}'); \
@@ -49,7 +49,7 @@ evals-all-providers:
 	    --system-config $(SYSTEM_CONFIG) --evals $(EVALS) \
 	    --results-dir $(RESULTS_DIR)/$$provider --ols-url $(OLS_URL) \
 	    --provider $$provider --model $$model \
-	    $$tags; \
+	    --tags $$tags; \
 	done
 
 # Install CNV operator (idempotent — skips if already present)

--- a/netobserv/Makefile
+++ b/netobserv/Makefile
@@ -17,10 +17,12 @@ include ../scripts/eval.mk
 # Suite infrastructure (NetObserv operator)
 include build/netobserv.mk
 
-# Setup: shared infra + NetObserv operator + FlowCollector
+# Setup: NetObserv operator first (MCP netobserv toolset requires operator to be installed)
+# then shared infra (MCP with netobserv toolset) + FlowCollector
 .PHONY: setup
-setup: _setup-shared
-	$(MAKE) setup-netobserv-openshift
+setup: netobserv-install-operator
+	$(MAKE) _setup-shared
+	$(MAKE) netobserv-install-flowcollector
 
 # Cleanup: NetObserv operator + shared infra
 .PHONY: cleanup

--- a/scripts/ci-ols-agentic-evals.sh
+++ b/scripts/ci-ols-agentic-evals.sh
@@ -7,6 +7,7 @@
 #   GOOGLE_APPLICATION_CREDENTIALS  - Path to GCP service account JSON (Vertex AI)
 #   VERTEX_PROJECT_ID               - GCP project ID (falls back to credentials JSON)
 #   VERTEX_REGION                   - GCP region (default: us-east1)
+#   AGENT_NAME                      - Agent to use: openai (OpenAI), gemini (Google), opus (Anthropic)
 #   SUITES                          - Space-separated scenario list (default: all)
 #   ARTIFACT_DIR                    - CI artifact directory (default: /tmp/artifacts)
 
@@ -28,6 +29,7 @@ function install_operator() {
 }
 
 function setup_openai() {
+    echo "==> Setting up OpenAI provider..."
     : "${OPENAI_API_KEY:?OPENAI_API_KEY must be set}"
 
     oc create secret generic llm-creds-openai -n "$NAMESPACE" \
@@ -64,6 +66,7 @@ EOF
 }
 
 function setup_vertex() {
+    echo "==> Setting up Vertex AI providers..."
     : "${GOOGLE_APPLICATION_CREDENTIALS:?GOOGLE_APPLICATION_CREDENTIALS must be set}"
 
     if [[ ! -f "$GOOGLE_APPLICATION_CREDENTIALS" ]]; then
@@ -142,8 +145,30 @@ EOF
 }
 
 function run_evals() {
-    echo "==> Running agentic evaluations..."
+    echo "==> Running agentic evaluations for agent: ${AGENT_NAME}"
     cd "$AGENTIC_DIR"
+
+    # Override system.yaml to use only the specified agent
+    local AGENT_MODEL
+    case "$AGENT_NAME" in
+        openai) AGENT_MODEL="gpt-5.4" ;;
+        gemini) AGENT_MODEL="gemini-2.5-pro" ;;
+        opus) AGENT_MODEL="claude-opus-4-6" ;;
+    esac
+
+    # Backup original system.yaml
+    cp system.yaml system.yaml.backup
+
+    # Update system.yaml to use only the specified agent
+    python3 -c "
+import yaml
+with open('system.yaml', 'r') as f:
+    config = yaml.safe_load(f)
+config['agents']['default']['agent'] = ['${AGENT_MODEL}']
+with open('system.yaml', 'w') as f:
+    yaml.safe_dump(config, f, default_flow_style=False)
+"
+
     make setup
 
     if [[ -n "${SUITES:-}" ]]; then
@@ -151,29 +176,59 @@ function run_evals() {
     else
         make evals
     fi
+
+    # Restore original system.yaml
+    mv system.yaml.backup system.yaml
 }
 
 function collect_results() {
     echo "==> Collecting results to ${ARTIFACT_DIR}..."
-    mkdir -p "$ARTIFACT_DIR/agentic-results"
-    cp -r "$AGENTIC_DIR/results/"* "$ARTIFACT_DIR/agentic-results/" 2>/dev/null || true
+    mkdir -p "$ARTIFACT_DIR/agentic-${AGENT_NAME}"
+    cp -r "$AGENTIC_DIR/results/"* "$ARTIFACT_DIR/agentic-${AGENT_NAME}/" 2>/dev/null || true
 }
 
 function cleanup() {
     echo "==> Cleaning up..."
     cd "$AGENTIC_DIR"
+    # Restore system.yaml if backup exists (ensures clean workspace on all exit paths)
+    if [[ -f system.yaml.backup ]]; then
+        mv system.yaml.backup system.yaml
+    fi
     make cleanup || true
 }
 
 trap cleanup EXIT
 
+# Default to 'openai' if not specified
+AGENT_NAME="${AGENT_NAME:-openai}"
+
+echo "==> Running agentic evaluations for agent: ${AGENT_NAME}"
+
 install_operator
 
 echo "==> Configuring LLM providers..."
-setup_openai
-setup_vertex
+case "$AGENT_NAME" in
+    openai)
+        # OpenAI agent - always needs OpenAI for both agent and judge
+        setup_openai
+        ;;
+    gemini)
+        # Google Gemini agent - needs Vertex for agent, OpenAI for judge
+        setup_openai  # For judge LLM
+        setup_vertex
+        ;;
+    opus)
+        # Anthropic Opus agent - needs Vertex for agent, OpenAI for judge
+        setup_openai  # For judge LLM
+        setup_vertex
+        ;;
+    *)
+        echo "ERROR: Unknown AGENT_NAME=${AGENT_NAME}. Valid values: openai, gemini, opus"
+        exit 1
+        ;;
+esac
 
 run_evals
 collect_results
 
-echo "==> Agentic evaluation complete."
+echo "==> Agentic evaluation complete for agent: ${AGENT_NAME}"


### PR DESCRIPTION
- Fix argument mismatch: change --tag to --tags in kubevirt and kiali-ossm Makefiles to align with Aug 28 refactor (commit f4ba27f) that switched run-evals.sh from --tag (singular, repeated) to --tags (plural, once)

- Add service account token fallback in kiali-ossm health validation for CI environments where oc whoami -t returns empty (certificate-based auth)

- Fix netobserv setup order: install NetObserv operator before MCP setup since MCP netobserv toolset requires operator CRDs to exist during startup

- Add AGENT_NAME environment variable to ci-ols-agentic-evals.sh to enable separate CI runs per LLM provider (openai, gemini, opus) with dedicated result artifacts per agent