### PR TITLE
feat: add evals for user-initated troubleshooting mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ agentic/results/logs/
 __pycache__/
 venv/
 .tools/
+.serena/
 
 # Secrets / credentials — never commit API keys
 .env

--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -201,14 +201,18 @@ else
 	for scenario in $(_OLS_CLASSIC); do \
 	  echo ""; \
 	  echo "==> Setup: $$scenario"; \
-	  if [ -x $$scenario/setup.sh ]; then bash $$scenario/setup.sh; fi; \
-	  bash $(SCRIPTS_DIR)/run-agentic-evals.sh \
-	    --system-config system-ols-classic.yaml \
-	    --evals $$scenario/evals-ols-classic.yaml \
-	    --eval-dir $(EVAL_DIR) \
-	    $(if $(TAG),--tags $(subst $(COMMA), ,$(TAG))); \
+	  scenario_status=0; \
+	  if [ -x $$scenario/setup.sh ]; then bash $$scenario/setup.sh || scenario_status=$$?; fi; \
+	  if [ $$scenario_status -eq 0 ]; then \
+	    bash $(SCRIPTS_DIR)/run-agentic-evals.sh \
+	      --system-config system-ols-classic.yaml \
+	      --evals $$scenario/evals-ols-classic.yaml \
+	      --eval-dir $(EVAL_DIR) \
+	      $(if $(TAG),--tags $(subst $(COMMA), ,$(TAG))) || scenario_status=$$?; \
+	  fi; \
 	  echo "==> Cleanup: $$scenario"; \
 	  if [ -x $$scenario/cleanup.sh ]; then bash $$scenario/cleanup.sh || echo "WARNING: cleanup failed (non-fatal)"; fi; \
+	  if [ $$scenario_status -ne 0 ]; then exit $$scenario_status; fi; \
 	done
 	@echo ""
 	@echo "==> Generating report..."

--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -209,8 +209,11 @@ else
 	    oc create serviceaccount "$$eval_sa" -n openshift-lightspeed >/dev/null; \
 	    eval_sa_created=1; \
 	  fi; \
-	  oc adm policy add-cluster-role-to-user cluster-reader -z "$$eval_sa" -n openshift-lightspeed >/dev/null; \
-	  eval_role_bound=1; \
+	  if ! oc get clusterrolebinding -o jsonpath='{range .items[*]}{.roleRef.name}{"|"}{range .subjects[*]}{.kind}:{.namespace}:{.name}{" "}{end}{"\n"}{end}' 2>/dev/null \
+	      | grep -q "^cluster-reader|.*ServiceAccount:openshift-lightspeed:$$eval_sa"; then \
+	    oc adm policy add-cluster-role-to-user cluster-reader -z "$$eval_sa" -n openshift-lightspeed >/dev/null; \
+	    eval_role_bound=1; \
+	  fi; \
 	  auth_token=$$(oc create token "$$eval_sa" -n openshift-lightspeed --duration=1h); \
 	fi; \
 	export API_KEY="$$auth_token"; \

--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -183,7 +183,10 @@ else
 	  fi; \
 	done
 	@pf_pid=""; \
-	trap 'if [ -n "$$pf_pid" ]; then kill $$pf_pid 2>/dev/null || true; fi' EXIT; \
+	eval_sa="ols-classic-eval"; \
+	eval_sa_created=0; \
+	eval_role_bound=0; \
+	trap 'if [ -n "$$pf_pid" ]; then kill $$pf_pid 2>/dev/null || true; fi; if [ "$$eval_role_bound" -eq 1 ]; then oc adm policy remove-cluster-role-from-user cluster-reader -z "$$eval_sa" -n openshift-lightspeed >/dev/null 2>&1 || true; fi; if [ "$$eval_sa_created" -eq 1 ]; then oc delete serviceaccount "$$eval_sa" -n openshift-lightspeed --ignore-not-found >/dev/null 2>&1 || true; fi' EXIT; \
 	if ! curl -ksf --connect-timeout 2 "https://localhost:8443/docs" >/dev/null 2>&1; then \
 	  echo "==> Starting port-forward to OLS..."; \
 	  oc port-forward -n openshift-lightspeed deployment/lightspeed-app-server 8443:8443 >/dev/null 2>&1 & \
@@ -193,11 +196,17 @@ else
 	auth_token=$$(oc whoami -t 2>/dev/null || true); \
 	if [ -z "$$auth_token" ]; then \
 	  echo "==> No OAuth token, creating service account token..."; \
-	  oc adm policy add-cluster-role-to-user cluster-admin -z default -n openshift-lightspeed >/dev/null 2>&1 || true; \
-	  auth_token=$$(oc create token default -n openshift-lightspeed --duration=1h); \
+	  if ! oc get serviceaccount "$$eval_sa" -n openshift-lightspeed >/dev/null 2>&1; then \
+	    oc create serviceaccount "$$eval_sa" -n openshift-lightspeed >/dev/null; \
+	    eval_sa_created=1; \
+	  fi; \
+	  oc adm policy add-cluster-role-to-user cluster-reader -z "$$eval_sa" -n openshift-lightspeed >/dev/null; \
+	  eval_role_bound=1; \
+	  auth_token=$$(oc create token "$$eval_sa" -n openshift-lightspeed --duration=1h); \
 	fi; \
 	export API_KEY="$$auth_token"; \
 	echo "==> Scenarios: $(_OLS_CLASSIC)"; \
+	overall_status=0; \
 	for scenario in $(_OLS_CLASSIC); do \
 	  echo ""; \
 	  echo "==> Setup: $$scenario"; \
@@ -212,14 +221,21 @@ else
 	  fi; \
 	  echo "==> Cleanup: $$scenario"; \
 	  if [ -x $$scenario/cleanup.sh ]; then bash $$scenario/cleanup.sh || echo "WARNING: cleanup failed (non-fatal)"; fi; \
-	  if [ $$scenario_status -ne 0 ]; then exit $$scenario_status; fi; \
-	done
-	@echo ""
-	@echo "==> Generating report..."
-	@../venv/bin/python3 $(SCRIPTS_DIR)/generate-report-classic.py \
-	  $(EVAL_DIR) \
-	  --output results/results_$(DATETIME).md
-	@echo "==> Results: results/results_$(DATETIME).md"
+	  if [ $$scenario_status -ne 0 ]; then overall_status=$$scenario_status; break; fi; \
+	done; \
+	if [ -n "$$(find "$(EVAL_DIR)" -name '*_summary.json' -print -quit 2>/dev/null)" ]; then \
+	  echo ""; \
+	  echo "==> Generating report..."; \
+	  ../venv/bin/python3 $(SCRIPTS_DIR)/generate-report-classic.py \
+	    $(EVAL_DIR) \
+	    --output results/results_$(DATETIME).md || report_status=$$?; \
+	  if [ $${report_status:-0} -eq 0 ]; then \
+	    echo "==> Results: results/results_$(DATETIME).md"; \
+	  elif [ $$overall_status -eq 0 ]; then \
+	    overall_status=$$report_status; \
+	  fi; \
+	fi; \
+	if [ $$overall_status -ne 0 ]; then exit $$overall_status; fi
 endif
 
 cleanup:

--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -182,6 +182,7 @@ else
 	    exit 1; \
 	  fi; \
 	done
+	@bash $(SCRIPTS_DIR)/preflight.sh --require-ols
 	@pf_pid=""; \
 	eval_sa="ols-classic-eval"; \
 	eval_sa_created=0; \
@@ -191,7 +192,15 @@ else
 	  echo "==> Starting port-forward to OLS..."; \
 	  oc port-forward -n openshift-lightspeed deployment/lightspeed-app-server 8443:8443 >/dev/null 2>&1 & \
 	  pf_pid=$$!; \
-	  sleep 3; \
+	  ols_ok=false; \
+	  for i in $$(seq 1 30); do \
+	    if curl -ksf --connect-timeout 2 "https://localhost:8443/docs" >/dev/null 2>&1; then ols_ok=true; break; fi; \
+	    sleep 2; \
+	  done; \
+	  if [ "$$ols_ok" != "true" ]; then \
+	    echo "Error: OLS not reachable at https://localhost:8443 after port-forward attempt"; \
+	    exit 1; \
+	  fi; \
 	fi; \
 	auth_token=$$(oc whoami -t 2>/dev/null || true); \
 	if [ -z "$$auth_token" ]; then \

--- a/agentic/Makefile
+++ b/agentic/Makefile
@@ -54,6 +54,14 @@ ALL_SCENARIOS := \
 	unready_pod_alert \
 	unready_pod_alert_remediation \
 	unscheduled_pod
+OLS_CLASSIC_SCENARIOS := \
+	crashlooping_pod_alert \
+	failed_job \
+	failing_api_alert \
+	pending_pvc_alert \
+	timeout_connections \
+	unbalanced_replicas \
+	unready_pod_alert
 SCENARIO ?=
 TAG ?=
 SETUP_MODE ?= run
@@ -78,7 +86,18 @@ else
   SCENARIOS := $(_CANDIDATES)
 endif
 
-.PHONY: setup eval cleanup help
+_OLS_CLASSIC_CANDIDATES := $(filter $(_CANDIDATES),$(OLS_CLASSIC_SCENARIOS))
+ifdef TAG
+  _OLS_CLASSIC := $(shell for d in $(_OLS_CLASSIC_CANDIDATES); do \
+    for t in $(subst $(COMMA), ,$(TAG)); do \
+      grep -q '^    - '"$$t"'$$' $$d/evals-ols-classic.yaml 2>/dev/null && echo $$d && break; \
+    done; \
+  done)
+else
+  _OLS_CLASSIC := $(_OLS_CLASSIC_CANDIDATES)
+endif
+
+.PHONY: setup setup-ols-classic eval eval-ols-classic cleanup help
 
 setup:
 	$(SCRIPTS_DIR)/setup-venv.sh
@@ -86,6 +105,10 @@ setup:
 	@echo "NOTE: Install lightspeed-agentic-operator manually by following:"
 	@echo "  https://github.com/openshift/lightspeed-agentic-operator/tree/main/hack/quickstart"
 	@echo "This will be automated in the future."
+
+setup-ols-classic: setup
+	@bash $(SCRIPTS_DIR)/preflight.sh
+	@bash $(SCRIPTS_DIR)/setup-ols.sh
 
 eval:
 ifeq ($(SCENARIOS),)
@@ -147,6 +170,54 @@ endif
 	@echo "==> Results: results/results_$(DATETIME).md"
 endif
 
+eval-ols-classic:
+ifeq ($(_OLS_CLASSIC),)
+	@echo "No OLS classic scenarios match the given filters."
+else
+	$(eval DATETIME := $(shell date +%Y%m%d_%H%M%S))
+	$(eval EVAL_DIR := results/logs/$(DATETIME))
+	@for scenario in $(_OLS_CLASSIC); do \
+	  if [ ! -f "$$scenario/evals-ols-classic.yaml" ]; then \
+	    echo "Error: $$scenario/evals-ols-classic.yaml not found"; \
+	    exit 1; \
+	  fi; \
+	done
+	@pf_pid=""; \
+	trap 'if [ -n "$$pf_pid" ]; then kill $$pf_pid 2>/dev/null || true; fi' EXIT; \
+	if ! curl -ksf --connect-timeout 2 "https://localhost:8443/docs" >/dev/null 2>&1; then \
+	  echo "==> Starting port-forward to OLS..."; \
+	  oc port-forward -n openshift-lightspeed deployment/lightspeed-app-server 8443:8443 >/dev/null 2>&1 & \
+	  pf_pid=$$!; \
+	  sleep 3; \
+	fi; \
+	auth_token=$$(oc whoami -t 2>/dev/null || true); \
+	if [ -z "$$auth_token" ]; then \
+	  echo "==> No OAuth token, creating service account token..."; \
+	  oc adm policy add-cluster-role-to-user cluster-admin -z default -n openshift-lightspeed >/dev/null 2>&1 || true; \
+	  auth_token=$$(oc create token default -n openshift-lightspeed --duration=1h); \
+	fi; \
+	export API_KEY="$$auth_token"; \
+	echo "==> Scenarios: $(_OLS_CLASSIC)"; \
+	for scenario in $(_OLS_CLASSIC); do \
+	  echo ""; \
+	  echo "==> Setup: $$scenario"; \
+	  if [ -x $$scenario/setup.sh ]; then bash $$scenario/setup.sh; fi; \
+	  bash $(SCRIPTS_DIR)/run-agentic-evals.sh \
+	    --system-config system-ols-classic.yaml \
+	    --evals $$scenario/evals-ols-classic.yaml \
+	    --eval-dir $(EVAL_DIR) \
+	    $(if $(TAG),--tags $(subst $(COMMA), ,$(TAG))); \
+	  echo "==> Cleanup: $$scenario"; \
+	  if [ -x $$scenario/cleanup.sh ]; then bash $$scenario/cleanup.sh || echo "WARNING: cleanup failed (non-fatal)"; fi; \
+	done
+	@echo ""
+	@echo "==> Generating report..."
+	@../venv/bin/python3 $(SCRIPTS_DIR)/generate-report-classic.py \
+	  $(EVAL_DIR) \
+	  --output results/results_$(DATETIME).md
+	@echo "==> Results: results/results_$(DATETIME).md"
+endif
+
 cleanup:
 	@for scenario in $(SCENARIOS); do \
 	  if [ -x $$scenario/cleanup.sh ]; then \
@@ -161,19 +232,28 @@ help:
 	@echo "Usage: make <target> [SETUP_MODE=run|scenario]"
 	@echo ""
 	@echo "Targets:"
-	@echo "  setup    Install venv (lightspeed-agentic-operator is manual for now)"
-	@echo "  eval     Run all the $(words $(SCENARIOS)) scenarios"
-	@echo "  cleanup  Run scenario cleanup scripts and remove venv"
-	@echo "  help     Show this help"
+	@echo "  setup              Install venv (lightspeed-agentic-operator is manual for now)"
+	@echo "  setup-ols-classic  Install OLS classic"
+	@echo "  eval               Run agentic scenarios ($(words $(SCENARIOS)) matched)"
+	@echo "  eval-ols-classic   Run OLS classic scenarios ($(words $(_OLS_CLASSIC)) matched)"
+	@echo "  cleanup            Run scenario cleanup scripts and remove venv"
+	@echo "  help               Show this help"
 	@echo ""
-	@echo "Options:"
+	@echo "Options (shared):"
 	@echo "  SCENARIO=...              Comma-separated scenario(s) to run (default: all)"
 	@echo "  TAG=...                   Filter by tag (default: none)"
+	@echo ""
+	@echo "Options (eval):"
 	@echo "  SETUP_MODE=run|scenario   Setup/cleanup lifecycle (default: run)"
 	@echo "    run:      per (scenario, agent, repeat) - for mutating agents"
 	@echo "    scenario: per scenario - for read-only agents, parallel OK"
+	@echo "  Agents and repeat count are read from system.yaml."
 	@echo ""
-	@echo "Agents and repeat count are read from system.yaml."
+	@echo "Options (eval-ols-classic):"
+	@echo "  Agents and repeat count are read from system-ols-classic.yaml."
 	@echo ""
-	@echo "Scenarios:"
+	@echo "Agentic scenarios:"
 	@echo "$(SCENARIOS)" | tr ' ' '\n' | column -x -c $$(tput cols) | expand | sed 's/^/  /'
+	@echo ""
+	@echo "OLS classic scenarios:"
+	@echo "$(_OLS_CLASSIC)" | tr ' ' '\n' | column -x -c $$(tput cols) | expand | sed 's/^/  /'

--- a/agentic/_disabled/oomkilled_pod/evals-ols-classic.yaml
+++ b/agentic/_disabled/oomkilled_pod/evals-ols-classic.yaml
@@ -1,0 +1,24 @@
+- conversation_group_id: oomkilled_pod
+  description: |
+    Alert fires after report-generator restarts several times.
+    RCA: the application stores every processed record in an unbounded cache and
+    exceeds its 60Mi memory limit.
+    Expected: identify the unbounded memory growth and recommend bounding the cache.
+  tag:
+    - classic
+    - core
+    - alert
+    - difficulty_normal
+
+  turns:
+    - turn_id: investigate_oomkill
+      query: >-
+        The report generator in data-processing keeps restarting during normal
+        processing. Can you investigate?
+      expected_response: >-
+        The report-generator container is OOMKilled because it keeps every
+        processed record in an unbounded cache. Its memory use grows until it
+        exceeds the 60Mi limit. The application must bound or evict the cache;
+        increasing the limit alone does not remove the leak.
+      turn_metrics:
+        - custom:answer_correctness

--- a/agentic/_disabled/oomkilled_pod/evals.yaml
+++ b/agentic/_disabled/oomkilled_pod/evals.yaml
@@ -1,4 +1,9 @@
 - conversation_group_id: oomkilled_pod
+  description: |
+    Alert fires after report-generator restarts several times.
+    RCA: the application stores every processed record in an unbounded cache and
+    exceeds its 60Mi memory limit.
+    Expected: identify the unbounded memory growth and recommend bounding the cache.
   tag:
     - agentic
     - core

--- a/agentic/_disabled/recurring_batch_failure/evals-ols-classic.yaml
+++ b/agentic/_disabled/recurring_batch_failure/evals-ols-classic.yaml
@@ -1,0 +1,21 @@
+- conversation_group_id: recurring_batch_failure
+  description: |
+    Some historical batch runs fail while most runs complete successfully.
+    RCA: calls to the upstream service time out between 03:00 and 03:05 UTC;
+    calls outside this window succeed.
+    Expected: identify the recurring time window and upstream connection failures.
+  tag:
+    - classic
+    - difficulty_medium
+
+  turns:
+    - turn_id: investigate_batch_failures
+      query: >-
+        Some historical batch runs in data-pipeline failed. Can you investigate?
+      expected_response: >-
+        batch-processor failures occur between 03:00 and 03:05 UTC because
+        requests to https://pipeline-intake.corp.net/submit time out. Outside
+        this window, batch processing completes successfully. The recurring
+        pattern is consistent with an upstream maintenance window.
+      turn_metrics:
+        - custom:answer_correctness

--- a/agentic/_disabled/recurring_batch_failure/evals.yaml
+++ b/agentic/_disabled/recurring_batch_failure/evals.yaml
@@ -1,4 +1,9 @@
 - conversation_group_id: recurring_batch_failure
+  description: |
+    Some historical batch runs fail while most runs complete successfully.
+    RCA: calls to the upstream service time out between 03:00 and 03:05 UTC;
+    calls outside this window succeed.
+    Expected: identify the recurring time window and upstream connection failures.
   tag:
     - agentic
     - difficulty_medium

--- a/agentic/_disabled/refused_connections/evals-ols-classic.yaml
+++ b/agentic/_disabled/refused_connections/evals-ols-classic.yaml
@@ -1,0 +1,23 @@
+- conversation_group_id: refused_connections
+  description: |
+    Gateway-proxy returns repeated connection refused errors.
+    RCA: a hot-reloaded configuration uses staging database and Redis endpoints
+    in production, where they are unreachable.
+    Expected: identify the configuration drift and restore the production endpoints.
+  tag:
+    - classic
+    - core
+    - difficulty_medium
+
+  turns:
+    - turn_id: investigate_refused_connections
+      query: >-
+        Requests through gateway-proxy in ingress-layer started failing. Can you
+        investigate the cause?
+      expected_response: >-
+        The connection refused errors started after gateway-proxy hot-reloaded
+        a changed configuration. The new configuration uses staging database
+        and Redis endpoints in production, where those endpoints are not
+        reachable.
+      turn_metrics:
+        - custom:answer_correctness

--- a/agentic/_disabled/refused_connections/evals.yaml
+++ b/agentic/_disabled/refused_connections/evals.yaml
@@ -1,4 +1,9 @@
 - conversation_group_id: refused_connections
+  description: |
+    Gateway-proxy returns repeated connection refused errors.
+    RCA: a hot-reloaded configuration uses staging database and Redis endpoints
+    in production, where they are unreachable.
+    Expected: identify the configuration drift and restore the production endpoints.
   tag:
     - agentic
     - core

--- a/agentic/crashlooping_pod_alert/evals-ols-classic.yaml
+++ b/agentic/crashlooping_pod_alert/evals-ols-classic.yaml
@@ -1,0 +1,21 @@
+- conversation_group_id: crashlooping_pod
+  description: |
+    Alert fires for repeated container restarts.
+    RCA: the pod crashes at startup because the required environment
+    variable DEPLOY_ENV is missing from the deployment.
+    Expected: add the DEPLOY_ENV environment variable to the container
+    spec.
+  tag:
+    - classic
+    - core
+    - alert
+    - difficulty_normal
+
+  turns:
+    - turn_id: investigate_crashloop
+      query: "Orders are not being processed in warehouse-ops. Can you investigate what is wrong?"
+      expected_response: >-
+        The order-fulfillment-daemon pod is crash-looping because the required
+        DEPLOY_ENV environment variable is missing from the deployment.
+      turn_metrics:
+        - custom:answer_correctness

--- a/agentic/failed_job/evals-ols-classic.yaml
+++ b/agentic/failed_job/evals-ols-classic.yaml
@@ -1,0 +1,21 @@
+- conversation_group_id: failed_job
+  description: |
+    Batch job fails after exhausting retries.
+    RCA: the job cannot connect to its database at prod-db:3333; logs
+    show repeated TCP connection refused (errno 111). The database
+    service is either missing or misconfigured.
+    Expected: identify the connection failure as root cause and
+    recommend fixing the database endpoint.
+  tag:
+    - classic
+    - core
+    - difficulty_normal
+
+  turns:
+    - turn_id: investigate_failed_job
+      query: "The latest inventory synchronization in catalog-mgmt failed. Can you find out why?"
+      expected_response: >-
+        The inventory-sync-validator job repeatedly fails because it cannot
+        connect to the database endpoint prod-db:3333.
+      turn_metrics:
+        - custom:answer_correctness

--- a/agentic/failing_api_alert/evals-ols-classic.yaml
+++ b/agentic/failing_api_alert/evals-ols-classic.yaml
@@ -1,0 +1,29 @@
+- conversation_group_id: failing_api
+  description: |
+    Alert fires for 100% payment error rate (payments-api returns
+    503).
+    RCA: reporting-service leaks database connections, exhausting the
+    shared PostgreSQL pool; payments-api cannot acquire a connection.
+    Expected: identify reporting-service as the root cause;
+    reconciliation-service CrashLooping is a separate issue, not the
+    cause.
+  tag:
+    - classic
+    - core
+    - alert
+    - difficulty_hard
+
+  turns:
+    - turn_id: investigate_payment_failures
+      query: >-
+        The payment service in the payments namespace is failing customer
+        requests. Can you investigate the cause?
+      expected_response: >-
+        Root cause: payments/reporting-service is repeatedly opening DB connections
+        and not releasing them properly, exhausting PostgreSQL connection slots.
+        payments/payments-api cannot obtain a DB connection and returns 503.
+        if mentioned, reconciliation-service CrashLooping is a separate issue, NOT RELATED
+        to the DB connection exhaustion.
+        Fix: rollback, restart, or scale down reporting-service.
+      turn_metrics:
+        - custom:answer_correctness

--- a/agentic/failing_api_alert/evals.yaml
+++ b/agentic/failing_api_alert/evals.yaml
@@ -38,7 +38,7 @@
             status: "True"
 
       expected_outcome: >-
-        Root cause: shared-services/reporting-service is repeatedly opening DB connections
+        Root cause: payments/reporting-service is repeatedly opening DB connections
         and not releasing them properly, exhausting PostgreSQL connection slots.
         payments/payments-api cannot obtain a DB connection and returns 503.
         if mentioned, reconciliation-service CrashLooping is a separate issue, NOT RELATED

--- a/agentic/pending_pvc_alert/evals-ols-classic.yaml
+++ b/agentic/pending_pvc_alert/evals-ols-classic.yaml
@@ -1,0 +1,24 @@
+- conversation_group_id: pending_pvc
+  description: |
+    Alert fires for a PVC stuck in Pending.
+    RCA: the PVC references StorageClass 'standard-v2' which does not
+    exist in the cluster. The init container also uses runAsUser: 65532,
+    which violates the namespace UID range enforced by restricted-v2 SCC.
+    Expected: change the PVC's StorageClass to a valid one or create
+    the missing StorageClass, and use a UID allowed by the SCC.
+  tag:
+    - classic
+    - core
+    - alert
+    - difficulty_medium
+
+  turns:
+    - turn_id: investigate_pending_pvc
+      query: "Memcached in cache-tier has not become available. Can you investigate?"
+      expected_response: >-
+        The memcached-data-pvc PersistentVolumeClaim is Pending because it
+        references the missing standard-v2 StorageClass. The init container
+        also uses UID 65532, which is outside the namespace range allowed by
+        the restricted-v2 SCC.
+      turn_metrics:
+        - custom:answer_correctness

--- a/agentic/results/example-ols-classic.md
+++ b/agentic/results/example-ols-classic.md
@@ -1,0 +1,1135 @@
+# Evaluation Summary
+
+2026-09-04 13:01:34 UTC | 7 scenarios, 2 agents, 1 repeat
+
+| | gpt-5.2 | gpt-5.4 |
+|---|---|---|
+| Pass rate | **100%** | **100%** |
+| Avg score | **0.98** | 0.98 |
+| Avg latency | 45s | **28s** |
+| Avg tokens | 97K | 62K |
+
+## Correctness
+
+Passed repeats / total repeats. Score: 0-1.00 (1.00 = perfect, 0.75 = minimum to pass).
+
+| Scenario | gpt-5.2 | gpt-5.4 |
+|---|---|---|
+| [crashlooping_pod](#crashlooping_pod) | **[✅ 1.00](#gpt-5.2--crashlooping_pod)** | **[✅ 1.00](#gpt-5.4--crashlooping_pod)** |
+| [failed_job](#failed_job) | [✅ 0.95](#gpt-5.2--failed_job) | **[✅ 0.98](#gpt-5.4--failed_job)** |
+| [failing_api](#failing_api) | [✅ 0.99](#gpt-5.2--failing_api) | **[✅ 1.00](#gpt-5.4--failing_api)** |
+| [pending_pvc](#pending_pvc) | **[✅ 0.98](#gpt-5.2--pending_pvc)** | [✅ 0.93](#gpt-5.4--pending_pvc) |
+| [timeout_connections](#timeout_connections) | **[✅ 1.00](#gpt-5.2--timeout_connections)** | **[✅ 1.00](#gpt-5.4--timeout_connections)** |
+| [unbalanced_replicas](#unbalanced_replicas) | **[✅ 0.95](#gpt-5.2--unbalanced_replicas)** | **[✅ 0.95](#gpt-5.4--unbalanced_replicas)** |
+| [unready_pod](#unready_pod) | **[✅ 1.00](#gpt-5.2--unready_pod)** | [✅ 0.98](#gpt-5.4--unready_pod) |
+| **Pass rate** | **✅ 100% (7/7)** | **✅ 100% (7/7)** |
+
+## Latency
+
+Average agent latency across all repeats of a scenario per agent.
+
+| Scenario | gpt-5.2 | gpt-5.4 |
+|---|---|---|
+| [crashlooping_pod](#crashlooping_pod) | [23s](#gpt-5.2--crashlooping_pod) | **[23s](#gpt-5.4--crashlooping_pod)** |
+| [failed_job](#failed_job) | [59s](#gpt-5.2--failed_job) | **[28s](#gpt-5.4--failed_job)** |
+| [failing_api](#failing_api) | [1m 7s](#gpt-5.2--failing_api) | **[35s](#gpt-5.4--failing_api)** |
+| [pending_pvc](#pending_pvc) | [37s](#gpt-5.2--pending_pvc) | **[19s](#gpt-5.4--pending_pvc)** |
+| [timeout_connections](#timeout_connections) | [1m 4s](#gpt-5.2--timeout_connections) | **[39s](#gpt-5.4--timeout_connections)** |
+| [unbalanced_replicas](#unbalanced_replicas) | [37s](#gpt-5.2--unbalanced_replicas) | **[26s](#gpt-5.4--unbalanced_replicas)** |
+| [unready_pod](#unready_pod) | [24s](#gpt-5.2--unready_pod) | **[24s](#gpt-5.4--unready_pod)** |
+| **Average** | 45s | **28s** |
+
+## Cost
+
+Total token usage for each scenario across all repeats per agent; the Average row shows average usage per evaluation.
+
+| Scenario | gpt-5.2 | gpt-5.4 |
+|---|---|---|
+| [crashlooping_pod](#crashlooping_pod) | [20K](#gpt-5.2--crashlooping_pod) | [21K](#gpt-5.4--crashlooping_pod) |
+| [failed_job](#failed_job) | [101K](#gpt-5.2--failed_job) | [47K](#gpt-5.4--failed_job) |
+| [failing_api](#failing_api) | [359K](#gpt-5.2--failing_api) | [121K](#gpt-5.4--failing_api) |
+| [pending_pvc](#pending_pvc) | [24K](#gpt-5.2--pending_pvc) | [18K](#gpt-5.4--pending_pvc) |
+| [timeout_connections](#timeout_connections) | [86K](#gpt-5.2--timeout_connections) | [56K](#gpt-5.4--timeout_connections) |
+| [unbalanced_replicas](#unbalanced_replicas) | [73K](#gpt-5.2--unbalanced_replicas) | [139K](#gpt-5.4--unbalanced_replicas) |
+| [unready_pod](#unready_pod) | [16K](#gpt-5.2--unready_pod) | [30K](#gpt-5.4--unready_pod) |
+| **Average** | 97K | 62K |
+
+# Scenarios
+
+## crashlooping_pod
+
+Alert fires for repeated container restarts.
+RCA: the pod crashes at startup because the required environment
+variable DEPLOY_ENV is missing from the deployment.
+Expected: add the DEPLOY_ENV environment variable to the container
+spec.
+
+**Tags**: `classic`, `alert`, `core`, `difficulty_normal`
+
+### Query
+
+```
+Orders are not being processed in warehouse-ops. Can you investigate what is wrong?
+```
+
+<a id="gpt-5.2--crashlooping_pod"></a>
+
+### gpt-5.2
+
+**Correctness**: ✅ PASS (score: 1.00)
+
+> Custom answer correctness: 1.00 - The response is fully correct and aligns exactly with the expected response. It identifies the core issue: the `order-fulfillment-daemon` pod is crash-looping because the required `DEPLOY_ENV` environment variable is missing from the deployment. That matches the expected answer precisely.
+
+**Latency**: 23s
+
+**Tokens**: 20,094
+
+````markdown
+### Evidence (what’s failing)
+- **Only workload in `warehouse-ops`** is `Deployment/order-fulfillment-daemon`, and it has **0/1 available replicas**:
+  - `warehouse-ops Deployment order-fulfillment-daemon 0/1 AVAILABLE`
+- The single pod is crash-looping / erroring:
+  - `Pod/ order-fulfillment-daemon-d7549fc8b-c8p42` shows **exitCode=1** with **restartCount=4**
+  - Namespace event: **`Back-off restarting failed container fulfillment-container`**
+- Container log shows the direct failure:
+  - **`Environment variable DEPLOY_ENV is undefined`**
+- There is an active alert tied to this pod:
+  - **`WarehouseOpsPodRestarting`** for `warehouse-ops/order-fulfillment-daemon-d7549fc8b-c8p42`
+
+### Root cause
+`Deployment/order-fulfillment-daemon` starts `/bin/sh -c ...` with a script that **exits 1 when `DEPLOY_ENV` is empty**. The deployment **does not define `DEPLOY_ENV`**, so the container immediately exits and never becomes available, which would stop order processing.
+
+### Fix / mitigation
+Update `Deployment/order-fulfillment-daemon` to provide `DEPLOY_ENV` (from a literal value, ConfigMap, or Secret).
+
+Example patch (literal value):
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: order-fulfillment-daemon
+  namespace: warehouse-ops
+spec:
+  template:
+    spec:
+      containers:
+      - name: fulfillment-container
+        env:
+        - name: DEPLOY_ENV
+          value: "prod"   # set to the correct environment for warehouse-ops
+```
+
+After applying, the pod should stop restarting and the deployment should reach **1/1 Available**.
+
+If you tell me what `DEPLOY_ENV` should be for this namespace (e.g., `prod`, `stage`, `dev`), I can apply the update directly and verify the rollout.
+````
+
+<a id="gpt-5.4--crashlooping_pod"></a>
+
+### gpt-5.4
+
+**Correctness**: ✅ PASS (score: 1.00)
+
+> Custom answer correctness: 1.00 - The response is fully correct and aligns exactly with the expected response. It identifies the core issue as the `order-fulfillment-daemon` pod crash-looping because the required `DEPLOY_ENV` environment variable is missing from the deployment. That is the same diagnosis as the expected answer.
+
+**Latency**: 23s
+
+**Tokens**: 21,338
+
+````markdown
+Diagnosis: the order processor in `warehouse-ops` is crashing immediately due to a missing required environment variable.
+
+Evidence
+- Active alert:
+  - `WarehouseOpsPodRestarting`
+  - pod: `order-fulfillment-daemon-d7549fc8b-c8p42`
+  - namespace: `warehouse-ops`
+- Deployment state:
+  - Deployment `order-fulfillment-daemon` is `0/1` available.
+  - ReplicaSet `order-fulfillment-daemon-d7549fc8b` has `1` desired, `0` ready.
+- Pod state:
+  - Pod `order-fulfillment-daemon-d7549fc8b-c8p42` is not ready, restart count `4`.
+  - Last container exit:
+    - container: `fulfillment-container`
+    - exit code: `1`
+    - reason: `Error`
+    - last finished at: `2026-09-04T13:00:46Z`
+- Pod logs:
+  - `Environment variable DEPLOY_ENV is undefined`
+- Deployment spec confirms the failure condition is built into the startup command:
+  - `if [ -z "${DEPLOY_ENV}" ]; then`
+  - `echo "Environment variable DEPLOY_ENV is undefined"`
+  - `exit 1`
+- The deployment has no `env:` section for `fulfillment-container`, so `DEPLOY_ENV` is never set.
+
+Root cause
+1. `order-fulfillment-daemon` was deployed without the required `DEPLOY_ENV` environment variable.
+2. The container exits immediately by design when that variable is absent.
+3. Because this is the only pod in `warehouse-ops`, order processing has no healthy worker.
+
+Recent change correlation
+- Deployment `order-fulfillment-daemon` was created at `2026-09-04T12:59:20Z`.
+- The failing pod was scheduled immediately after that.
+- Events show repeated restart/backoff beginning right after startup:
+  - `Back-off restarting failed container fulfillment-container`
+
+Fix / mitigation
+- Update Deployment `order-fulfillment-daemon` in `warehouse-ops` to set `DEPLOY_ENV` to the expected value for this environment.
+- If the value should come from a ConfigMap or Secret, add the appropriate `env` / `envFrom` reference.
+- This is reversible: rolling back to the previous working deployment spec or removing the bad revision should restore processing.
+
+Most likely remediation target
+- Resource: `apps/v1 Deployment/warehouse-ops/order-fulfillment-daemon`
+- Container: `fulfillment-container`
+
+No other application resources were present in `warehouse-ops` besides this deployment/pod path, so this crash is the primary issue directly blocking processing.
+````
+
+[Back to top](#evaluation-summary)
+
+## failed_job
+
+Batch job fails after exhausting retries.
+RCA: the job cannot connect to its database at prod-db:3333; logs
+show repeated TCP connection refused (errno 111). The database
+service is either missing or misconfigured.
+Expected: identify the connection failure as root cause and
+recommend fixing the database endpoint.
+
+**Tags**: `classic`, `difficulty_normal`, `core`
+
+### Query
+
+```
+The latest inventory synchronization in catalog-mgmt failed. Can you find out why?
+```
+
+<a id="gpt-5.2--failed_job"></a>
+
+### gpt-5.2
+
+**Correctness**: ✅ PASS (score: 0.95)
+
+> Custom answer correctness: 0.95 - The response is highly correct and closely aligned with the expected answer. It clearly identifies the primary root cause: the `inventory-sync-validator` job fails because it cannot connect to `prod-db:3333`, which matches the expected response exactly.
+
+**Latency**: 59s
+
+**Tokens**: 101,265
+
+````markdown
+### Evidence (what failed)
+- **Job:** `catalog-mgmt/inventory-sync-validator` is **Failed** with `BackoffLimitExceeded`  
+  - `startTime: 2026-09-04T13:01:44Z`
+  - `backoffLimit: 1`
+  - `status.failed: 2`
+- **Pods created by the job (both ended in Error):**
+  - `catalog-mgmt/inventory-sync-validator-vh6hq`
+  - `catalog-mgmt/inventory-sync-validator-4pstl`
+
+### Why it failed (root cause)
+1) **The sync job exits fatally because it cannot connect to the database endpoint `prod-db:3333`**
+   - Pod logs (both attempts) show repeated failures and then exit code `1`:
+     - `Socket connect returned errno 111 - connection refused`
+     - `FATAL: Unable to connect to required database`
+   - This indicates something is reachable at that DNS name but **nothing is accepting connections on port 3333** (or the name resolves somewhere that refuses the connection).
+
+2) **There is no `Service` named `prod-db` in the `catalog-mgmt` namespace**
+   - `Service catalog-mgmt/prod-db` **does not exist** (`services "prod-db" not found`)
+   - `Service`/`Endpoints`/`EndpointSlice` lists in `catalog-mgmt` came back empty, so there’s nothing in-namespace providing `prod-db:3333`.
+
+3) **(Secondary) First pod hit a transient mount error because the ConfigMap didn’t exist yet**
+   - Event at `2026-09-04 13:01:44Z` for `inventory-sync-validator-vh6hq`:
+     - `FailedMount: configmap "inventory-sync-entrypoint" not found`
+   - The ConfigMap `catalog-mgmt/inventory-sync-entrypoint` was created at `2026-09-04T13:01:45Z` (after the job started), so the first attempt raced it.
+
+### Fix / mitigation
+- **Primary fix:** make the database endpoint valid and reachable from `catalog-mgmt`.
+  - Create the missing `Service` (and backing Pods/Endpoints) for **`prod-db`**, or update the job/config to point to the correct DB host/port.
+  - Ensure whatever `prod-db` resolves to is actually **listening on port `3333`**.
+- **Secondary fix (ordering):** apply/create the ConfigMap **before** creating the Job (to avoid the `FailedMount` race).
+- Optional hardening: increase `backoffLimit` temporarily so a transient DB startup doesn’t cause immediate job failure.
+
+If you tell me what should provide the DB (a Deployment/StatefulSet name, or if it’s external), I can trace where `prod-db` is supposed to resolve to and what’s refusing the connection.
+````
+
+<a id="gpt-5.4--failed_job"></a>
+
+### gpt-5.4
+
+**Correctness**: ✅ PASS (score: 0.98)
+
+> Custom answer correctness: 0.98 - The response is essentially correct and strongly aligned with the expected answer. It identifies the same core failure reason: the `inventory-sync-validator` job failed because it could not connect to the database endpoint `prod-db:3333`.
+
+**Latency**: 28s
+
+**Tokens**: 46,711
+
+````markdown
+Yes. The latest sync failed because the job could not connect to its configured database endpoint.
+
+**Affected resources**
+- Namespace: `catalog-mgmt`
+- Job: `inventory-sync-validator`
+- Pods:
+  1. `inventory-sync-validator-vh6hq`
+  2. `inventory-sync-validator-4pstl`
+
+**Evidence**
+1. Both job pods failed with the same error:
+   - `inventory-sync-validator-vh6hq` log at `2026-09-04T13:01:47`
+   - `inventory-sync-validator-4pstl` log at `2026-09-04T13:01:57`
+   - Exact error:
+     - `Socket connect returned errno 111 - connection refused`
+     - `Target host: prod-db, port: 3333`
+     - `FATAL: Unable to connect to required database`
+
+2. The job exhausted retries and then failed:
+   - Event on `Job/inventory-sync-validator` at `2026-09-04 13:01:59 UTC`:
+     - `BackoffLimitExceeded`
+   - Job spec has `backoffLimit: 1`, so after the first failed pod it created one retry pod and then stopped.
+
+3. The configured endpoint is `prod-db:3333`:
+   - `ConfigMap/inventory-sync-entrypoint` contains:
+     - `DB_HOST = "prod-db"`
+     - `DB_PORT = 3333`
+
+4. There is no Kubernetes `Service` named `prod-db` in `catalog-mgmt`:
+   - `Service/prod-db` lookup returned `services "prod-db" not found`
+   - Listing Services in `catalog-mgmt` returned none
+
+**Root cause**
+1. **Primary cause:** the sync job is configured to use `prod-db:3333`, but that endpoint is not available from the namespace.
+   - No `Service` named `prod-db` exists in `catalog-mgmt`
+   - The application logs show repeated `connection refused` to `prod-db:3333`
+
+2. **Secondary issue:** the first pod also hit an initial ConfigMap timing/race problem:
+   - Event on `Pod/inventory-sync-validator-vh6hq`:
+     - `MountVolume.SetUp failed for volume "scripts" : configmap "inventory-sync-entrypoint" not found`
+   - This was transient; the pod later started, so it is **not** the final failure cause.
+
+**Fix / mitigation**
+1. Verify what `prod-db` is supposed to be:
+   - If it should be an in-namespace Service, create or restore `Service/prod-db` and its backing pods/endpoints.
+   - If it should point to an external database, correct the job/config to use the real hostname and port.
+
+2. After correcting the endpoint, rerun the sync job.
+
+3. Optional cleanup:
+   - Ensure `ConfigMap/inventory-sync-entrypoint` exists before creating the job to avoid the initial `FailedMount` race.
+
+**Bottom line**
+The latest inventory synchronization did **not** fail because of scheduling or image pull problems. It failed because `inventory-sync-validator` was configured to connect to `prod-db:3333`, and that database endpoint was unavailable/misconfigured for the namespace.
+````
+
+[Back to top](#evaluation-summary)
+
+## failing_api
+
+Alert fires for 100% payment error rate (payments-api returns
+503).
+RCA: reporting-service leaks database connections, exhausting the
+shared PostgreSQL pool; payments-api cannot acquire a connection.
+Expected: identify reporting-service as the root cause;
+reconciliation-service CrashLooping is a separate issue, not the
+cause.
+
+**Tags**: `classic`, `alert`, `core`, `difficulty_hard`
+
+### Query
+
+```
+The payment service in the payments namespace is failing customer requests. Can you investigate the cause?
+```
+
+<a id="gpt-5.2--failing_api"></a>
+
+### gpt-5.2
+
+**Correctness**: ✅ PASS (score: 0.99)
+
+> Custom answer correctness: 0.99 - The response is essentially correct and aligns very closely with the expected answer.
+
+**Latency**: 1m 7s
+
+**Tokens**: 358,647
+
+````markdown
+### Evidence (what’s failing and why)
+1. **Customer-facing payment requests are failing in `payments`**
+   - Alert firing: **`PaymentErrorRateHigh` (critical)** in namespace `payments` with **100% error rate**.
+   - `payments-api` pod `payments/payments-api-c7c648878-pv2px` is returning **HTTP 503** on `/api/v1/process-payment` and logs show DB connection failures:
+     - `connection to server at "postgres" (172.30.58.99), port 5432 failed: FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute`
+
+2. **PostgreSQL is rejecting new connections due to low connection limit**
+   - Postgres logs from `payments/postgres-5bd4d575fb-l5vsj` show repeated:
+     - `FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute`
+   - Metrics confirm **Postgres is configured with a very low max connection limit**:
+     - `pg_settings_max_connections{namespace="payments"} = 20`
+     - `pg_settings_superuser_reserved_connections{namespace="payments"} = 3`
+     - Active connections observed:
+       - `sum(pg_stat_activity_count{namespace="payments",datname="demo"}) = 18`
+     - With `max_connections=20` and `superuser_reserved_connections=3`, you effectively have **~17 usable slots for normal traffic**; at 18 connections, new non-superuser connections will be rejected exactly as seen.
+
+3. **Root driver: connection leak / stuck transactions from `reporting-service`**
+   - Live DB activity shows **16 connections “idle in transaction”** from a single client IP:
+     - `dbuser | 10.128.2.101 | idle in transaction | 16`
+   - `10.128.2.101` matches the `reporting-service` pod IP:
+     - `payments/reporting-service-6d7f67656f-9p4m9` has IP **`10.128.2.101`**
+   - This strongly indicates **`reporting-service` is holding transactions open and exhausting the limited Postgres connection budget**, which then causes **`payments-api` to fail and return 503s**.
+
+### Root cause
+**Database connection starvation caused by `reporting-service` holding many PostgreSQL connections “idle in transaction” (16 connections), combined with PostgreSQL being configured with `max_connections=20` (and 3 superuser-reserved), leaving too few usable slots.**  
+This leads to Postgres rejecting new connections and `payments-api` failing customer requests with 503.
+
+### Fix / Mitigation (ordered)
+1. **Immediate mitigation (fastest recovery): restart `reporting-service`**
+   - Restarting `payments/reporting-service` will drop the leaked/stuck DB sessions and should quickly restore capacity for `payments-api`.
+
+2. **Increase Postgres `max_connections` (if appropriate for the workload/resources)**
+   - Current `max_connections=20` is extremely tight for multiple services. Raising it provides headroom, but make sure Postgres memory settings can handle it.
+
+3. **Correct the application behavior in `reporting-service` (real fix)**
+   - The DB shows sessions **idle in transaction**, which usually means:
+     - transactions not committed/rolled back
+     - connections not returned to pool
+     - long-running requests leaving DB sessions open
+   - Fix by ensuring:
+     - proper transaction handling (commit/rollback)
+     - connection pooling with sane limits (per-service pool caps)
+     - timeouts (statement_timeout / idle_in_transaction_session_timeout)
+
+### Additional issue noticed (not the primary cause of customer request failures)
+- `payments/reconciliation-service-587768b96f-9fnz6` is **CrashLoopBackOff**.
+  - Events show probes failing: `HTTP probe failed with statuscode: 400`
+  - This should be fixed, but it’s separate from the immediate **payments-api ↔ postgres connection exhaustion** problem driving the request failures.
+````
+
+<a id="gpt-5.4--failing_api"></a>
+
+### gpt-5.4
+
+**Correctness**: ✅ PASS (score: 1.00)
+
+> Custom answer correctness: 1.00 - The response is fully correct and aligns very closely with the expected response.
+
+**Latency**: 35s
+
+**Tokens**: 121,133
+
+````markdown
+Diagnosis
+
+Evidence
+- `payments-api` is healthy at the pod level (`payments-api-c7c648878-pv2px` is `1/1 Running`), but its application logs show every customer request failing with PostgreSQL connection errors:
+  - `2026-09-04 13:07:31,250 ERROR Payment failed ... FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute`
+  - requests return `503` on `/api/v1/process-payment`
+- Alerting matches that symptom:
+  - `PaymentErrorRateHigh` in namespace `payments`: `Payment error rate is 100.00%`
+  - `PostgresqlTooManyConnections` in namespace `payments`: `18 active connections detected`
+- PostgreSQL logs confirm connection exhaustion began earlier:
+  - first observed at `2026-09-04 13:05:58.533 UTC`
+  - repeated `FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute`
+- On the database, current activity shows the leaked connections are coming from `reporting-service-6d7f67656f-9p4m9` (`10.128.2.101`):
+  - `16` sessions from client `10.128.2.101`
+  - state: `idle in transaction`
+  - query left open: `SELECT count(*) FROM reports`
+- PostgreSQL is configured with only `20` max connections:
+  - `show max_connections;` → `20`
+  - `select count(*) from pg_stat_activity;` → `23`
+- `reporting-service` was just rolled out to a new image:
+  - deployment `payments/reporting-service` revision `2`
+  - current image: `quay.io/afalossi/ts01-reporting-service:v1.0.2`
+  - previous ReplicaSet was using `v1.0.1`
+- `reporting-service` logs correlate exactly with the buildup:
+  - starts at `2026-09-04 13:03:38,294 INFO Starting reporting-service v1.0.2`
+  - every 10 seconds: `INFO Open db connection`
+  - then: `ERROR Failed to process pending reports: division by zero`
+  - connections are not closed afterward
+
+Root cause
+1. `payments/reporting-service` version `v1.0.2` is leaking PostgreSQL connections after hitting `division by zero`.
+2. Those leaked sessions accumulate as `idle in transaction` until PostgreSQL hits its `max_connections` limit (`20`).
+3. Once exhausted, `payments-api` cannot open new DB connections and returns `503` for customer payment requests.
+
+This is the direct cause of the payment outage.
+
+Recommended fix / mitigation
+1. Immediate reversible mitigation:
+   - scale `payments/reporting-service` to `0`, or roll it back from `v1.0.2` to the previous `v1.0.1`
+   - this should stop new leaked sessions
+2. Then clear existing stuck DB sessions:
+   - restart `payments/postgres` or terminate the leaked `dbuser` sessions
+3. Permanent fix:
+   - fix `reporting-service v1.0.2` so DB connections/transactions are closed on exceptions, especially on the `division by zero` path
+
+Notes
+- There is also a separate issue in `payments/reconciliation-service`:
+  - pod `reconciliation-service-587768b96f-9fnz6` is `CrashLoopBackOff`
+  - deployment uses image `registry.redhat.io/rhel9/httpd-24:latest`
+  - probes are hitting port `8443` while the container exposes `8080`
+- That is a real problem, but it is not the cause of the payment request failures. The payment failures are caused by PostgreSQL connection exhaustion from `reporting-service`.
+
+If you want, I can apply the immediate mitigation now by scaling down `reporting-service` or help choose the safer rollback path.
+````
+
+[Back to top](#evaluation-summary)
+
+## pending_pvc
+
+Alert fires for a PVC stuck in Pending.
+RCA: the PVC references StorageClass 'standard-v2' which does not
+exist in the cluster. The init container also uses runAsUser: 65532,
+which violates the namespace UID range enforced by restricted-v2 SCC.
+Expected: change the PVC's StorageClass to a valid one or create
+the missing StorageClass, and use a UID allowed by the SCC.
+
+**Tags**: `difficulty_medium`, `core`, `classic`, `alert`
+
+### Query
+
+```
+Memcached in cache-tier has not become available. Can you investigate?
+```
+
+<a id="gpt-5.2--pending_pvc"></a>
+
+### gpt-5.2
+
+**Correctness**: ✅ PASS (score: 0.98)
+
+> Custom answer correctness: 0.98 - The response is factually accurate and closely matches the expected answer. It correctly identifies both key blockers:
+
+**Latency**: 37s
+
+**Tokens**: 23,673
+
+````markdown
+### Evidence (why memcached is not becoming available)
+
+**1) Pods are not being created due to SCC admission failure**
+- `cache-tier` events show `FailedCreate` for ReplicaSet `memcached-5df8c85fbf`:
+  - `pods "memcached-5df8c85fbf-" is forbidden: unable to validate against any security context constraint`
+  - Key violations called out:
+    - `restricted-v2: .initContainers[0].runAsUser: Invalid value: 65532: must be in the ranges: [1000860000, 1000869999]`
+    - `restricted-v3: .spec.hostUsers: Invalid value: null: Host Users must be set to false`
+- Deployment `cache-tier/memcached` currently has:
+  - initContainer `init-perms` with `securityContext.runAsUser: 65532`
+  - pod `spec.securityContext: {}` (and no `hostUsers: false`), matching the error above.
+- Current status: Deployment `memcached` is **0/1 Available**, ReplicaSet desired=1 but **0 pods** exist.
+
+**2) PVC is stuck Pending because the referenced StorageClass doesn’t exist**
+- Alert firing: `CacheTierPersistentVolumeClaimPending` for `cache-tier/memcached-data-pvc`.
+- Event for PVC:
+  - `ProvisioningFailed: storageclass.storage.k8s.io "standard-v2" not found`
+- PVC spec:
+  - `storageClassName: standard-v2`
+- Actual StorageClasses in the cluster:
+  - `gp3-csi (default)`
+  - `gp2-csi`
+
+These are **two independent blockers**: SCC rejection prevents pod creation, and even if SCC is fixed, the pod would be unable to mount the volume until the PVC binds.
+
+---
+
+### Root cause
+1. **Deployment security context is incompatible with OpenShift “restricted” SCC** (hard-coded `runAsUser: 65532` in the initContainer; and `hostUsers` not explicitly set to `false`).
+2. **PVC references a non-existent StorageClass (`standard-v2`)**, so it cannot be provisioned/bound.
+
+---
+
+### Fix / mitigation
+
+**A) Fix the PVC**
+- Choose one:
+  1) **Delete and recreate** `cache-tier/memcached-data-pvc` with `storageClassName: gp3-csi` (or omit `storageClassName` to use the default `gp3-csi`).
+  2) If you don’t need persistence for memcached, remove the PVC/volume and use `emptyDir` instead.
+
+> Note: `storageClassName` is effectively not something you can “patch in place” for an existing PVC in a safe/standard way; the typical fix is delete+recreate the claim (and accept data loss if any).
+
+**B) Fix the Deployment SCC issues**
+- Update `cache-tier/memcached` pod template to:
+  - **Remove** `initContainers[0].securityContext.runAsUser: 65532` (let OpenShift assign a UID in the namespace range), and/or remove the initContainer entirely.
+  - **Set** `spec.template.spec.hostUsers: false`.
+  - If you need writable permissions on the mounted volume, prefer using pod-level `securityContext.fsGroup` (set within the namespace’s allowed range) over a `chmod` initContainer—because the initContainer won’t be allowed to run as root under restricted SCC.
+
+If you want, I can propose an exact corrected Deployment+PVC YAML for `cache-tier` based on whether you want **persistent storage** or **ephemeral cache** (emptyDir).
+````
+
+<a id="gpt-5.4--pending_pvc"></a>
+
+### gpt-5.4
+
+**Correctness**: ✅ PASS (score: 0.93)
+
+> Custom answer correctness: 0.93 - The response is largely correct and aligns well with the expected answer. It identifies the two key issues:
+
+**Latency**: 19s
+
+**Tokens**: 17,893
+
+````markdown
+Findings for `cache-tier/memcached`:
+
+## Evidence
+
+1. **Deployment is unavailable**
+   - `Deployment`: `cache-tier/memcached`
+   - Status: `READY 0/1`, `AVAILABLE 0`
+   - Condition:
+     - `Available=False` with `MinimumReplicasUnavailable`
+     - `ReplicaFailure=True` with `FailedCreate`
+
+2. **No pod was created**
+   - `ReplicaSet`: `cache-tier/memcached-5df8c85fbf`
+   - Status: `DESIRED 1`, `CURRENT 0`, `READY 0`
+
+3. **Immediate pod creation failure is an OpenShift SCC rejection**
+   - Event at `2026-09-04 13:11:12 UTC`:
+     - `Error creating: pods "memcached-5df8c85fbf-" is forbidden: unable to validate against any security context constraint`
+   - Exact SCC errors include:
+     - `.initContainers[0].runAsUser: Invalid value: 65532: must be in the ranges: [1000860000, 1000869999]`
+     - `restricted-v3: .spec.hostUsers: Invalid value: null: Host Users must be set to false`
+
+4. **Persistent storage is also misconfigured**
+   - Alert firing:
+     - `CacheTierPersistentVolumeClaimPending`
+     - PVC: `cache-tier/memcached-data-pvc`
+   - Event at `2026-09-04 13:11:15 UTC`:
+     - `storageclass.storage.k8s.io "standard-v2" not found`
+   - PVC status:
+     - `phase: Pending`
+
+5. **Requested storage class does not exist**
+   - Available StorageClasses:
+     - `gp2-csi`
+     - `gp3-csi` **(default)**
+   - Missing:
+     - `standard-v2`
+
+## Root cause
+
+There are **2 blockers**:
+
+1. **Pod spec is incompatible with OpenShift restricted SCC**
+   - The init container explicitly sets `runAsUser: 65532`, but the namespace `cache-tier` is assigned UID range `1000860000-1000869999`.
+   - The pod template also omits `spec.hostUsers: false`, which `restricted-v3` requires.
+
+2. **PVC references a non-existent StorageClass**
+   - `memcached-data-pvc` requests `storageClassName: standard-v2`
+   - That StorageClass is not present in the cluster, so the claim remains `Pending`.
+
+## Why memcached is not available
+
+The **first failure** is the SCC rejection, so no pod is created at all.  
+Even after fixing that, the workload would still be blocked by the **Pending PVC** unless the storage class is corrected.
+
+## Fix / mitigation
+
+### 1. Fix the pod security settings
+Update `Deployment/cache-tier/memcached`:
+
+- Remove hard-coded `runAsUser: 65532` from init container, or set a valid namespace-assigned UID
+- Set pod-level:
+  - `spec.template.spec.hostUsers: false`
+- Keep restricted-compatible security settings:
+  - `runAsNonRoot: true`
+  - `allowPrivilegeEscalation: false`
+  - `capabilities.drop: ["ALL"]`
+
+### 2. Fix the PVC storage class
+Update `PersistentVolumeClaim/cache-tier/memcached-data-pvc` to use an existing class, likely:
+- `gp3-csi` (default)
+
+Because `storageClassName` on an existing PVC is effectively immutable for this use case, the usual fix is:
+- delete and recreate the PVC with the correct `storageClassName`
+- or create a new PVC and update the Deployment to reference it
+
+## Recommended order
+
+1. Fix Deployment SCC compatibility
+2. Recreate/fix the PVC to use `gp3-csi`
+3. Reconcile the Deployment and verify the pod is created and becomes Ready
+
+If you want, I can apply the fixes for the Deployment and PVC.
+````
+
+[Back to top](#evaluation-summary)
+
+## timeout_connections
+
+Frontend logs connection timeouts to the backend, which appears
+healthy.
+RCA: a NetworkPolicy only allows ingress from pods labelled
+tier=backend; the frontend has tier=frontend, so traffic is
+blocked.
+Expected: update the NetworkPolicy ingress rule to allow
+tier=frontend.
+
+**Tags**: `difficulty_normal`, `core`, `classic`
+
+### Query
+
+```
+The frontend in service-mesh cannot reach backend-service. Can you investigate the cause?
+```
+
+<a id="gpt-5.2--timeout_connections"></a>
+
+### gpt-5.2
+
+**Correctness**: ✅ PASS (score: 1.00)
+
+> Custom answer correctness: 1.00 - The response is fully correct and matches the expected diagnosis exactly. It identifies the root cause as the `backend-network-policy` NetworkPolicy, explains that it selects backend pods and only permits ingress from pods labeled `tier=backend`, and correctly contrasts that with the frontend pod’s `tier=frontend` label. This directly explains why traffic from the frontend to `backend-service` is blocked.
+
+**Latency**: 1m 4s
+
+**Tokens**: 86,126
+
+````markdown
+### Evidence (what’s failing)
+- `frontend` pod is timing out to both the Service VIP and directly to the backend pod:
+  - Pod: `service-mesh/frontend-6cbbd65959-6s9zd`
+  - Backend Service VIP: `backend-service` (`172.30.219.100:8080`)
+  - Backend Pod IP: `10.128.2.102:8080`
+  - `wget` output: `download timed out` (to both addresses)
+
+- The backend pod is actually *listening* on port 8080:
+  - Pod: `service-mesh/backend-54d6d7b87c-n5hz6`
+  - `/proc/net/tcp` shows `0.0.0.0:8080` in `LISTEN` state.
+
+### Root cause
+A **NetworkPolicy is blocking ingress to the backend pods from the frontend pods**.
+
+- NetworkPolicy: `service-mesh/backend-network-policy`
+- It selects backend pods: `podSelector: matchLabels: app=backend`
+- It only allows ingress **from pods with `tier=backend`** on TCP/8080:
+  ```yaml
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          tier: backend
+    ports:
+    - port: 8080
+  policyTypes: ["Ingress"]
+  ```
+- Your frontend pod has `tier=frontend`, so it is **not allowed** to connect, resulting in the timeouts.
+
+### Fix / mitigation
+Update the NetworkPolicy to allow traffic from the frontend to backend on 8080 (choose one):
+
+1) **Allow from frontend by label** (recommended)
+- Add an additional `from` rule permitting `tier=frontend` (or `app=frontend`), e.g.:
+  - allow `podSelector: matchLabels: tier: frontend` on port 8080
+
+2) **Temporarily remove the restrictive policy** (fastest, less safe)
+- Delete `backend-network-policy` to confirm connectivity returns, then re-create with correct `from` selectors.
+
+If you tell me what label you want to use as the “allowed client” identity (e.g., `app=frontend` vs `tier=frontend`), I can provide the exact corrected YAML.
+````
+
+<a id="gpt-5.4--timeout_connections"></a>
+
+### gpt-5.4
+
+**Correctness**: ✅ PASS (score: 1.00)
+
+> Custom answer correctness: 1.00 - The response is fully correct and aligns exactly with the expected answer. It identifies the root cause as the `backend-network-policy` NetworkPolicy, which permits ingress to `app=backend` pods only from pods labeled `tier=backend`. It also correctly notes that the `frontend` pod has `tier=frontend`, so its traffic is denied.
+
+**Latency**: 39s
+
+**Tokens**: 55,645
+
+````markdown
+Diagnosis: ingress to `backend` is blocked by a `NetworkPolicy` in `service-mesh`.
+
+**Evidence**
+- `frontend` pod: `frontend-6cbbd65959-6s9zd`, labels `app=frontend,tier=frontend`
+- `backend` pod: `backend-54d6d7b87c-n5hz6`, labels `app=backend,tier=backend`
+- Service `backend-service` exists and has a live endpoint:
+  - ClusterIP: `172.30.219.100`
+  - Endpoint: `10.128.2.102:8080`
+- DNS from `frontend` resolves correctly:
+  - `backend-service.service-mesh.svc.cluster.local -> 172.30.219.100`
+- `backend` is actually listening on `8080`:
+  - `/etc/nginx/conf.d/default.conf`: `listen 8080;`
+  - `/proc/net/tcp` in the backend pod shows `0.0.0.0:8080` in `LISTEN`
+- Connectivity still fails from `frontend`:
+  - `wget` in `frontend` logs: `can't connect to remote host (172.30.219.100): Connection refused`
+  - direct connect test from `frontend` to backend pod IP: `10.128.2.102:8080: Connection timed out`
+  - service connect test from `frontend`: `backend-service:8080: Connection timed out`
+
+**Root cause**
+`NetworkPolicy/backend-network-policy` allows ingress to pods with `app=backend` **only from pods with `tier=backend`**:
+
+```yaml
+spec:
+  podSelector:
+    matchLabels:
+      app: backend
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          tier: backend
+    ports:
+    - port: 8080
+```
+
+`frontend` has `tier=frontend`, so it is denied by policy.
+
+**Fix**
+Update `backend-network-policy` to allow `frontend` traffic, for example by permitting pods with `app=frontend` or `tier=frontend`.
+
+Example minimal change:
+```yaml
+ingress:
+- from:
+  - podSelector:
+      matchLabels:
+        app: frontend
+  ports:
+  - port: 8080
+    protocol: TCP
+```
+
+Or broader:
+```yaml
+ingress:
+- from:
+  - podSelector:
+      matchLabels:
+        tier: frontend
+  - podSelector:
+      matchLabels:
+        tier: backend
+  ports:
+  - port: 8080
+    protocol: TCP
+```
+
+**Conclusion**
+The issue is not DNS, not the Service, and not the backend process. The blocking component is `NetworkPolicy/backend-network-policy` in `service-mesh`.
+````
+
+[Back to top](#evaluation-summary)
+
+## unbalanced_replicas
+
+Two namespaces expected to have the same pod count show different
+counts.
+RCA: fleet-alpha has 6 pods, fleet-alpha1 has 9 pods (3 extra
+pods from 6 additional workloads).
+Expected: identify the discrepancy and report which extra
+workloads exist in fleet-alpha1.
+
+**Tags**: `core`, `difficulty_normal`, `classic`
+
+### Query
+
+```
+fleet-alpha and fleet-alpha1 should have the same number of running pods, but the counts appear different. Can you investigate the discrepancy?
+```
+
+<a id="gpt-5.2--unbalanced_replicas"></a>
+
+### gpt-5.2
+
+**Correctness**: ✅ PASS (score: 0.95)
+
+> Custom answer correctness: 0.95 - The response is largely correct and aligns well with the expected answer. It correctly states that:
+
+**Latency**: 37s
+
+**Tokens**: 72,649
+
+````markdown
+### Evidence (current running pod counts)
+
+- **Project/namespace `fleet-alpha`**: **6 Running pods**
+  - From Deployments (2):  
+    - `dispatcher-north-85d8df8df4-8nklj` (Deployment `dispatcher-north`)  
+    - `dispatcher-south-5d57f9d8-2zc4n` (Deployment `dispatcher-south`)
+  - **Standalone (unmanaged) Pods (4)** *(no ownerReferences; created directly as Pods)*:  
+    - `logger-central`  
+    - `scheduler-main`  
+    - `tracker-primary`  
+    - `tracker-secondary`
+
+- **Project/namespace `fleet-alpha1`**: **9 Running pods**
+  - All are from **Deployments (9)** (each at 1 replica):
+    - `cache-handler-55758689b4-9lqfs` (Deployment `cache-handler`)
+    - `ingestion-node-85b56fdd9b-v7dmx` (Deployment `ingestion-node`)
+    - `output-node-79cf45dd5c-kj9lj` (Deployment `output-node`)
+    - `proxy-router-5cf87b8bbf-gswdf` (Deployment `proxy-router`)
+    - `store-primary-8c8d5cc95-v6n9b` (Deployment `store-primary`)
+    - `store-replica-7bb964bc6f-tt5m2` (Deployment `store-replica`)
+    - `transform-node-5d96dbffb6-pw8ml` (Deployment `transform-node`)
+    - `validator-east-767c4ff59-d6vc8` (Deployment `validator-east`)
+    - `validator-west-57775958bf-rhlzj` (Deployment `validator-west`)
+
+### What’s causing the discrepancy
+
+This is **not** a “some pods failed to run” situation—everything listed is Running.
+
+The counts differ because the two namespaces do **not** have the same set of workloads:
+
+1. **`fleet-alpha1` has 9 Deployments** (=> 9 managed pods).
+2. **`fleet-alpha` has only 2 Deployments**, plus **4 standalone Pods** that are not managed by a controller.
+
+So the “expected same number of running pods” assumption doesn’t match what’s actually deployed in each namespace.
+
+### Fix / Mitigation (how to make them match)
+
+Decide what the *intended* topology is, then align one namespace to the other:
+
+- If **`fleet-alpha` should look like `fleet-alpha1`**: create the missing Deployments in `fleet-alpha` (`cache-handler`, `ingestion-node`, `output-node`, `proxy-router`, `store-primary`, `store-replica`, `transform-node`, `validator-east`, `validator-west`) and/or remove components that shouldn’t be there.
+- If **`fleet-alpha1` should look like `fleet-alpha`**: remove the extra Deployments in `fleet-alpha1` (7 more than `fleet-alpha`’s 2 Deployments).
+
+Also: the 4 standalone pods in `fleet-alpha` (`logger-central`, `scheduler-main`, `tracker-primary`, `tracker-secondary`) should ideally be converted into Deployments/StatefulSets if they’re meant to be long-running services—standalone pods won’t be recreated elsewhere if deleted (no controller to reconcile desired state).
+
+If you tell me which namespace is the “source of truth” (or what the expected component list is), I can point out exactly what to add/remove to make the pod counts equal.
+````
+
+<a id="gpt-5.4--unbalanced_replicas"></a>
+
+### gpt-5.4
+
+**Correctness**: ✅ PASS (score: 0.95)
+
+> Custom answer correctness: 0.95 - The response is highly consistent with the expected answer and correctly identifies the key discrepancy:
+
+**Latency**: 26s
+
+**Tokens**: 139,110
+
+````markdown
+I investigated both namespaces.
+
+**Current running pod counts**
+- **fleet-alpha:** **6** running pods
+- **fleet-alpha1:** **9** running pods
+
+### Evidence
+
+**fleet-alpha pods**
+1. `dispatcher-north-85d8df8df4-8nklj` — owned by Deployment `dispatcher-north`
+2. `dispatcher-south-5d57f9d8-2zc4n` — owned by Deployment `dispatcher-south`
+3. `logger-central` — **standalone Pod**
+4. `scheduler-main` — **standalone Pod**
+5. `tracker-primary` — **standalone Pod**
+6. `tracker-secondary` — **standalone Pod**
+
+**fleet-alpha workloads**
+- Deployments:
+  - `dispatcher-north` → 1 replica available
+  - `dispatcher-south` → 1 replica available
+- ReplicaSets:
+  - `dispatcher-north-85d8df8df4` → desired 1, ready 1
+  - `dispatcher-south-5d57f9d8` → desired 1, ready 1
+
+**fleet-alpha1 pods**
+1. `cache-handler-55758689b4-9lqfs`
+2. `ingestion-node-85b56fdd9b-v7dmx`
+3. `output-node-79cf45dd5c-kj9lj`
+4. `proxy-router-5cf87b8bbf-gswdf`
+5. `store-primary-8c8d5cc95-v6n9b`
+6. `store-replica-7bb964bc6f-tt5m2`
+7. `transform-node-5d96dbffb6-pw8ml`
+8. `validator-east-767c4ff59-d6vc8`
+9. `validator-west-57775958bf-rhlzj`
+
+**fleet-alpha1 workloads**
+- 9 Deployments, each at **1/1 available**
+- 9 ReplicaSets, each at **desired 1 / ready 1**
+
+### Root cause
+
+The discrepancy is **not due to failed or stuck pods**. Both namespaces are healthy from a pod-status perspective.
+
+The real difference is the **workload definitions are different**:
+
+1. **`fleet-alpha` has only 2 Deployment-managed pods**
+   - `dispatcher-north`
+   - `dispatcher-south`
+
+2. **`fleet-alpha` also has 4 manually created standalone Pods**
+   - `logger-central`
+   - `scheduler-main`
+   - `tracker-primary`
+   - `tracker-secondary`
+
+   These pods have `kubectl.kubernetes.io/last-applied-configuration` annotations and **no ownerReferences**, which confirms they were created directly as Pods rather than by a Deployment/StatefulSet.
+
+3. **`fleet-alpha1` has 9 Deployment-managed pods**
+   - no standalone pods
+   - all pods are owned by ReplicaSets from Deployments
+
+So the count mismatch comes from **configuration drift between the namespaces**, not runtime failure.
+
+### Additional observations
+- All listed pods in both namespaces are `Running` and `Ready`
+- `fleet-alpha` events show only normal scheduling/startup events for its pods
+- No evidence that missing pods in either namespace are crash-looping or pending
+
+### Fix / mitigation
+
+If these namespaces are supposed to be identical, reconcile the manifests:
+
+- Either **add the missing workloads to `fleet-alpha`**
+- Or **remove the extra/non-matching workloads**
+- Prefer converting the 4 standalone pods in `fleet-alpha` into managed workloads (Deployments/StatefulSets) if they are meant to persist:
+  - `logger-central`
+  - `scheduler-main`
+  - `tracker-primary`
+  - `tracker-secondary`
+
+### Bottom line
+
+**The counts differ because the namespaces do not contain the same set of workloads.**
+- `fleet-alpha` = 2 Deployment pods + 4 standalone pods = **6**
+- `fleet-alpha1` = 9 Deployment pods = **9**
+
+If you want, I can next map which specific workloads are missing on each side and produce a namespace-to-namespace diff.
+````
+
+[Back to top](#evaluation-summary)
+
+## unready_pod
+
+Alert fires for a pod in not-ready state.
+RCA: the readiness probe does an HTTP GET on port 9200 but the
+container is a simple echo/sleep loop with no HTTP server.
+Expected: remove the readiness probe or replace it with an exec
+probe appropriate for the container.
+
+**Tags**: `core`, `alert`, `classic`, `difficulty_normal`
+
+### Query
+
+```
+The catalog indexing workload in discovery-hub never becomes available. Can you investigate the cause?
+```
+
+<a id="gpt-5.2--unready_pod"></a>
+
+### gpt-5.2
+
+**Correctness**: ✅ PASS (score: 1.00)
+
+> Custom answer correctness: 1.00 - The response is fully correct and matches the expected response exactly in substance. It identifies the key issue: the `catalog-index-service` pod is not becoming Ready because its readiness probe performs an HTTP GET on `/healthz` at port `9200`, but the container is only running a `busybox` loop and does not start any HTTP server on that port. That directly explains why the probe gets `connection refused` and why the workload never becomes available.
+
+**Latency**: 24s
+
+**Tokens**: 16,002
+
+````markdown
+### Evidence (what’s failing)
+- In `discovery-hub`, the only indexing-related workload I see is the Pod **`catalog-index-service`**:
+  - Pod status: **`Running`**, but **`READY 0/1`** (`ContainersNotReady`)
+- Namespace events show repeated readiness probe failures:
+  - **`Readiness probe failed: Get "http://10.128.2.120:9200/healthz": dial tcp 10.128.2.120:9200: connect: connection refused`**
+- Pod spec confirms why the probe fails:
+  - Container image: **`busybox:1.36`**
+  - Container command: **`sh -c "while true; do echo 'Running...'; sleep 5; done"`**
+  - Readiness probe: HTTP GET **`/healthz`** on port **`9200`**
+- Container logs are only:
+  - `Running...` (no indication anything is listening on port 9200)
+
+### Root cause
+The Pod’s **readiness probe checks an HTTP endpoint on port 9200**, but the container **never starts a process that listens on port 9200** (it only runs an infinite sleep/echo loop). Therefore the probe always gets **connection refused**, and the Pod never becomes Ready/Available.
+
+### Fix / mitigation
+Pick one (depending on what this “catalog indexing” workload is supposed to do):
+
+1. **Fix the container to actually run the catalog indexing service** that exposes `:9200/healthz` (most likely the intended solution).
+2. If this is a placeholder/smoke-test Pod, **change the readiness probe** to something that matches reality, e.g. an `exec` probe, or remove the readiness probe entirely.
+3. If you just need the current Pod to become Ready for testing, run something that listens on 9200 (temporary), and/or adjust the probe to the port/path your process serves.
+
+If you tell me what image/process the real catalog indexer should run (or if there is a Deployment/Operator that should own it), I can check why that intended controller isn’t creating the correct workload (right now this Pod appears to be a standalone Pod, not managed by a Deployment/StatefulSet in this namespace).
+````
+
+<a id="gpt-5.4--unready_pod"></a>
+
+### gpt-5.4
+
+**Correctness**: ✅ PASS (score: 0.98)
+
+> Custom answer correctness: 0.98 - The response is essentially correct and aligns very closely with the expected answer.
+
+**Latency**: 24s
+
+**Tokens**: 30,362
+
+````markdown
+I investigated `discovery-hub/catalog-index-service`.
+
+**Root cause**
+
+The indexing workload is a **standalone Pod**, not a Deployment/StatefulSet/ReplicaSet, and its container never starts any service on the readiness port.
+
+**Evidence**
+
+1. **The pod exists but never becomes Ready**
+   - Pod: `discovery-hub/catalog-index-service`
+   - Status: `Running`
+   - Ready: `0/1`
+   - Alert firing: `DiscoveryHubPodNotReady`
+   - Pod condition:
+     - `Ready=False`
+     - `ContainersReady=False`
+
+2. **Readiness probe is failing because nothing is listening on port 9200**
+   - Event:
+     - `Readiness probe failed: Get "http://10.128.2.120:9200/healthz": dial tcp 10.128.2.120:9200: connect: connection refused`
+
+3. **The container command does not run an index service**
+   - Container image: `busybox:1.36`
+   - Container command:
+     - `sh -c while true; do echo 'Running...'; sleep 5; done`
+   - Pod logs only show:
+     - `Running...`
+   - Exec check inside the pod:
+     - `wget http://127.0.0.1:9200/healthz` → `Connection refused`
+
+4. **There is no owning workload/controller**
+   - No Deployment in `discovery-hub`
+   - No StatefulSet in `discovery-hub`
+   - No ReplicaSet in `discovery-hub`
+
+5. **The pod spec itself confirms the mismatch**
+   - It declares:
+     - container port `9200`
+     - readiness probe `GET /healthz` on port `9200`
+   - But the actual process is only a shell loop and does not expose HTTP at all.
+
+**Conclusion**
+
+`catalog-index-service` never becomes available because the pod spec is wrong for the intended workload:
+- it runs `busybox` instead of a catalog indexing service image
+- it executes an infinite shell loop instead of starting the application
+- the readiness probe expects an HTTP endpoint on `:9200/healthz`, but no process is listening there
+
+**Fix / mitigation**
+
+1. **Replace the pod with the correct workload definition**
+   - Use the real catalog indexing service image
+   - Start the actual application process
+   - Keep the readiness probe only if the app really exposes `http://:9200/healthz`
+
+2. **If this pod is only a placeholder/test object**
+   - Remove it, or
+   - Change/remove the readiness probe so it matches what the container actually does
+
+3. **Use a controller instead of a naked pod**
+   - Prefer a Deployment so the workload is managed and easier to update/debug
+
+**Most likely intended correction**
+- The container should launch the real index service binary/process
+- That process must listen on port `9200`
+- `/healthz` must return success for readiness
+
+If you want, I can also help draft a corrected Deployment/Pod spec for `catalog-index-service`.
+````
+
+[Back to top](#evaluation-summary)

--- a/agentic/system-ols-classic.yaml
+++ b/agentic/system-ols-classic.yaml
@@ -1,0 +1,53 @@
+logging:
+  source_level: DEBUG
+
+core:
+  max_threads: 3
+  fail_on_invalid_data: true
+  skip_on_failure: false
+  cache_enabled: false
+
+llm_pool:
+  defaults:
+    parameters:
+      max_completion_tokens: 1000
+  models:
+    judge:
+      provider: openai
+      model: gpt-5.4
+
+judge_panel:
+  judges: [judge]
+
+agents:
+  enabled: true
+  default:
+    agent: [gpt-5.4, gpt-5.2]
+    repeat: 1
+    parallel: true
+    agent_config:
+      timeout: 300
+  gpt-5.4:
+    type: http_api
+    api_base: https://localhost:8443
+    endpoint_type: query
+    provider: openai
+    model: gpt-5.4
+    extra_request_params:
+      mode: troubleshooting
+  gpt-5.2:
+    type: http_api
+    api_base: https://localhost:8443
+    endpoint_type: query
+    provider: openai
+    model: gpt-5.2
+    extra_request_params:
+      mode: troubleshooting
+
+storage:
+  - type: file
+    output_dir: ./eval_output
+    enabled_outputs: [csv, json]
+
+environment:
+  LITELLM_LOG: ERROR

--- a/agentic/timeout_connections/evals-ols-classic.yaml
+++ b/agentic/timeout_connections/evals-ols-classic.yaml
@@ -1,0 +1,25 @@
+- conversation_group_id: timeout_connections
+  description: |
+    Frontend logs connection timeouts to the backend, which appears
+    healthy.
+    RCA: a NetworkPolicy only allows ingress from pods labelled
+    tier=backend; the frontend has tier=frontend, so traffic is
+    blocked.
+    Expected: update the NetworkPolicy ingress rule to allow
+    tier=frontend.
+  tag:
+    - classic
+    - core
+    - difficulty_normal
+
+  turns:
+    - turn_id: investigate_connectivity
+      query: >-
+        The frontend in service-mesh cannot reach backend-service. Can you
+        investigate the cause?
+      expected_response: >-
+        The backend-network-policy NetworkPolicy only allows ingress from pods
+        with tier=backend. The frontend pod has tier=frontend, so the policy
+        blocks its traffic to backend-service.
+      turn_metrics:
+        - custom:answer_correctness

--- a/agentic/unbalanced_replicas/evals-ols-classic.yaml
+++ b/agentic/unbalanced_replicas/evals-ols-classic.yaml
@@ -1,0 +1,28 @@
+- conversation_group_id: unbalanced_replicas
+  description: |
+    Two namespaces expected to have the same pod count show different
+    counts.
+    RCA: fleet-alpha has 6 pods, fleet-alpha1 has 9 pods (3 extra
+    pods from 6 additional workloads).
+    Expected: identify the discrepancy and report which extra
+    workloads exist in fleet-alpha1.
+  tag:
+    - classic
+    - core
+    - difficulty_normal
+
+  turns:
+    - turn_id: compare_namespace_pod_counts
+      query: >-
+        fleet-alpha and fleet-alpha1 should have the same number of running
+        pods, but the counts appear different. Can you investigate the
+        discrepancy?
+      expected_response: >-
+        fleet-alpha has 6 running pods, while fleet-alpha1 has 9, so
+        fleet-alpha1 has 3 more pods. fleet-alpha1 has 9 one-replica
+        Deployments, including the additional workloads store-primary,
+        store-replica, cache-handler, proxy-router, validator-east, and
+        validator-west. fleet-alpha has 2 one-replica Deployments and 4
+        standalone Pods.
+      turn_metrics:
+        - custom:answer_correctness

--- a/agentic/unready_pod_alert/evals-ols-classic.yaml
+++ b/agentic/unready_pod_alert/evals-ols-classic.yaml
@@ -1,0 +1,24 @@
+- conversation_group_id: unready_pod
+  description: |
+    Alert fires for a pod in not-ready state.
+    RCA: the readiness probe does an HTTP GET on port 9200 but the
+    container is a simple echo/sleep loop with no HTTP server.
+    Expected: remove the readiness probe or replace it with an exec
+    probe appropriate for the container.
+  tag:
+    - classic
+    - core
+    - alert
+    - difficulty_normal
+
+  turns:
+    - turn_id: investigate_unready_pod
+      query: >-
+        The catalog indexing workload in discovery-hub never becomes available.
+        Can you investigate the cause?
+      expected_response: >-
+        The catalog-index-service pod is not Ready because its HTTP readiness
+        probe checks /healthz on port 9200, but the container does not run an
+        HTTP server on that port.
+      turn_metrics:
+        - custom:answer_correctness

--- a/scripts/generate-report-agentic.py
+++ b/scripts/generate-report-agentic.py
@@ -309,6 +309,20 @@ def mean_duration(agent_amended: list, conversations: list[str]) -> float | None
     return sum(durations) / len(durations)
 
 
+def format_tokens(n: int) -> str:
+    return f"{n:,}"
+
+
+def format_tokens_compact(n: int) -> str:
+    if n >= 1_000_000:
+        v = n / 1_000_000
+        return f"{v:.1f}M".replace(".0M", "M")
+    if n >= 1_000:
+        v = n / 1_000
+        return f"{v:.0f}K"
+    return str(n)
+
+
 def format_duration(seconds: float) -> str:
     if seconds < 60:
         return f"{seconds:.0f}s"
@@ -431,7 +445,7 @@ def generate_overview_table(
 
     # Avg tokens
     avg_tok = {a: mean_tokens(agent_amended[a], conversations) for a in agent_names}
-    cells = [str(avg_tok[a]) if avg_tok[a] is not None else "N/A" for a in agent_names]
+    cells = [format_tokens_compact(avg_tok[a]) if avg_tok[a] is not None else "N/A" for a in agent_names]
     lines.append(f"| Avg tokens | {' | '.join(cells)} |")
 
     return "\n".join(lines)
@@ -621,7 +635,7 @@ def generate_duration_table(
 def tokens_cell(agent_amended: list, cid: str, agent: str) -> str:
     t = scenario_tokens(agent_amended, cid)
     anchor = anchor_id(agent, cid)
-    return f"[{t}](#{anchor})"
+    return f"[{format_tokens_compact(t)}](#{anchor})"
 
 
 def generate_tokens_table(
@@ -639,7 +653,7 @@ def generate_tokens_table(
 
     # Mean row
     avg_tok = {a: mean_tokens(agent_amended[a], conversations) for a in agent_names}
-    cells = [str(avg_tok[a]) if avg_tok[a] is not None else "N/A" for a in agent_names]
+    cells = [format_tokens_compact(avg_tok[a]) if avg_tok[a] is not None else "N/A" for a in agent_names]
     lines.append(f"| **Average** | {' | '.join(cells)} |")
 
     return "\n".join(lines)

--- a/scripts/generate-report-agentic.py
+++ b/scripts/generate-report-agentic.py
@@ -766,7 +766,8 @@ def generate_scenario_details(
                 conv_results = [r for r in results if r["conversation_group_id"] == cid]
                 for r in conv_results:
                     result_icon = "✅" if r["result"] == "PASS" else "❌"
-                    score_str = f"{r['score']:.2f}" if r["score"] is not None else "N/A"
+                    score = r.get("score")
+                    score_str = f"{score:.2f}" if score is not None else "N/A"
                     lines.append(
                         f"**{metric_label(r['metric_identifier'])}**: "
                         f"{result_icon} {r['result']} (score: {score_str})"

--- a/scripts/generate-report-classic.py
+++ b/scripts/generate-report-classic.py
@@ -1,0 +1,810 @@
+#!/usr/bin/env python3
+"""Generate a Markdown report from NxM OLS Classic evaluation output.
+
+Reads the eval session directory produced by lightspeed-eval and
+generates a comparative report across agents and runs.
+
+Unlike agentic evals, classic evals use a single metric
+(custom:answer_correctness) and derive duration from agent_latency
+in the results JSON.
+
+Usage:
+    python3 generate-report-classic.py EVAL_DIR [--output FILE]
+
+EVAL_DIR is the eval session directory
+(e.g., results/ols-classic/20260904_124503/).
+"""
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+CORRECTNESS_METRIC = "custom:answer_correctness"
+
+
+def discover_agents(eval_dir: Path) -> list[str]:
+    """Discover agent names from subdirectories containing run_* dirs."""
+    agents = []
+    for child in sorted(eval_dir.iterdir()):
+        if child.is_dir() and any(child.glob("run_*")):
+            agents.append(child.name)
+    return agents
+
+
+def find_run_dirs(eval_dir: Path, agent_name: str) -> list[Path]:
+    """Find run_N directories for an agent, sorted by index."""
+    agent_dir = eval_dir / agent_name
+    if not agent_dir.is_dir():
+        return []
+    dirs = sorted(agent_dir.glob("run_*"), key=lambda p: int(p.name.split("_")[1]))
+    return dirs
+
+
+def load_run_summary(run_dir: Path) -> list[dict] | None:
+    """Load results from all summary JSONs in a run directory."""
+    files = sorted(run_dir.glob("*_summary.json"))
+    if not files:
+        return None
+    results = []
+    for f in files:
+        with open(f) as fh:
+            data = json.load(fh)
+        results.extend(data.get("results", []))
+    return results
+
+
+def extract_judge_model(eval_dir: Path, agent_names: list[str]) -> str:
+    """Extract the judge model name from the first available summary JSON."""
+    for agent in agent_names:
+        for rd in find_run_dirs(eval_dir, agent):
+            for f in sorted(rd.glob("*_summary.json")):
+                with open(f) as fh:
+                    data = json.load(fh)
+                config = data.get("configuration", {})
+                judges = config.get("judge_panel", {}).get("judges", [])
+                if not judges:
+                    continue
+                models = config.get("llm_pool", {}).get("models", {})
+                model = models.get(judges[0], {}).get("model", "")
+                if model:
+                    return model
+    return ""
+
+
+def load_amended_entries(run_dir: Path) -> list[dict]:
+    """Load conversation entries from all amended YAMLs in a run directory."""
+    files = sorted(run_dir.glob("*amended*.yaml"))
+    if not files:
+        return []
+    entries = []
+    for path in files:
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, list):
+            continue
+        for entry in data:
+            cid = entry.get("conversation_group_id", "")
+            turns = entry.get("turns", [])
+            tags = entry.get("tag", [])
+            if not turns:
+                continue
+            turn = turns[0]
+            agent_tok = (turn.get("api_input_tokens") or 0) + (turn.get("api_output_tokens") or 0)
+
+            entries.append({
+                "conversation_group_id": cid,
+                "description": entry.get("description", ""),
+                "query": turn.get("query", ""),
+                "response": turn.get("response", ""),
+                "tags": tags,
+                "agent_latency": turn.get("agent_latency"),
+                "agent_tokens": agent_tok,
+            })
+    return entries
+
+
+def collect_conversations(agent_runs: dict[str, list]) -> list[str]:
+    """Collect ordered unique conversation IDs across all agents/runs."""
+    seen = set()
+    conversations = []
+    for runs in agent_runs.values():
+        for results in runs:
+            if results is None:
+                continue
+            for r in results:
+                cid = r["conversation_group_id"]
+                if cid not in seen:
+                    seen.add(cid)
+                    conversations.append(cid)
+    return conversations
+
+
+def get_score(results: list[dict], conversation_id: str) -> float | None:
+    for r in results:
+        if r["conversation_group_id"] == conversation_id and r["metric_identifier"] == CORRECTNESS_METRIC:
+            return r.get("score")
+    return None
+
+
+def get_result(results: list[dict], conversation_id: str) -> str | None:
+    for r in results:
+        if r["conversation_group_id"] == conversation_id and r["metric_identifier"] == CORRECTNESS_METRIC:
+            return r.get("result")
+    return None
+
+
+def get_judge_reason(results: list[dict], conversation_id: str) -> str:
+    for r in results:
+        if r["conversation_group_id"] == conversation_id and r["metric_identifier"] == CORRECTNESS_METRIC:
+            for js in r.get("judge_scores") or []:
+                reason = js.get("reason", "")
+                if reason:
+                    return reason
+    return ""
+
+
+def get_agent_latency(results: list[dict], conversation_id: str) -> float | None:
+    for r in results:
+        if r["conversation_group_id"] == conversation_id and r["metric_identifier"] == CORRECTNESS_METRIC:
+            return r.get("agent_latency")
+    return None
+
+
+def anchor_id(agent: str, conversation_id: str) -> str:
+    return f"{agent}--{conversation_id}"
+
+
+def score_cell(agent_runs: list, conversation_id: str, agent: str) -> str:
+    scores = []
+    for results in agent_runs:
+        if results is None:
+            continue
+        score = get_score(results, conversation_id)
+        result = get_result(results, conversation_id)
+        if result is not None:
+            scores.append((result, score))
+
+    if not scores:
+        return "N/A"
+
+    anchor = anchor_id(agent, conversation_id)
+
+    if len(scores) == 1:
+        result, score = scores[0]
+        icon = "✅" if result == "PASS" else "❌"
+        score_str = f"{score:.2f}" if score is not None else "N/A"
+        return f"[{icon} {score_str}](#{anchor})"
+
+    passed = sum(1 for r, _ in scores if r == "PASS")
+    total = len(scores)
+    valid_scores = [s for _, s in scores if s is not None]
+    avg = sum(valid_scores) / len(valid_scores) if valid_scores else None
+    icon = "✅" if passed == total else ("❌" if passed == 0 else "")
+    avg_str = f" ({avg:.2f})" if avg is not None else ""
+    return f"[{icon} {passed}/{total}](#{anchor}){avg_str}"
+
+
+def format_timestamp(timestamp: str) -> str:
+    if not timestamp:
+        return ""
+    dt = datetime.fromisoformat(timestamp)
+    return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def format_tokens(n: int) -> str:
+    return f"{n:,}"
+
+
+def format_tokens_compact(n: int) -> str:
+    if n >= 1_000_000:
+        v = n / 1_000_000
+        return f"{v:.1f}M".replace(".0M", "M")
+    if n >= 1_000:
+        v = n / 1_000
+        return f"{v:.0f}K"
+    return str(n)
+
+
+def format_duration(seconds: float) -> str:
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    minutes = int(seconds // 60)
+    secs = int(seconds % 60)
+    return f"{minutes}m {secs}s"
+
+
+def overall_score(agent_runs: list, conversations: list[str]) -> tuple[int, int]:
+    passed = 0
+    total = 0
+    for results in agent_runs:
+        if results is None:
+            continue
+        for cid in conversations:
+            result = get_result(results, cid)
+            if result is not None:
+                total += 1
+                if result == "PASS":
+                    passed += 1
+    return passed, total
+
+
+def overall_score_cell(passed: int, total: int, bold: bool = False) -> str:
+    if total == 0:
+        return "N/A"
+    pct = round(100 * passed / total)
+    if passed == total:
+        icon = "✅ "
+    elif passed == 0:
+        icon = "❌ "
+    else:
+        icon = ""
+    text = f"{icon}{pct}% ({passed}/{total})"
+    if bold:
+        text = f"**{text}**"
+    return text
+
+
+def scenario_mean_score(agent_runs: list, conversation_id: str) -> float | None:
+    scores = []
+    for results in agent_runs:
+        if results is None:
+            continue
+        s = get_score(results, conversation_id)
+        if s is not None:
+            scores.append(s)
+    return sum(scores) / len(scores) if scores else None
+
+
+def mean_score(agent_runs: list, conversations: list[str]) -> float | None:
+    scores = []
+    for results in agent_runs:
+        if results is None:
+            continue
+        for cid in conversations:
+            s = get_score(results, cid)
+            if s is not None:
+                scores.append(s)
+    if not scores:
+        return None
+    return sum(scores) / len(scores)
+
+
+def scenario_latency(agent_runs: list, conversation_id: str) -> float | None:
+    """Mean agent_latency for a single scenario across runs."""
+    latencies = []
+    for results in agent_runs:
+        if results is None:
+            continue
+        lat = get_agent_latency(results, conversation_id)
+        if lat is not None:
+            latencies.append(lat)
+    return sum(latencies) / len(latencies) if latencies else None
+
+
+def mean_latency(agent_runs: list, conversations: list[str]) -> float | None:
+    latencies = []
+    for results in agent_runs:
+        if results is None:
+            continue
+        for cid in conversations:
+            lat = get_agent_latency(results, cid)
+            if lat is not None:
+                latencies.append(lat)
+    if not latencies:
+        return None
+    return sum(latencies) / len(latencies)
+
+
+def scenario_tokens(agent_amended: list, cid: str) -> int:
+    total = 0
+    for entries in agent_amended:
+        for entry in entries:
+            if entry["conversation_group_id"] == cid:
+                total += entry.get("agent_tokens", 0)
+    return total
+
+
+def total_tokens(agent_amended: list, conversations: list[str]) -> int:
+    total = 0
+    for entries in agent_amended:
+        for entry in entries:
+            if entry["conversation_group_id"] in conversations:
+                total += entry.get("agent_tokens", 0)
+    return total
+
+
+def mean_tokens(agent_amended: list, conversations: list[str]) -> int | None:
+    tokens = []
+    for entries in agent_amended:
+        for entry in entries:
+            if entry["conversation_group_id"] in conversations and entry.get("agent_tokens") is not None:
+                tokens.append(entry["agent_tokens"])
+    if not tokens:
+        return None
+    return round(sum(tokens) / len(tokens))
+
+
+def generate_overview_table(
+    conversations: list[str],
+    agent_names: list[str],
+    agent_runs: dict[str, list],
+    agent_amended: dict[str, list],
+) -> str:
+    header = "| | " + " | ".join(agent_names) + " |"
+    separator = "|---|" + "|".join("---" for _ in agent_names) + "|"
+    lines = [header, separator]
+
+    # Pass rate %
+    scores_map = {a: overall_score(agent_runs[a], conversations) for a in agent_names}
+    pcts = {a: round(100 * p / t) if t > 0 else None for a, (p, t) in scores_map.items()}
+    best_pct = max((v for v in pcts.values() if v is not None), default=None)
+    cells = []
+    for a in agent_names:
+        if pcts[a] is None:
+            cells.append("N/A")
+        else:
+            text = f"{pcts[a]}%"
+            if pcts[a] == best_pct:
+                text = f"**{text}**"
+            cells.append(text)
+    lines.append(f"| Pass rate | {' | '.join(cells)} |")
+
+    # Mean score
+    mean_scores = {a: mean_score(agent_runs[a], conversations) for a in agent_names}
+    best_mean = max((s for s in mean_scores.values() if s is not None), default=None)
+    cells = []
+    for a in agent_names:
+        s = mean_scores[a]
+        if s is None:
+            cells.append("N/A")
+        else:
+            text = f"{s:.2f}"
+            if best_mean is not None and s == best_mean:
+                text = f"**{text}**"
+            cells.append(text)
+    lines.append(f"| Avg score | {' | '.join(cells)} |")
+
+    # Mean latency
+    mean_latencies = {a: mean_latency(agent_runs[a], conversations) for a in agent_names}
+    best_lat = min((d for d in mean_latencies.values() if d is not None), default=None)
+    cells = []
+    for a in agent_names:
+        d = mean_latencies[a]
+        if d is None:
+            cells.append("N/A")
+        else:
+            text = format_duration(d)
+            if best_lat is not None and d == best_lat:
+                text = f"**{text}**"
+            cells.append(text)
+    lines.append(f"| Avg latency | {' | '.join(cells)} |")
+
+    # Avg tokens
+    avg_tok = {a: mean_tokens(agent_amended[a], conversations) for a in agent_names}
+    cells = [format_tokens_compact(avg_tok[a]) if avg_tok[a] is not None else "N/A" for a in agent_names]
+    lines.append(f"| Avg tokens | {' | '.join(cells)} |")
+
+    return "\n".join(lines)
+
+
+def generate_summary_table(
+    conversations: list[str],
+    agent_names: list[str],
+    agent_runs: dict[str, list],
+) -> str:
+    header = "| Scenario | " + " | ".join(agent_names) + " |"
+    separator = "|---|" + "|".join("---" for _ in agent_names) + "|"
+    lines = [header, separator]
+    for cid in conversations:
+        anchor = cid.lower().replace(" ", "-")
+        avg_scores = {a: scenario_mean_score(agent_runs[a], cid) for a in agent_names}
+        best = max((s for s in avg_scores.values() if s is not None), default=None)
+        cells = []
+        for a in agent_names:
+            cell = score_cell(agent_runs[a], cid, a)
+            if best is not None and avg_scores[a] is not None and avg_scores[a] == best:
+                cell = f"**{cell}**"
+            cells.append(cell)
+        lines.append(f"| [{cid}](#{anchor}) | {' | '.join(cells)} |")
+    scores = {a: overall_score(agent_runs[a], conversations) for a in agent_names}
+    best_pct = max(
+        (p / t if t > 0 else -1 for p, t in scores.values()),
+        default=-1,
+    )
+    overall = " | ".join(
+        overall_score_cell(
+            *scores[a],
+            bold=(scores[a][1] > 0 and scores[a][0] / scores[a][1] == best_pct),
+        )
+        for a in agent_names
+    )
+    lines.append(f"| **Pass rate** | {overall} |")
+    return "\n".join(lines)
+
+
+def generate_latency_table(
+    conversations: list[str],
+    agent_names: list[str],
+    agent_runs: dict[str, list],
+) -> str:
+    header = "| Scenario | " + " | ".join(agent_names) + " |"
+    separator = "|---|" + "|".join("---" for _ in agent_names) + "|"
+    lines = [header, separator]
+    for cid in conversations:
+        latencies = {a: scenario_latency(agent_runs[a], cid) for a in agent_names}
+        best = min((d for d in latencies.values() if d is not None), default=None)
+        cells = []
+        for a in agent_names:
+            d = latencies[a]
+            if d is None:
+                cells.append("N/A")
+            else:
+                anc = anchor_id(a, cid)
+                text = f"[{format_duration(d)}](#{anc})"
+                if best is not None and d == best:
+                    text = f"**{text}**"
+                cells.append(text)
+        cid_anchor = cid.lower().replace(" ", "-")
+        lines.append(f"| [{cid}](#{cid_anchor}) | {' | '.join(cells)} |")
+
+    mean_latencies = {a: mean_latency(agent_runs[a], conversations) for a in agent_names}
+    best_mean = min((d for d in mean_latencies.values() if d is not None), default=None)
+    cells = []
+    for a in agent_names:
+        d = mean_latencies[a]
+        if d is None:
+            cells.append("N/A")
+        else:
+            text = format_duration(d)
+            if best_mean is not None and d == best_mean:
+                text = f"**{text}**"
+            cells.append(text)
+    lines.append(f"| **Average** | {' | '.join(cells)} |")
+
+    return "\n".join(lines)
+
+
+def generate_tokens_table(
+    conversations: list[str],
+    agent_names: list[str],
+    agent_amended: dict[str, list],
+) -> str:
+    header = "| Scenario | " + " | ".join(agent_names) + " |"
+    separator = "|---|" + "|".join("---" for _ in agent_names) + "|"
+    lines = [header, separator]
+    for cid in conversations:
+        cells = []
+        for a in agent_names:
+            t = scenario_tokens(agent_amended[a], cid)
+            anc = anchor_id(a, cid)
+            cells.append(f"[{format_tokens_compact(t)}](#{anc})")
+        cid_anchor = cid.lower().replace(" ", "-")
+        lines.append(f"| [{cid}](#{cid_anchor}) | {' | '.join(cells)} |")
+
+    avg_tok = {a: mean_tokens(agent_amended[a], conversations) for a in agent_names}
+    cells = [format_tokens_compact(avg_tok[a]) if avg_tok[a] is not None else "N/A" for a in agent_names]
+    lines.append(f"| **Average** | {' | '.join(cells)} |")
+
+    return "\n".join(lines)
+
+
+def generate_scenario_details(
+    conversations: list[str],
+    agent_names: list[str],
+    agent_runs: dict[str, list],
+    agent_amended: dict[str, list],
+) -> str:
+    lines = []
+
+    for cid in conversations:
+        lines.append(f"## {cid}")
+        lines.append("")
+
+        description = None
+        tags = None
+        query = None
+        for agent in agent_names:
+            for entries in agent_amended[agent]:
+                for entry in entries:
+                    if entry["conversation_group_id"] == cid:
+                        if not description and entry.get("description"):
+                            description = entry["description"]
+                        if not tags and entry.get("tags"):
+                            tags = entry["tags"]
+                        if not query and entry.get("query"):
+                            query = entry["query"]
+                if description and tags and query:
+                    break
+
+        if description:
+            lines.append(description.strip())
+            lines.append("")
+
+        if tags:
+            lines.append(f"**Tags**: `{'`, `'.join(tags)}`")
+            lines.append("")
+
+        if query:
+            lines.append("### Query")
+            lines.append("")
+            lines.append("```")
+            lines.append(query.strip())
+            lines.append("```")
+            lines.append("")
+
+        for agent in agent_names:
+            runs = agent_runs[agent]
+            amended_runs = agent_amended[agent]
+            total_runs = len(runs)
+
+            for run_idx, (results, amended_entries) in enumerate(zip(runs, amended_runs)):
+                if results is None:
+                    continue
+
+                run_num = run_idx + 1
+                if run_idx == 0:
+                    aid = anchor_id(agent, cid)
+                    lines.append(f'<a id="{aid}"></a>')
+                    lines.append("")
+                if total_runs > 1:
+                    lines.append(f"### {agent} (run {run_num}/{total_runs})")
+                else:
+                    lines.append(f"### {agent}")
+                lines.append("")
+
+                conv_results = [r for r in results if r["conversation_group_id"] == cid]
+                for r in conv_results:
+                    result_icon = "✅" if r["result"] == "PASS" else "❌"
+                    score_str = f"{r['score']:.2f}" if r["score"] is not None else "N/A"
+                    lines.append(
+                        f"**Correctness**: "
+                        f"{result_icon} {r['result']} (score: {score_str})"
+                    )
+
+                    for js in r.get("judge_scores") or []:
+                        reason = js.get("reason", "")
+                        if reason:
+                            lines.append("")
+                            lines.append(f"> {reason}")
+
+                    lines.append("")
+
+                    lat = r.get("agent_latency")
+                    if lat is not None:
+                        lines.append(f"**Latency**: {format_duration(lat)}")
+                        lines.append("")
+
+                # Tokens
+                for entry in amended_entries:
+                    if entry["conversation_group_id"] == cid and entry.get("agent_tokens"):
+                        lines.append(f"**Tokens**: {format_tokens(entry['agent_tokens'])}")
+                        lines.append("")
+                        break
+
+                response = None
+                for entry in amended_entries:
+                    if entry["conversation_group_id"] == cid and entry.get("response"):
+                        response = entry["response"]
+                        break
+
+                if response:
+                    lines.append("````markdown")
+                    lines.append(response.strip())
+                    lines.append("````")
+                    lines.append("")
+
+        lines.append("[Back to top](#evaluation-summary)")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def generate_report(eval_dir: Path) -> str:
+    agent_names = discover_agents(eval_dir)
+
+    agent_runs: dict[str, list] = {}
+    agent_amended: dict[str, list] = {}
+    for agent in agent_names:
+        run_dirs = find_run_dirs(eval_dir, agent)
+        runs = []
+        amended = []
+        for rd in run_dirs:
+            runs.append(load_run_summary(rd))
+            amended.append(load_amended_entries(rd))
+        agent_runs[agent] = runs
+        agent_amended[agent] = amended
+
+    conversations = collect_conversations(agent_runs)
+    repeat = max((len(find_run_dirs(eval_dir, a)) for a in agent_names), default=1)
+
+    timestamp_str = ""
+    for agent in agent_names:
+        run_dirs = find_run_dirs(eval_dir, agent)
+        for rd in run_dirs:
+            files = sorted(rd.glob("*_summary.json"))
+            if files:
+                with open(files[0]) as f:
+                    ts = json.load(f).get("timestamp", "")
+                if ts:
+                    timestamp_str = format_timestamp(ts)
+                    break
+        if timestamp_str:
+            break
+
+    judge = extract_judge_model(eval_dir, agent_names)
+
+    lines = ["# Evaluation Summary"]
+    lines.append("")
+    stats = (
+        f"{len(conversations)} scenario{'s' if len(conversations) != 1 else ''}, "
+        f"{len(agent_names)} agent{'s' if len(agent_names) != 1 else ''}, "
+        f"{repeat} repeat{'s' if repeat > 1 else ''}"
+    )
+    parts = []
+    if timestamp_str:
+        parts.append(timestamp_str)
+    parts.append(stats)
+    if judge:
+        parts.append(f"Judge: {judge}")
+    lines.append(" | ".join(parts))
+    lines.append("")
+
+    lines.append(generate_overview_table(
+        conversations, agent_names, agent_runs, agent_amended
+    ))
+    lines.append("")
+
+    lines.append("## Correctness")
+    lines.append("")
+    lines.append("Passed repeats / total repeats."
+                 " Score: 0-1.00 (1.00 = perfect, 0.75 = minimum to pass).")
+    lines.append("")
+    lines.append(generate_summary_table(conversations, agent_names, agent_runs))
+    lines.append("")
+
+    lines.append("## Latency")
+    lines.append("")
+    lines.append("Average agent latency across all repeats of a scenario per agent.")
+    lines.append("")
+    lines.append(generate_latency_table(conversations, agent_names, agent_runs))
+    lines.append("")
+
+    lines.append("## Cost")
+    lines.append("")
+    lines.append("Total token usage for each scenario across all repeats per agent;"
+                 " the Average row shows average usage per evaluation.")
+    lines.append("")
+    lines.append(generate_tokens_table(conversations, agent_names, agent_amended))
+    lines.append("")
+
+    lines.append("# Scenarios")
+    lines.append("")
+    lines.append(
+        generate_scenario_details(
+            conversations, agent_names, agent_runs, agent_amended
+        )
+    )
+
+    return "\n".join(lines)
+
+
+GREEN = "\033[0;32m"
+RED = "\033[0;31m"
+RESET = "\033[0m"
+
+
+def _scenario_pass_total(agent_runs: list, conversation_id: str) -> tuple[int, int]:
+    passed = 0
+    total = 0
+    for results in agent_runs:
+        if results is None:
+            continue
+        result = get_result(results, conversation_id)
+        if result is not None:
+            total += 1
+            if result == "PASS":
+                passed += 1
+    return passed, total
+
+
+def _colorize(passed: int, total: int) -> str:
+    text = f"{passed}/{total}"
+    if passed == total:
+        return f"{GREEN}{text}{RESET}"
+    if passed == 0:
+        return f"{RED}{text}{RESET}"
+    return text
+
+
+def print_correctness_table(
+    conversations: list[str],
+    agent_names: list[str],
+    agent_runs: dict[str, list],
+) -> None:
+    grid: list[list[tuple[int, int]]] = []
+    for cid in conversations:
+        row = [_scenario_pass_total(agent_runs[a], cid) for a in agent_names]
+        grid.append(row)
+
+    totals = [overall_score(agent_runs[a], conversations) for a in agent_names]
+
+    def _footer_plain(p, t):
+        pct = round(100 * p / t) if t else 0
+        return f"{pct}% ({p}/{t})"
+
+    scenario_w = max(len("Scenario"), len("Pass rate"), *(len(c) for c in conversations))
+    col_widths = [
+        max(len(a), max(len(f"{r[0]}/{r[1]}") for r in col_vals), len(_footer_plain(t[0], t[1])))
+        for a, col_vals, t in zip(agent_names, zip(*grid), totals)
+    ]
+
+    sep = "+-" + "-+-".join("-" * w for w in [scenario_w] + col_widths) + "-+"
+    header = "| " + " | ".join(
+        f"{h:<{w}}" for h, w in zip(["Scenario"] + agent_names, [scenario_w] + col_widths)
+    ) + " |"
+
+    print(sep)
+    print(header)
+    print(sep)
+    for cid, row in zip(conversations, grid):
+        cells = [f"{cid:<{scenario_w}}"]
+        for (p, t), w in zip(row, col_widths):
+            plain = f"{p}/{t}"
+            colored = _colorize(p, t)
+            cells.append(f"{colored}{' ' * (w - len(plain))}")
+        print("| " + " | ".join(cells) + " |")
+    print(sep)
+    footer_cells = [f"{'Pass rate':<{scenario_w}}"]
+    for (p, t), w in zip(totals, col_widths):
+        plain = _footer_plain(p, t)
+        pct = round(100 * p / t) if t else 0
+        colored = _colorize(p, t)
+        text = f"{pct}% ({colored})"
+        footer_cells.append(f"{text}{' ' * (w - len(plain))}")
+    print("| " + " | ".join(footer_cells) + " |")
+    print(sep)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Generate Markdown report from NxM OLS Classic evaluation output",
+    )
+    parser.add_argument(
+        "eval_dir",
+        help="Eval session directory containing {agent}/run_{N}/ subdirectories",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        help="Output file path (default: EVAL_DIR/results.md)",
+    )
+    args = parser.parse_args()
+
+    eval_dir = Path(args.eval_dir)
+    if not eval_dir.is_dir():
+        print(f"Error: {eval_dir} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    md = generate_report(eval_dir)
+
+    output = Path(args.output) if args.output else eval_dir / "results.md"
+    output.write_text(md)
+
+    agent_names = discover_agents(eval_dir)
+    agent_runs = {}
+    for agent in agent_names:
+        agent_runs[agent] = [load_run_summary(rd) for rd in find_run_dirs(eval_dir, agent)]
+    conversations = collect_conversations(agent_runs)
+
+    print()
+    print_correctness_table(conversations, agent_names, agent_runs)
+    print()
+    print(f"Report written to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-report-classic.py
+++ b/scripts/generate-report-classic.py
@@ -737,10 +737,13 @@ def print_correctness_table(
         return f"{pct}% ({p}/{t})"
 
     scenario_w = max(len("Scenario"), len("Pass rate"), *(len(c) for c in conversations))
-    col_widths = [
-        max(len(a), max(len(f"{r[0]}/{r[1]}") for r in col_vals), len(_footer_plain(t[0], t[1])))
-        for a, col_vals, t in zip(agent_names, zip(*grid), totals)
-    ]
+    col_widths = []
+    for index, (agent, total) in enumerate(zip(agent_names, totals, strict=True)):
+        result_width = max(
+            (len(f"{row[index][0]}/{row[index][1]}") for row in grid),
+            default=0,
+        )
+        col_widths.append(max(len(agent), result_width, len(_footer_plain(*total))))
 
     sep = "+-" + "-+-".join("-" * w for w in [scenario_w] + col_widths) + "-+"
     header = "| " + " | ".join(

--- a/scripts/generate-report-classic.py
+++ b/scripts/generate-report-classic.py
@@ -558,7 +558,8 @@ def generate_scenario_details(
                 conv_results = [r for r in results if r["conversation_group_id"] == cid]
                 for r in conv_results:
                     result_icon = "✅" if r["result"] == "PASS" else "❌"
-                    score_str = f"{r['score']:.2f}" if r["score"] is not None else "N/A"
+                    score = r.get("score")
+                    score_str = f"{score:.2f}" if score is not None else "N/A"
                     lines.append(
                         f"**Correctness**: "
                         f"{result_icon} {r['result']} (score: {score_str})"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 OLS_NS="${OLS_NS:-openshift-lightspeed}"
-errors=0
+REQUIRE_OLS=0
+if [ "${1:-}" = "--require-ols" ]; then
+  REQUIRE_OLS=1
+fi
 
 echo "==> Preflight checks..."
 
@@ -23,6 +26,10 @@ printf '\033[0;32m  OK:\033[0m logged in as %s\n' "$user"
 
 # 3. OLS operator installed
 if ! oc api-resources --api-group=ols.openshift.io 2>/dev/null | grep -q olsconfigs; then
+  if [ "$REQUIRE_OLS" -eq 1 ]; then
+    printf '\033[0;31mFAIL:\033[0m OLSConfig CRD not found — OLS operator not installed on this cluster (run make setup-ols-classic)\n'
+    exit 1
+  fi
   printf '\033[0;33mWARN:\033[0m OLSConfig CRD not found — OLS operator not installed (make setup will install it)\n'
 else
   printf '\033[0;32m  OK:\033[0m OLS operator CRD found\n'
@@ -34,9 +41,17 @@ else
     if [ "$avail" = "True" ]; then
       printf '\033[0;32m  OK:\033[0m lightspeed-app-server is Available\n'
     else
+      if [ "$REQUIRE_OLS" -eq 1 ]; then
+        printf '\033[0;31mFAIL:\033[0m lightspeed-app-server exists but is not Available\n'
+        exit 1
+      fi
       printf '\033[0;33mWARN:\033[0m lightspeed-app-server exists but is not Available\n'
     fi
   else
+    if [ "$REQUIRE_OLS" -eq 1 ]; then
+      printf '\033[0;31mFAIL:\033[0m lightspeed-app-server deployment not found in %s (run make setup-ols-classic)\n' "$OLS_NS"
+      exit 1
+    fi
     printf '\033[0;33mWARN:\033[0m lightspeed-app-server deployment not found in %s\n' "$OLS_NS"
   fi
 fi

--- a/scripts/setup-ols.sh
+++ b/scripts/setup-ols.sh
@@ -185,7 +185,6 @@ spec:
   ols:
     defaultModel: "${OLS_DEFAULT_MODEL}"
     defaultProvider: "${OLS_DEFAULT_PROVIDER}"
-    introspectionEnabled: false
 EOF
 
 # 8. Wait for OLS to be ready

--- a/scripts/setup-ols.sh
+++ b/scripts/setup-ols.sh
@@ -138,12 +138,7 @@ if $has_openai; then
       url: https://api.openai.com/v1
       models:
       - name: gpt-5.4
-        parameters:
-          tool_budget_ratio: 0.5
-      - name: gpt-5.5
-        parameters:
-          tool_budget_ratio: 0.5
-      - name: gpt-5.4-nano"
+      - name: gpt-5.2"
 fi
 if $has_gcp; then
   providers+="

--- a/scripts/tests/test_generate_report_agentic.py
+++ b/scripts/tests/test_generate_report_agentic.py
@@ -553,6 +553,19 @@ class TestGenerateReport:
         assert "| Avg tokens | 100 |" in report
         assert "| **Average** | 100 |" in report
 
+    def test_tokens_compact_formatting(self, tmp_path):
+        _write_run(
+            tmp_path / "agent" / "run_1",
+            results=[_make_result("s1")],
+            amended_entries=[{
+                "conversation_id": "s1",
+                "api_input_tokens": 50000,
+                "api_output_tokens": 1000,
+            }],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "| Avg tokens | 51K |" in report
+
 
 class TestPrintCorrectnessTable:
     def test_basic_output(self, tmp_path, capsys):

--- a/scripts/tests/test_generate_report_classic.py
+++ b/scripts/tests/test_generate_report_classic.py
@@ -1,0 +1,461 @@
+"""Tests for generate-report-classic.py."""
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+import importlib.util
+
+spec = importlib.util.spec_from_file_location(
+    "generate_report_classic",
+    Path(__file__).resolve().parent.parent / "generate-report-classic.py",
+)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+def _make_summary_json(results: list[dict], config: dict | None = None) -> dict:
+    return {
+        "timestamp": "2026-09-04T10:00:00+00:00",
+        "total_evaluations": len(results),
+        "summary_stats": {},
+        "configuration": config or {"llm": {"provider": "openai", "model": "gpt-4o-mini"}},
+        "results": results,
+    }
+
+
+def _make_result(
+    conversation_id: str,
+    result: str = "PASS",
+    score: float = 1.0,
+    reason: str = "Good",
+    agent_latency: float = 15.0,
+    api_input_tokens: int = 40000,
+    api_output_tokens: int = 800,
+) -> dict:
+    return {
+        "conversation_group_id": conversation_id,
+        "tag": [conversation_id],
+        "turn_id": "turn_1",
+        "metric_identifier": "custom:answer_correctness",
+        "result": result,
+        "score": score,
+        "threshold": None,
+        "execution_time": agent_latency + 5.0,
+        "evaluation_latency": 5.0,
+        "judge_llm_input_tokens": 900,
+        "judge_llm_output_tokens": 400,
+        "judge_scores": [{"reason": reason}],
+        "time_to_first_token": None,
+        "streaming_duration": None,
+        "agent_latency": agent_latency,
+        "tokens_per_second": None,
+    }
+
+
+def _make_amended_yaml(entries: list[dict]) -> list[dict]:
+    result = []
+    for e in entries:
+        turn = {
+            "query": e.get("query", "What is wrong?"),
+            "response": e.get("response", "The pod has 3 replicas."),
+            "api_input_tokens": e.get("api_input_tokens", 40000),
+            "api_output_tokens": e.get("api_output_tokens", 800),
+            "agent_latency": e.get("agent_latency", 15.0),
+        }
+        entry = {
+            "conversation_group_id": e["conversation_id"],
+            "tag": e.get("tags", [e["conversation_id"]]),
+            "turns": [turn],
+        }
+        if "description" in e:
+            entry["description"] = e["description"]
+        result.append(entry)
+    return result
+
+
+def _write_run(
+    run_dir: Path,
+    results: list[dict],
+    amended_entries: list[dict],
+    timestamp: str = "20260904_100000",
+    config: dict | None = None,
+):
+    run_dir.mkdir(parents=True, exist_ok=True)
+    summary = _make_summary_json(results, config)
+    (run_dir / f"evaluation_{timestamp}_summary.json").write_text(json.dumps(summary))
+    amended = _make_amended_yaml(amended_entries)
+    (run_dir / f"evals-ols-classic_amended_{timestamp}.yaml").write_text(yaml.dump(amended))
+
+
+class TestDiscoverAgents:
+    def test_discovers_agents_from_directories(self, tmp_path):
+        (tmp_path / "gpt-5.4" / "run_1").mkdir(parents=True)
+        (tmp_path / "gpt-5.2" / "run_1").mkdir(parents=True)
+        agents = mod.discover_agents(tmp_path)
+        assert set(agents) == {"gpt-5.4", "gpt-5.2"}
+
+    def test_ignores_non_agent_files(self, tmp_path):
+        (tmp_path / "gpt-5.4" / "run_1").mkdir(parents=True)
+        (tmp_path / "eval_report.json").write_text("{}")
+        agents = mod.discover_agents(tmp_path)
+        assert agents == ["gpt-5.4"]
+
+    def test_returns_sorted_agents(self, tmp_path):
+        for name in ["opus", "gpt", "gemini"]:
+            (tmp_path / name / "run_1").mkdir(parents=True)
+        agents = mod.discover_agents(tmp_path)
+        assert agents == ["gemini", "gpt", "opus"]
+
+    def test_empty_directory(self, tmp_path):
+        agents = mod.discover_agents(tmp_path)
+        assert agents == []
+
+
+class TestFindRunDirs:
+    def test_finds_run_dirs_sorted(self, tmp_path):
+        agent_dir = tmp_path / "agent1"
+        for i in [3, 1, 2]:
+            (agent_dir / f"run_{i}").mkdir(parents=True)
+        dirs = mod.find_run_dirs(tmp_path, "agent1")
+        assert [d.name for d in dirs] == ["run_1", "run_2", "run_3"]
+
+    def test_missing_agent_returns_empty(self, tmp_path):
+        assert mod.find_run_dirs(tmp_path, "nonexistent") == []
+
+
+class TestLoadRunSummary:
+    def test_reads_all_summary_jsons(self, tmp_path):
+        run_dir = tmp_path / "run_1"
+        run_dir.mkdir()
+        r1 = [_make_result("scenario_a", score=0.9)]
+        r2 = [_make_result("scenario_b", score=0.8)]
+        (run_dir / "evaluation_20260904_100000_summary.json").write_text(
+            json.dumps(_make_summary_json(r1))
+        )
+        (run_dir / "evaluation_20260904_100100_summary.json").write_text(
+            json.dumps(_make_summary_json(r2))
+        )
+        results = mod.load_run_summary(run_dir)
+        assert len(results) == 2
+        cids = {r["conversation_group_id"] for r in results}
+        assert cids == {"scenario_a", "scenario_b"}
+
+    def test_no_summary_files(self, tmp_path):
+        run_dir = tmp_path / "run_1"
+        run_dir.mkdir()
+        assert mod.load_run_summary(run_dir) is None
+
+
+class TestGenerateReport:
+    def test_single_agent_single_run(self, tmp_path):
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[_make_result("unbalanced_replicas")],
+            amended_entries=[{"conversation_id": "unbalanced_replicas"}],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "# Evaluation Summary" in report
+        assert "gpt-5.4" in report
+        assert "unbalanced_replicas" in report
+
+    def test_multi_agent_multi_run(self, tmp_path):
+        for agent in ["gpt-5.4", "gpt-5.2"]:
+            for run in [1, 2]:
+                _write_run(
+                    tmp_path / agent / f"run_{run}",
+                    results=[_make_result("unbalanced_replicas", score=0.9 if run == 1 else 0.5)],
+                    amended_entries=[{"conversation_id": "unbalanced_replicas"}],
+                    timestamp=f"20260904_10000{run}",
+                )
+        report = mod.generate_report(tmp_path)
+        assert "2 agents" in report
+        assert "2 repeat" in report
+        assert "gpt-5.4" in report
+        assert "gpt-5.2" in report
+
+    def test_multiple_scenarios_across_invocations(self, tmp_path):
+        run_dir = tmp_path / "gpt-5.4" / "run_1"
+        _write_run(
+            run_dir,
+            results=[_make_result("scenario_a", score=1.0)],
+            amended_entries=[{"conversation_id": "scenario_a"}],
+            timestamp="20260904_100000",
+        )
+        r2 = [_make_result("scenario_b", score=0.8)]
+        (run_dir / "evaluation_20260904_100100_summary.json").write_text(
+            json.dumps(_make_summary_json(r2))
+        )
+        amended_b = _make_amended_yaml([{"conversation_id": "scenario_b"}])
+        (run_dir / "evals-ols-classic_amended_20260904_100100.yaml").write_text(yaml.dump(amended_b))
+
+        report = mod.generate_report(tmp_path)
+        assert "scenario_a" in report
+        assert "scenario_b" in report
+        assert "2 scenario" in report
+
+    def test_overall_score_row(self, tmp_path):
+        for run in [1, 2]:
+            _write_run(
+                tmp_path / "gpt-5.4" / f"run_{run}",
+                results=[
+                    _make_result("s1", result="PASS"),
+                    _make_result("s2", result="PASS" if run == 1 else "FAIL"),
+                ],
+                amended_entries=[
+                    {"conversation_id": "s1"},
+                    {"conversation_id": "s2"},
+                ],
+                timestamp=f"20260904_10000{run}",
+            )
+        report = mod.generate_report(tmp_path)
+        assert "**Pass rate**" in report
+        assert "75% (3/4)" in report
+
+    def test_timestamp_in_header(self, tmp_path):
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[_make_result("s1")],
+            amended_entries=[{"conversation_id": "s1"}],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "2026-09-04 10:00:00 UTC" in report
+
+    def test_scenario_description(self, tmp_path):
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[_make_result("s1")],
+            amended_entries=[{
+                "conversation_id": "s1",
+                "description": "Two namespaces with different pod counts.",
+            }],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "Two namespaces with different pod counts." in report
+
+    def test_scenarios_heading(self, tmp_path):
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[_make_result("s1")],
+            amended_entries=[{"conversation_id": "s1"}],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "# Scenarios" in report
+
+    def test_handles_null_judge_scores(self, tmp_path):
+        result = _make_result("s1")
+        result["judge_scores"] = None
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[result],
+            amended_entries=[{"conversation_id": "s1"}],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "# Evaluation Summary" in report
+        assert "s1" in report
+
+    def test_score_cell_links_to_agent_section(self, tmp_path):
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[_make_result("s1")],
+            amended_entries=[{"conversation_id": "s1"}],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "(#gpt-5.4--s1)" in report
+
+    def test_agent_section_has_anchor(self, tmp_path):
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[_make_result("s1")],
+            amended_entries=[{"conversation_id": "s1"}],
+        )
+        report = mod.generate_report(tmp_path)
+        assert '<a id="gpt-5.4--s1"></a>' in report
+
+    def test_best_overall_score_is_bold(self, tmp_path):
+        for run in [1, 2]:
+            _write_run(
+                tmp_path / "gpt-5.4" / f"run_{run}",
+                results=[_make_result("s1", result="PASS")],
+                amended_entries=[{"conversation_id": "s1"}],
+                timestamp=f"20260904_10000{run}",
+            )
+            _write_run(
+                tmp_path / "gemini" / f"run_{run}",
+                results=[_make_result("s1", result="PASS" if run == 1 else "FAIL")],
+                amended_entries=[{"conversation_id": "s1"}],
+                timestamp=f"20260904_10000{run}",
+            )
+        report = mod.generate_report(tmp_path)
+        assert "**✅ 100% (2/2)**" in report
+        assert "50% (1/2)" in report
+        assert "**50% (1/2)**" not in report
+
+    def test_tied_best_overall_scores_both_bold(self, tmp_path):
+        for agent in ["gpt-5.4", "gemini"]:
+            _write_run(
+                tmp_path / agent / "run_1",
+                results=[_make_result("s1", result="PASS")],
+                amended_entries=[{"conversation_id": "s1"}],
+            )
+        report = mod.generate_report(tmp_path)
+        assert report.count("**✅ 100% (1/1)**") == 2
+
+    def test_judge_in_header(self, tmp_path):
+        config = {
+            "llm_pool": {"models": {"judge": {"model": "gpt-5.4"}}},
+            "judge_panel": {"judges": ["judge"]},
+        }
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[_make_result("s1")],
+            amended_entries=[{"conversation_id": "s1"}],
+            config=config,
+        )
+        report = mod.generate_report(tmp_path)
+        assert "Judge: gpt-5.4" in report
+
+    def test_no_judge_by_default(self, tmp_path):
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[_make_result("s1")],
+            amended_entries=[{"conversation_id": "s1"}],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "Judge" not in report
+
+    def test_duration_from_agent_latency(self, tmp_path):
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[_make_result("s1", agent_latency=25.5)],
+            amended_entries=[{"conversation_id": "s1", "agent_latency": 25.5}],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "26s" in report
+
+    def test_tokens_in_scenario_details(self, tmp_path):
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[_make_result("s1", api_input_tokens=40000, api_output_tokens=800)],
+            amended_entries=[{
+                "conversation_id": "s1",
+                "api_input_tokens": 40000,
+                "api_output_tokens": 800,
+            }],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "**Tokens**: 40,800" in report
+
+    def test_tokens_from_results(self, tmp_path):
+        _write_run(
+            tmp_path / "agent" / "run_1",
+            results=[_make_result("s1", api_input_tokens=50000, api_output_tokens=1000)],
+            amended_entries=[{
+                "conversation_id": "s1",
+                "api_input_tokens": 50000,
+                "api_output_tokens": 1000,
+            }],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "| Avg tokens | 51K |" in report
+
+    def test_avg_tokens_divides_by_evaluations_not_scenarios(self, tmp_path):
+        for run in [1, 2]:
+            _write_run(
+                tmp_path / "agent" / f"run_{run}",
+                results=[_make_result("s1", api_input_tokens=60, api_output_tokens=40)],
+                amended_entries=[{
+                    "conversation_id": "s1",
+                    "api_input_tokens": 60,
+                    "api_output_tokens": 40,
+                }],
+                timestamp=f"20260904_10000{run}",
+            )
+        report = mod.generate_report(tmp_path)
+        assert "| Avg tokens | 100 |" in report
+        assert "| **Average** | 100 |" in report
+
+    def test_tokens_compact_millions(self, tmp_path):
+        _write_run(
+            tmp_path / "agent" / "run_1",
+            results=[_make_result("s1", api_input_tokens=1200000, api_output_tokens=50000)],
+            amended_entries=[{
+                "conversation_id": "s1",
+                "api_input_tokens": 1200000,
+                "api_output_tokens": 50000,
+            }],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "| Avg tokens | 1.2M |" in report
+        # Detail section keeps exact number
+        assert "**Tokens**: 1,250,000" in report
+
+    def test_no_completed_metric(self, tmp_path):
+        """Classic evals only have answer_correctness, no status metric."""
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[_make_result("s1")],
+            amended_entries=[{"conversation_id": "s1"}],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "Completed" not in report
+        assert "openshift_agentic_run_status" not in report
+
+    def test_response_not_stripped(self, tmp_path):
+        """Classic responses are shown in full, no section stripping."""
+        response_text = "## Evidence\n\nThe pods are running.\n\n## Root cause\n\nConfig mismatch."
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[_make_result("s1")],
+            amended_entries=[{
+                "conversation_id": "s1",
+                "response": response_text,
+            }],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "## Evidence" in report
+        assert "## Root cause" in report
+
+
+class TestPrintCorrectnessTable:
+    def test_basic_output(self, tmp_path, capsys):
+        for agent, result in [("agentA", "PASS"), ("agentB", "FAIL")]:
+            _write_run(
+                tmp_path / agent / "run_1",
+                results=[_make_result("s1", result=result)],
+                amended_entries=[{"conversation_id": "s1"}],
+            )
+        agent_runs = {
+            a: [mod.load_run_summary(tmp_path / a / "run_1")]
+            for a in ["agentA", "agentB"]
+        }
+        conversations = mod.collect_conversations(agent_runs)
+        mod.print_correctness_table(conversations, ["agentA", "agentB"], agent_runs)
+        out = capsys.readouterr().out
+        assert "s1" in out
+        assert "1/1" in out
+        assert "Pass rate" in out
+
+    def test_multi_run_counts(self, tmp_path, capsys):
+        _write_run(
+            tmp_path / "a" / "run_1",
+            results=[_make_result("s1", result="PASS")],
+            amended_entries=[{"conversation_id": "s1"}],
+        )
+        _write_run(
+            tmp_path / "a" / "run_2",
+            results=[_make_result("s1", result="FAIL", score=0.2)],
+            amended_entries=[{"conversation_id": "s1"}],
+            timestamp="20260904_100001",
+        )
+        agent_runs = {"a": [
+            mod.load_run_summary(tmp_path / "a" / "run_1"),
+            mod.load_run_summary(tmp_path / "a" / "run_2"),
+        ]}
+        conversations = mod.collect_conversations(agent_runs)
+        mod.print_correctness_table(conversations, ["a"], agent_runs)
+        out = capsys.readouterr().out
+        assert "1/2" in out

--- a/scripts/tests/test_generate_report_classic.py
+++ b/scripts/tests/test_generate_report_classic.py
@@ -257,6 +257,31 @@ class TestGenerateReport:
         assert "# Evaluation Summary" in report
         assert "s1" in report
 
+    def test_handles_null_score(self, tmp_path):
+        result = _make_result("s1")
+        result["score"] = None
+        result["result"] = "ERROR"
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[result],
+            amended_entries=[{"conversation_id": "s1"}],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "score: N/A" in report
+        assert "ERROR" in report
+
+    def test_handles_missing_score_key(self, tmp_path):
+        result = _make_result("s1")
+        del result["score"]
+        result["result"] = "ERROR"
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[result],
+            amended_entries=[{"conversation_id": "s1"}],
+        )
+        report = mod.generate_report(tmp_path)
+        assert "score: N/A" in report
+
     def test_score_cell_links_to_agent_section(self, tmp_path):
         _write_run(
             tmp_path / "gpt-5.4" / "run_1",

--- a/scripts/tests/test_generate_report_classic.py
+++ b/scripts/tests/test_generate_report_classic.py
@@ -151,6 +151,17 @@ class TestLoadRunSummary:
 
 
 class TestGenerateReport:
+    def test_empty_results_keep_agent_column(self, tmp_path):
+        _write_run(
+            tmp_path / "gpt-5.4" / "run_1",
+            results=[],
+            amended_entries=[],
+        )
+
+        report = mod.generate_report(tmp_path)
+
+        assert "| | gpt-5.4 |" in report
+
     def test_single_agent_single_run(self, tmp_path):
         _write_run(
             tmp_path / "gpt-5.4" / "run_1",


### PR DESCRIPTION
## Summary

- Add OLS Classic eval support: `evals-ols-classic.yaml` definitions for 7 scenarios (crashlooping_pod_alert, failed_job, failing_api_alert, pending_pvc_alert, timeout_connections, unbalanced_replicas, unready_pod_alert)
- Add `system-ols-classic.yaml` config with gpt-5.4 and gpt-5.2 agents, gpt-5.4 judge
- Add `generate-report-classic.py` to produce Markdown reports from classic eval results, with compact token formatting (K/M) in tables and exact numbers in scenario details
- Wire up `make eval-ols-classic` to generate reports automatically, using the same output paths as agentic evals (`results/logs/` for raw data, `results/results_*.md` for reports)
- Add `make setup-ols-classic` target for OLS operator installation

## Key differences from agentic report

| | Agentic | Classic |
|---|---|---|
| Metrics | Completed + Correctness | Correctness only |
| Duration source | Analysis condition timestamps | `agent_latency` from results JSON |
| Response display | Strips `## Request` section | Full response |

## Scenario mapping

These scenarios were ported from the old Classic eval suite under new shared names:

| Old Classic name | Current shared scenario | Status |
|---|---|---|
| `envvar_missing` | `crashlooping_pod_alert` | active |
| `batch_failure` | `failed_job` | active |
| `failing_api_alert` | `failing_api_alert` | active |
| `storage_binding` | `pending_pvc_alert` | active |
| `ingress_rule_mismatch` | `timeout_connections` | active |
| `wrong_networkpolicy` | `timeout_connections` | active |
| `namespace_pod_count` | `unbalanced_replicas` | active |
| `readiness_probe_diagnosis` | `unready_pod_alert` | active |
| `oom` | `oomkilled_pod` | disabled (fixture needs redesign) |
| `scheduled_outage_detection` | `recurring_batch_failure` | disabled (fixture needs redesign) |
| `periodic_failure_window` | `recurring_batch_failure` | disabled (fixture needs redesign) |
| `config_drift_analysis` | `refused_connections` | disabled (fixture needs redesign) |

The 3 disabled scenarios are under `agentic/_disabled/` and have known fixture-quality problems (answer leaks in logs, synthetic-looking faults).

## Test plan

- [x] 31 unit tests for `generate-report-classic.py` (mirrors agentic test suite)
- [x] Existing 27 agentic report tests still pass
- [x] Lint passes (`make lint`)
- [x] Verified report generation against real results