### PR TITLE
fix: resolve runtime errors in CI eval scripts

### DIFF
--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -64,6 +64,7 @@ OLS_CLASSIC_SCENARIOS := \
 	unready_pod_alert
 SCENARIO ?=
 TAG ?=
+AGENT ?=
 SETUP_MODE ?= run
 
 COMMA := ,
@@ -125,7 +126,11 @@ else
 	done
 	$(eval DATETIME := $(shell date +%Y%m%d_%H%M%S))
 	$(eval EVAL_DIR := results/logs/$(DATETIME))
+ifdef AGENT
+	$(eval _AGENTS := $(strip $(subst $(COMMA), ,$(AGENT))))
+else
 	$(eval _AGENTS := $(shell ../venv/bin/python3 -c "import yaml; c=yaml.safe_load(open('system.yaml')); print(' '.join(c.get('agents',{}).get('default',{}).get('agent',[])))"))
+endif
 	$(eval _REPEAT := $(shell ../venv/bin/python3 -c "import yaml; c=yaml.safe_load(open('system.yaml')); print(c.get('agents',{}).get('default',{}).get('repeat',1))"))
 ifeq ($(SETUP_MODE),run)
 	@echo "==> SETUP_MODE=run: $(_REPEAT) repeat(s), agents: $(subst $(SPACE),$(COMMA) ,$(_AGENTS))"
@@ -276,10 +281,12 @@ help:
 	@echo "  TAG=...                   Filter by tag (default: none)"
 	@echo ""
 	@echo "Options (eval):"
+	@echo "  AGENT=...                 Comma-separated agent model(s) to run (default: all from system.yaml)"
 	@echo "  SETUP_MODE=run|scenario   Setup/cleanup lifecycle (default: run)"
 	@echo "    run:      per (scenario, agent, repeat) - for mutating agents"
 	@echo "    scenario: per scenario - for read-only agents, parallel OK"
-	@echo "  Agents and repeat count are read from system.yaml."
+	@echo "  Agents and repeat count are read from system.yaml.(agents can be overridden with AGENT=)."
+	@echo "  Example: make eval AGENT=gpt-5.4,gemini-2.5-pro SCENARIO=blocked_deployment"
 	@echo ""
 	@echo "Options (eval-ols-classic):"
 	@echo "  Agents and repeat count are read from system-ols-classic.yaml."

--- a/scripts/ci-ols-agentic-evals.sh
+++ b/scripts/ci-ols-agentic-evals.sh
@@ -8,7 +8,7 @@
 #   VERTEX_PROJECT_ID               - GCP project ID (falls back to credentials JSON)
 #   VERTEX_REGION                   - GCP region (default: us-east1)
 #   AGENT_NAME                      - Agent to use: openai (OpenAI), gemini (Google), opus (Anthropic)
-#   SUITES                          - Space-separated scenario list (default: all)
+#   SCENARIOS                       - Space-separated scenario list (default: all)
 #   ARTIFACT_DIR                    - CI artifact directory (default: /tmp/artifacts)
 
 set -euo pipefail
@@ -159,22 +159,40 @@ function run_evals() {
     # Backup original system.yaml
     cp system.yaml system.yaml.backup
 
-    # Update system.yaml to use only the specified agent
-    python3 -c "
-import yaml
-with open('system.yaml', 'r') as f:
-    config = yaml.safe_load(f)
-config['agents']['default']['agent'] = ['${AGENT_MODEL}']
-with open('system.yaml', 'w') as f:
-    yaml.safe_dump(config, f, default_flow_style=False)
-"
+    # Update system.yaml to use only the specified agent (no Python dependencies)
+    sed -i.tmp "s/agent: \[gpt-5.4, gemini-2.5-pro, claude-opus-4-6\]/agent: [${AGENT_MODEL}]/" system.yaml
+    rm -f system.yaml.tmp
 
+    # Validate that system.yaml now contains exactly the expected agent
+    if ! grep -q "agent: \[${AGENT_MODEL}\]" system.yaml; then
+        echo "ERROR: Failed to configure system.yaml with agent: [${AGENT_MODEL}]"
+        echo "Expected pattern not found after sed replacement."
+        echo "Current agent configuration:"
+        grep "agent: \[" system.yaml || echo "  (no agent: [...] line found)"
+        mv system.yaml.backup system.yaml
+        exit 1
+    fi
+
+    # Verify no multi-agent configuration remains
+    if grep -q "agent: \[.*,.*\]" system.yaml; then
+        echo "ERROR: system.yaml still contains multi-agent configuration after replacement"
+        echo "Current agent configuration:"
+        grep "agent: \[" system.yaml
+        mv system.yaml.backup system.yaml
+        exit 1
+    fi
+
+    echo "==> Verified system.yaml configured with single agent: [${AGENT_MODEL}]"
+
+    # Run setup after system.yaml is modified
     make setup
 
-    if [[ -n "${SUITES:-}" ]]; then
-        make evals SUITES="$SUITES"
+    if [[ -n "${SCENARIOS:-}" ]]; then
+        # Convert space-separated SCENARIOS to comma-separated SCENARIO for Makefile
+        local SCENARIO_LIST="${SCENARIOS// /,}"
+        make eval SCENARIO="$SCENARIO_LIST"
     else
-        make evals
+        make eval
     fi
 
     # Restore original system.yaml

--- a/scripts/ci-ols-agentic-evals.sh
+++ b/scripts/ci-ols-agentic-evals.sh
@@ -7,7 +7,7 @@
 #   GOOGLE_APPLICATION_CREDENTIALS  - Path to GCP service account JSON (Vertex AI)
 #   VERTEX_PROJECT_ID               - GCP project ID (falls back to credentials JSON)
 #   VERTEX_REGION                   - GCP region (default: us-east1)
-#   AGENT_NAME                      - Agent to use: openai (OpenAI), gemini (Google), opus (Anthropic)
+#   AGENT                           - Agent model to use: gpt-5.4, gemini-2.5-pro, claude-opus-4-6
 #   SCENARIOS                       - Space-separated scenario list (default: all)
 #   ARTIFACT_DIR                    - CI artifact directory (default: /tmp/artifacts)
 
@@ -28,15 +28,22 @@ function install_operator() {
     echo "==> Operator installed."
 }
 
-function setup_openai() {
-    echo "==> Setting up OpenAI provider..."
+function setup_openai_secret() {
+    echo "==> Setting up OpenAI secret for judge LLM..."
     : "${OPENAI_API_KEY:?OPENAI_API_KEY must be set}"
 
     oc create secret generic llm-creds-openai -n "$NAMESPACE" \
         --from-literal=OPENAI_API_KEY="$OPENAI_API_KEY" \
         --dry-run=client -o yaml | oc apply -f -
 
-    oc apply -f - <<'EOF'
+    echo "    OpenAI secret configured."
+}
+
+function setup_openai_agent() {
+    local AGENT_MODEL="$1"
+    echo "==> Setting up OpenAI agent with model: ${AGENT_MODEL}..."
+
+    oc apply -f - <<EOF
 apiVersion: agentic.openshift.io/v1alpha1
 kind: LLMProvider
 metadata:
@@ -56,17 +63,18 @@ metadata:
 spec:
   llmProvider:
     name: openai
-  model: "gpt-5.4"
+  model: "${AGENT_MODEL}"
   timeouts:
     analysisSeconds: 600
     executionSeconds: 600
     verificationSeconds: 600
 EOF
-    echo "    OpenAI provider configured."
+    echo "    OpenAI agent configured with model: ${AGENT_MODEL}"
 }
 
 function setup_vertex() {
-    echo "==> Setting up Vertex AI providers..."
+    local AGENT_MODEL="$1"
+    echo "==> Setting up Vertex AI provider for ${AGENT_MODEL}..."
     : "${GOOGLE_APPLICATION_CREDENTIALS:?GOOGLE_APPLICATION_CREDENTIALS must be set}"
 
     if [[ ! -f "$GOOGLE_APPLICATION_CREDENTIALS" ]]; then
@@ -78,170 +86,121 @@ function setup_vertex() {
         VERTEX_PROJECT_ID=$(python3 -c "import json; print(json.load(open('$GOOGLE_APPLICATION_CREDENTIALS'))['project_id'])")
         echo "    Extracted project ID from credentials: $VERTEX_PROJECT_ID"
     fi
-    VERTEX_REGION="${VERTEX_REGION:-us-east1}"
 
     oc create secret generic llm-creds-vertex -n "$NAMESPACE" \
         --from-file=GOOGLE_APPLICATION_CREDENTIALS="$GOOGLE_APPLICATION_CREDENTIALS" \
         --dry-run=client -o yaml | oc apply -f -
 
+    # Determine provider type and agent name based on model
+    case "$AGENT_MODEL" in
+        claude-opus-4-6)
+            VERTEX_REGION="${VERTEX_REGION:-us-east1}"
+            PROVIDER_NAME="vertex-anthropic"
+            MODEL_PROVIDER="Anthropic"
+            AGENT_NAME="opus"
+            ;;
+        gemini-2.5-pro)
+            VERTEX_REGION="global"
+            PROVIDER_NAME="vertex-google"
+            MODEL_PROVIDER="Google"
+            AGENT_NAME="gemini"
+            ;;
+        *)
+            echo "ERROR: Unknown Vertex model: ${AGENT_MODEL}"
+            exit 1
+            ;;
+    esac
+
     oc apply -f - <<EOF
 apiVersion: agentic.openshift.io/v1alpha1
 kind: LLMProvider
 metadata:
-  name: vertex-anthropic
+  name: ${PROVIDER_NAME}
   namespace: $NAMESPACE
 spec:
   type: GoogleCloudVertex
   googleCloudVertex:
     projectID: $VERTEX_PROJECT_ID
     region: $VERTEX_REGION
-    modelProvider: Anthropic
+    modelProvider: ${MODEL_PROVIDER}
     credentialsSecret:
       name: llm-creds-vertex
 ---
 apiVersion: agentic.openshift.io/v1alpha1
 kind: Agent
 metadata:
-  name: opus
+  name: ${AGENT_NAME}
   namespace: $NAMESPACE
 spec:
   llmProvider:
-    name: vertex-anthropic
-  model: "claude-opus-4-6"
-  timeouts:
-    analysisSeconds: 300
-    executionSeconds: 300
-    verificationSeconds: 300
----
-apiVersion: agentic.openshift.io/v1alpha1
-kind: LLMProvider
-metadata:
-  name: vertex-google
-  namespace: $NAMESPACE
-spec:
-  type: GoogleCloudVertex
-  googleCloudVertex:
-    projectID: $VERTEX_PROJECT_ID
-    region: global
-    modelProvider: Google
-    credentialsSecret:
-      name: llm-creds-vertex
----
-apiVersion: agentic.openshift.io/v1alpha1
-kind: Agent
-metadata:
-  name: gemini
-  namespace: $NAMESPACE
-spec:
-  llmProvider:
-    name: vertex-google
-  model: "gemini-2.5-pro"
+    name: ${PROVIDER_NAME}
+  model: "${AGENT_MODEL}"
   timeouts:
     analysisSeconds: 300
     executionSeconds: 300
     verificationSeconds: 300
 EOF
-    echo "    Vertex AI providers configured (Anthropic + Gemini)."
+    echo "    Vertex AI provider configured: ${MODEL_PROVIDER} with model ${AGENT_MODEL}"
 }
 
 function run_evals() {
-    echo "==> Running agentic evaluations for agent: ${AGENT_NAME}"
+    echo "==> Running agentic evaluations for agent: ${AGENT}"
     cd "$AGENTIC_DIR"
 
-    # Override system.yaml to use only the specified agent
-    local AGENT_MODEL
-    case "$AGENT_NAME" in
-        openai) AGENT_MODEL="gpt-5.4" ;;
-        gemini) AGENT_MODEL="gemini-2.5-pro" ;;
-        opus) AGENT_MODEL="claude-opus-4-6" ;;
-    esac
-
-    # Backup original system.yaml
-    cp system.yaml system.yaml.backup
-
-    # Update system.yaml to use only the specified agent (no Python dependencies)
-    sed -i.tmp "s/agent: \[gpt-5.4, gemini-2.5-pro, claude-opus-4-6\]/agent: [${AGENT_MODEL}]/" system.yaml
-    rm -f system.yaml.tmp
-
-    # Validate that system.yaml now contains exactly the expected agent
-    if ! grep -q "agent: \[${AGENT_MODEL}\]" system.yaml; then
-        echo "ERROR: Failed to configure system.yaml with agent: [${AGENT_MODEL}]"
-        echo "Expected pattern not found after sed replacement."
-        echo "Current agent configuration:"
-        grep "agent: \[" system.yaml || echo "  (no agent: [...] line found)"
-        mv system.yaml.backup system.yaml
-        exit 1
-    fi
-
-    # Verify no multi-agent configuration remains
-    if grep -q "agent: \[.*,.*\]" system.yaml; then
-        echo "ERROR: system.yaml still contains multi-agent configuration after replacement"
-        echo "Current agent configuration:"
-        grep "agent: \[" system.yaml
-        mv system.yaml.backup system.yaml
-        exit 1
-    fi
-
-    echo "==> Verified system.yaml configured with single agent: [${AGENT_MODEL}]"
-
-    # Run setup after system.yaml is modified
+    # Run setup (system.yaml used as-is)
     make setup
 
+    # Run evals with AGENT variable
+    local MAKE_ARGS="AGENT=${AGENT}"
     if [[ -n "${SCENARIOS:-}" ]]; then
         # Convert space-separated SCENARIOS to comma-separated SCENARIO for Makefile
         local SCENARIO_LIST="${SCENARIOS// /,}"
-        make eval SCENARIO="$SCENARIO_LIST"
-    else
-        make eval
+        MAKE_ARGS+=" SCENARIO=${SCENARIO_LIST}"
     fi
 
-    # Restore original system.yaml
-    mv system.yaml.backup system.yaml
+    make eval $MAKE_ARGS
 }
 
 function collect_results() {
     echo "==> Collecting results to ${ARTIFACT_DIR}..."
-    mkdir -p "$ARTIFACT_DIR/agentic-${AGENT_NAME}"
-    cp -r "$AGENTIC_DIR/results/"* "$ARTIFACT_DIR/agentic-${AGENT_NAME}/" 2>/dev/null || true
+    mkdir -p "$ARTIFACT_DIR/agentic-${AGENT}"
+    cp -r "$AGENTIC_DIR/results/"* "$ARTIFACT_DIR/agentic-${AGENT}/" 2>/dev/null || true
 }
 
 function cleanup() {
     echo "==> Cleaning up..."
     cd "$AGENTIC_DIR"
-    # Restore system.yaml if backup exists (ensures clean workspace on all exit paths)
-    if [[ -f system.yaml.backup ]]; then
-        mv system.yaml.backup system.yaml
-    fi
     make cleanup || true
 }
 
 trap cleanup EXIT
 
-# Default to 'openai' if not specified
-AGENT_NAME="${AGENT_NAME:-openai}"
+# Default to gpt-5.4 if not specified
+AGENT="${AGENT:-gpt-5.4}"
 
-echo "==> Running agentic evaluations for agent: ${AGENT_NAME}"
+echo "==> Running agentic evaluations for agent: ${AGENT}"
 
 install_operator
 
 echo "==> Configuring LLM providers..."
-case "$AGENT_NAME" in
-    openai)
-        # OpenAI agent - always needs OpenAI for both agent and judge
-        setup_openai
+case "$AGENT" in
+    gpt-5.4)
+        # OpenAI agent - needs secret for both agent and judge
+        setup_openai_secret
+        setup_openai_agent "$AGENT"
         ;;
-    gemini)
-        # Google Gemini agent - needs Vertex for agent, OpenAI for judge
-        setup_openai  # For judge LLM
-        setup_vertex
+    gemini-2.5-pro)
+        # Google Gemini agent - needs Vertex for agent, OpenAI secret for judge
+        setup_openai_secret  # For judge LLM only (no Agent CR needed)
+        setup_vertex "$AGENT"
         ;;
-    opus)
-        # Anthropic Opus agent - needs Vertex for agent, OpenAI for judge
-        setup_openai  # For judge LLM
-        setup_vertex
+    claude-opus-4-6)
+        # Anthropic Opus agent - needs Vertex for agent, OpenAI secret for judge
+        setup_openai_secret  # For judge LLM only (no Agent CR needed)
+        setup_vertex "$AGENT"
         ;;
     *)
-        echo "ERROR: Unknown AGENT_NAME=${AGENT_NAME}. Valid values: openai, gemini, opus"
+        echo "ERROR: Unknown AGENT=${AGENT}. Valid values: gpt-5.4, gemini-2.5-pro, claude-opus-4-6"
         exit 1
         ;;
 esac
@@ -249,4 +208,4 @@ esac
 run_evals
 collect_results
 
-echo "==> Agentic evaluation complete for agent: ${AGENT_NAME}"
+echo "==> Agentic evaluation complete for agent: ${AGENT}"

--- a/scripts/generate-report-agentic.py
+++ b/scripts/generate-report-agentic.py
@@ -110,12 +110,27 @@ def load_amended_entries(run_dir: Path) -> list[dict]:
                 continue
             turn = turns[0]
             duration = None
-            agentic_run_results = turn.get("openshift_agentic_run_results") or {}
-            analysis_results = agentic_run_results.get("analysis", [])
-            if analysis_results:
-                conditions = analysis_results[0].get("conditions", [])
-                started = next((c["lastTransitionTime"] for c in conditions if c["type"] == "Started"), None)
-                completed = next((c["lastTransitionTime"] for c in conditions if c["type"] == "Completed"), None)
+            run_results = turn.get("openshift_agentic_run_results")
+            if not isinstance(run_results, dict):
+                run_results = None
+            analysis_results = run_results.get("analysis", []) if run_results else []
+            if isinstance(analysis_results, list) and analysis_results and isinstance(analysis_results[0], dict):
+                # Normalize conditions to empty list if null or not a list
+                conditions = analysis_results[0].get("conditions")
+                if not isinstance(conditions, list):
+                    conditions = []
+
+                # Validate each condition is a dict with required fields before accessing
+                started = next(
+                    (c.get("lastTransitionTime") for c in conditions
+                     if isinstance(c, dict) and c.get("type") == "Started"),
+                    None
+                )
+                completed = next(
+                    (c.get("lastTransitionTime") for c in conditions
+                     if isinstance(c, dict) and c.get("type") == "Completed"),
+                    None
+                )
                 if started and completed:
                     s = datetime.fromisoformat(started.replace("Z", "+00:00"))
                     e = datetime.fromisoformat(completed.replace("Z", "+00:00"))
@@ -123,13 +138,29 @@ def load_amended_entries(run_dir: Path) -> list[dict]:
 
             agent_tok = (turn.get("api_input_tokens") or 0) + (turn.get("api_output_tokens") or 0)
 
+            # Normalize agentic_run_status to dict (handle non-dict truthy values like lists)
+            run_status = turn.get("openshift_agentic_run_status")
+            if not isinstance(run_status, dict):
+                run_status = {}
+
+            # Normalize conditions to list of dicts (prevents phase_status iteration errors)
+            if "conditions" in run_status:
+                conditions_raw = run_status["conditions"]
+                if not isinstance(conditions_raw, list):
+                    run_status["conditions"] = []
+                else:
+                    # Filter to only valid dict entries
+                    run_status["conditions"] = [
+                        c for c in conditions_raw if isinstance(c, dict)
+                    ]
+
             entries.append({
                 "conversation_group_id": cid,
                 "description": entry.get("description", ""),
                 "query": turn.get("query", ""),
                 "response": turn.get("response", ""),
                 "tags": tags,
-                "agentic_run_status": turn.get("openshift_agentic_run_status") or {},
+                "agentic_run_status": run_status,
                 "analysis_duration": duration,
                 "agent_tokens": agent_tok,
             })

--- a/scripts/summarize-agentic-evals.py
+++ b/scripts/summarize-agentic-evals.py
@@ -26,9 +26,9 @@ def load_json_data(json_files: list[Path]) -> tuple[list[list[dict]], dict, str]
     for path in sorted(json_files):
         with open(path) as f:
             data = json.load(f)
-        runs.append(data.get("results", []))
+        runs.append(data.get("results") or [])
         if not config:
-            config = data.get("configuration", {})
+            config = data.get("configuration") or {}
             timestamp = data.get("timestamp", "")
     return runs, config, timestamp
 
@@ -98,9 +98,15 @@ def load_amended_data(json_files: list[Path]) -> list[list[dict]]:
 
 def _format_diagnosis(turn: dict) -> str:
     """Extract and format diagnosis from an amended YAML turn."""
-    results = turn.get("openshift_agentic_run_results", {})
-    for analysis in results.get("analysis", []):
-        diag = analysis.get("diagnosis", {})
+    results = turn.get("openshift_agentic_run_results")
+    if not isinstance(results, dict):
+        return ""
+    for analysis in results.get("analysis") or []:
+        if not isinstance(analysis, dict):
+            continue
+        diag = analysis.get("diagnosis")
+        if not isinstance(diag, dict):
+            continue
         root_cause = diag.get("rootCause", "")
         summary = diag.get("summary", "")
         if root_cause or summary:
@@ -438,7 +444,8 @@ def main():
 
     descriptions = load_descriptions(evals_files)
     json_runs, config, timestamp = load_json_data(json_files)
-    amended_runs = load_amended_data(json_files)
+    # Only load amended data for agentic runs (OLS behavioral runs don't have this)
+    amended_runs = load_amended_data(json_files) if run_type == "agentic" else [[] for _ in json_runs]
     conversations, columns, rows = build_summary(json_runs)
     total_runs = len(json_runs)
 

--- a/scripts/tests/test_generate_report_agentic.py
+++ b/scripts/tests/test_generate_report_agentic.py
@@ -439,6 +439,179 @@ class TestGenerateReport:
         assert "# Evaluation Summary" in report
         assert "s1" in report
 
+    def test_handles_non_dict_agentic_run_status(self, tmp_path):
+        """Regression test: agentic_run_status as list should be normalized to {}."""
+        run_dir = tmp_path / "gpt-5.4" / "run_1"
+        _write_run(
+            run_dir,
+            results=[_make_result("remediation-scenario")],
+            amended_entries=[{
+                "conversation_id": "remediation-scenario",
+                "tags": ["remediation"],
+            }],
+        )
+        # Inject a list instead of dict for openshift_agentic_run_status
+        amended_path = next(run_dir.glob("*amended*.yaml"))
+        amended = yaml.safe_load(amended_path.read_text())
+        amended[0]["turns"][0]["openshift_agentic_run_status"] = ["invalid", "list", "value"]
+        amended_path.write_text(yaml.dump(amended))
+
+        # Should not crash with AttributeError when phase_status tries .get()
+        report = mod.generate_report(tmp_path)
+
+        assert "# Evaluation Summary" in report
+        assert "remediation-scenario" in report
+        # Phase breakdown should show Failed (no valid conditions)
+        assert "[A ❌ 0/1<br>E ❌ 0/1<br>V ❌ 0/1](#gpt-5.4--remediation-scenario)" in report
+
+    def test_handles_null_conditions_in_analysis(self, tmp_path):
+        """Regression test: conditions field as null should be normalized to []."""
+        run_dir = tmp_path / "gpt-5.4" / "run_1"
+        _write_run(
+            run_dir,
+            results=[_make_result("s1")],
+            amended_entries=[{
+                "conversation_id": "s1",
+                "agentic_run_results": {"analysis": [{"conditions": None}]},
+            }],
+        )
+        amended_path = next(run_dir.glob("*amended*.yaml"))
+        amended = yaml.safe_load(amended_path.read_text())
+        amended[0]["turns"][0]["openshift_agentic_run_results"] = {"analysis": [{"conditions": None}]}
+        amended_path.write_text(yaml.dump(amended))
+
+        # Should not crash when conditions is null
+        report = mod.generate_report(tmp_path)
+        assert "# Evaluation Summary" in report
+        assert "s1" in report
+
+    def test_handles_conditions_with_none_entries(self, tmp_path):
+        """Regression test: conditions list containing None should skip invalid entries."""
+        run_dir = tmp_path / "gpt-5.4" / "run_1"
+        _write_run(
+            run_dir,
+            results=[_make_result("s1")],
+            amended_entries=[{
+                "conversation_id": "s1",
+                "agentic_run_results": {
+                    "analysis": [{
+                        "conditions": [
+                            None,
+                            {"type": "Started", "lastTransitionTime": "2026-01-01T10:00:00Z"},
+                            None,
+                            {"type": "Completed", "lastTransitionTime": "2026-01-01T10:05:00Z"},
+                        ]
+                    }]
+                },
+            }],
+        )
+        amended_path = next(run_dir.glob("*amended*.yaml"))
+        amended = yaml.safe_load(amended_path.read_text())
+        amended[0]["turns"][0]["openshift_agentic_run_results"] = {
+            "analysis": [{
+                "conditions": [
+                    None,
+                    {"type": "Started", "lastTransitionTime": "2026-01-01T10:00:00Z"},
+                    None,
+                    {"type": "Completed", "lastTransitionTime": "2026-01-01T10:05:00Z"},
+                ]
+            }]
+        }
+        amended_path.write_text(yaml.dump(amended))
+
+        # Should skip None entries and process valid conditions
+        report = mod.generate_report(tmp_path)
+        assert "# Evaluation Summary" in report
+        assert "s1" in report
+
+    def test_handles_conditions_missing_type_field(self, tmp_path):
+        """Regression test: condition entries missing 'type' field should be skipped."""
+        run_dir = tmp_path / "gpt-5.4" / "run_1"
+        _write_run(
+            run_dir,
+            results=[_make_result("s1")],
+            amended_entries=[{
+                "conversation_id": "s1",
+                "agentic_run_results": {
+                    "analysis": [{
+                        "conditions": [
+                            {"status": "True"},  # Missing 'type' field
+                            {"type": "Started", "lastTransitionTime": "2026-01-01T10:00:00Z"},
+                            {"lastTransitionTime": "2026-01-01T10:05:00Z"},  # Missing 'type' field
+                        ]
+                    }]
+                },
+            }],
+        )
+        amended_path = next(run_dir.glob("*amended*.yaml"))
+        amended = yaml.safe_load(amended_path.read_text())
+        amended[0]["turns"][0]["openshift_agentic_run_results"] = {
+            "analysis": [{
+                "conditions": [
+                    {"status": "True"},  # Missing 'type' field
+                    {"type": "Started", "lastTransitionTime": "2026-01-01T10:00:00Z"},
+                    {"lastTransitionTime": "2026-01-01T10:05:00Z"},  # Missing 'type' field
+                ]
+            }]
+        }
+        amended_path.write_text(yaml.dump(amended))
+
+        # Should skip entries missing 'type' and process valid ones
+        report = mod.generate_report(tmp_path)
+        assert "# Evaluation Summary" in report
+        assert "s1" in report
+
+    def test_normalizes_null_conditions_in_stored_status(self, tmp_path):
+        """Regression test: null conditions in agentic_run_status should be normalized to [] before storage."""
+        run_dir = tmp_path / "gpt-5.4" / "run_1"
+        _write_run(
+            run_dir,
+            results=[_make_result("remediation-scenario")],
+            amended_entries=[{
+                "conversation_id": "remediation-scenario",
+                "tags": ["remediation"],
+            }],
+        )
+        amended_path = next(run_dir.glob("*amended*.yaml"))
+        amended = yaml.safe_load(amended_path.read_text())
+        amended[0]["turns"][0]["openshift_agentic_run_status"] = {"conditions": None}
+        amended_path.write_text(yaml.dump(amended))
+
+        # Should not crash in phase_status when iterating conditions
+        report = mod.generate_report(tmp_path)
+        assert "# Evaluation Summary" in report
+        assert "[A ❌ 0/1<br>E ❌ 0/1<br>V ❌ 0/1](#gpt-5.4--remediation-scenario)" in report
+
+    def test_normalizes_non_dict_entries_in_stored_conditions(self, tmp_path):
+        """Regression test: non-dict entries in conditions list should be filtered before storage."""
+        run_dir = tmp_path / "gpt-5.4" / "run_1"
+        _write_run(
+            run_dir,
+            results=[_make_result("remediation-scenario")],
+            amended_entries=[{
+                "conversation_id": "remediation-scenario",
+                "tags": ["remediation"],
+            }],
+        )
+        amended_path = next(run_dir.glob("*amended*.yaml"))
+        amended = yaml.safe_load(amended_path.read_text())
+        amended[0]["turns"][0]["openshift_agentic_run_status"] = {
+            "conditions": [
+                None,
+                "invalid-string",
+                {"type": "Analyzed", "status": "True"},
+                123,
+                {"type": "Executed", "status": "False"},
+            ]
+        }
+        amended_path.write_text(yaml.dump(amended))
+
+        # Should filter out non-dict entries and process only valid dicts
+        report = mod.generate_report(tmp_path)
+        assert "# Evaluation Summary" in report
+        # Should process the two valid conditions
+        assert "[A ✅ 1/1<br>E ❌ 0/1<br>V ❌ 0/1](#gpt-5.4--remediation-scenario)" in report
+
     def test_no_rankings_section(self, tmp_path):
         _write_run(
             tmp_path / "gpt-5.4" / "run_1",


### PR DESCRIPTION
Use sed instead of python3+yaml in ci-ols-agentic-evals.sh to avoid ModuleNotFoundError before venv exists.

Fix null-safety and conditional amended data loading in summarize-agentic-evals.py for OLS behavioral evaluations.


Assisted-by: Claude Code:claude-sonnet-4-5